### PR TITLE
ci(release): publish Helm chart as OCI artifact to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,6 +338,65 @@ jobs:
             --predicate sbom.spdx.json \
             ${{ env.DOCKERHUB_IMAGE }}@${{ steps.push.outputs.digest }}
 
+  # ── Gate E (chart): Publish Helm chart as an OCI artifact ─────────────
+  # Parity with the container image: the chart is pushed to GHCR as an
+  # OCI artifact so it installs by reference without a repo checkout:
+  #   helm install arq-signals oci://ghcr.io/elevarq/charts/arq-signals \
+  #     --version <X.Y.Z>
+  # The chart version is stamped from the release tag at package time, so
+  # the published chart can never drift from the release even if the
+  # committed Chart.yaml lags. See #3.
+  publish-chart:
+    name: Publish Helm chart (OCI)
+    needs: [validate, publish]
+    runs-on: ubuntu-24.04
+    env:
+      CHART_REGISTRY: oci://ghcr.io/elevarq/charts
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Lint chart
+        run: helm lint deploy/helm/arq-signals
+
+      - name: Log in to GHCR (helm registry)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Package chart (version stamped from tag)
+        id: package
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          helm package deploy/helm/arq-signals \
+            --version "${VERSION}" \
+            --app-version "${VERSION}" \
+            --destination dist-chart
+          echo "file=dist-chart/arq-signals-${VERSION}.tgz" >> "$GITHUB_OUTPUT"
+
+      - name: Push chart to GHCR
+        id: push
+        run: |
+          # `helm push` prints the pushed digest to stderr; capture the
+          # whole stream so the cosign step can sign the exact digest.
+          helm push "${{ steps.package.outputs.file }}" "${CHART_REGISTRY}" 2>&1 | tee push.log
+          DIGEST="$(grep -oE 'sha256:[0-9a-f]{64}' push.log | head -1)"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Keyless signing, same trust root as the container image: the
+      # signature binds back to this workflow's GitHub OIDC identity.
+      - name: Sign chart (cosign keyless)
+        run: |
+          cosign sign --yes \
+            "ghcr.io/elevarq/charts/arq-signals@${{ steps.push.outputs.digest }}"
+
   # ── Go binary artifacts ───────────────────────────────────────────────
   build-binaries:
     name: Build Go Binaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Release workflow now publishes the Helm chart as an OCI artifact to
+  `oci://ghcr.io/elevarq/charts/arq-signals`, cosign-signed with the
+  same keyless GitHub OIDC identity as the container image. The chart
+  version is stamped from the release tag at package time. (#3)
+
 ## [0.9.0] - 2026-05-27
 
 ### Added

--- a/deploy/helm/arq-signals/Chart.yaml
+++ b/deploy/helm/arq-signals/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 0.8.0
+version: 0.9.0
 appVersion: "0.9.0"
 keywords:
   - postgresql

--- a/deploy/helm/arq-signals/values.yaml
+++ b/deploy/helm/arq-signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/arq-signals
-  tag: "0.8.0"
+  tag: "0.9.0"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration

--- a/examples/helm/README.md
+++ b/examples/helm/README.md
@@ -5,6 +5,30 @@ A starter Helm chart is provided at
 
 ## Install
 
+Each release publishes the chart as an OCI artifact to GHCR, so you
+can install by reference without a repo checkout (the chart version
+matches the release version):
+
+```bash
+helm install arq-signals oci://ghcr.io/elevarq/charts/arq-signals \
+  --version 0.9.0 \
+  --set target.host=db.example.com \
+  --set target.user=arq_signals \
+  --set target.dbname=postgres \
+  --set target.passwordSecretName=arq-pg-password
+```
+
+The published chart is cosign-signed (keyless, GitHub OIDC) — the same
+trust root as the container image. Verify before install:
+
+```bash
+cosign verify ghcr.io/elevarq/charts/arq-signals:0.9.0 \
+  --certificate-identity-regexp='github.com/Elevarq/Arq-Signals/.github/workflows/release.yml@' \
+  --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+```
+
+Or install straight from a working-tree checkout:
+
 ```bash
 helm install arq-signals deploy/helm/arq-signals/ \
   --set target.host=db.example.com \


### PR DESCRIPTION
## Summary

Publishes the Arq-Signals Helm chart as an OCI artifact to GHCR on each release tag, for parity with the container image and pgAgroal (Elevarq/pgAgroal#40).

After this, the chart installs by reference without a repo checkout:

```bash
helm install arq-signals oci://ghcr.io/elevarq/charts/arq-signals --version <X.Y.Z>
```

## Changes

- **release.yml**: new `publish-chart` job (needs `validate` + `publish`) — `helm lint`, package with the version stamped from the release tag (`--version`/`--app-version`), push to `oci://ghcr.io/elevarq/charts`, then cosign-sign the chart digest keyless via the workflow's GitHub OIDC identity (same trust root as the image). Uses the built-in `GITHUB_TOKEN` (`packages: write` already declared) — no new secret.
- **Chart.yaml / values.yaml**: reconcile chart `version` and `image.tag` from 0.8.0 to 0.9.0 to align with the released image.
- **examples/helm/README.md**: document the `oci://` install and `cosign verify`.
- **CHANGELOG.md**: Unreleased entry.

Stamping the version from the tag at package time means the published chart can't drift from the release even if a committed Chart.yaml lags.

## Verification

- `actionlint` clean on the workflow.
- `helm lint deploy/helm/arq-signals` passes (only the cosmetic icon recommendation).
- `helm package --version 0.9.0 --app-version 0.9.0` produces `arq-signals-0.9.0.tgz` locally.

The publish path itself exercises on the next release tag.

Closes #3