### PR TITLE
feat(sensitivity): high-sensitivity default-on with opt-out (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   eligible-but-never-run collectors as `never_run` so consumers can
   detect missing coverage (R107, #5).
 
+### Changed
+
+- **Sensitivity policy: collect-everything default, privacy opt-out.**
+  The live `pg_stat_activity` query-text collectors
+  (`long_running_txns_v1`, `blocking_locks_v1`,
+  `idle_in_txn_offenders_v1`, `wraparound_blockers_v1`) are now
+  classified `HighSensitivity = true`. The
+  `signals.high_sensitivity_collectors_enabled` default flips from
+  `false` to **`true`**, so high-sensitivity collectors run by default;
+  set the flag (or `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED`)
+  to `false` to opt out and skip them entirely.
+  `metadata.json.high_sensitivity_collectors_enabled` reflects the
+  effective state so auditors can tell whether sensitive data may be
+  present. (R075 revised, #6)
+
 ### Fixed
 
 - Disabled or removed targets no longer linger as active. The daemon

--- a/features/arq-signals/specification.md
+++ b/features/arq-signals/specification.md
@@ -586,18 +586,40 @@ ordered. Specifically:
 
 ### Collector Sensitivity
 
-**ARQ-SIGNALS-R075**: The system shall classify collectors that emit
-application-authored SQL text — `pg_views_definitions_v1`,
-`pg_matviews_definitions_v1`, `pg_triggers_definitions_v1`,
-`pg_functions_definitions_v1` — as **high-sensitivity** and disable
-them by default. They run only when the operator opts in via
-`signals.high_sensitivity_collectors_enabled: true` (or the
-`ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED=true` environment
-variable). When disabled, each shall appear in
-`collector_status.json` with `status=skipped` and
-`reason=config_disabled`. This control exists for local operator
-control over data sensitivity; it is not an exfiltration boundary
-(Arq Signals runs inside the operator's own environment).
+**ARQ-SIGNALS-R075**: The system shall classify as **high-sensitivity**
+the collectors that emit application-authored SQL text or live
+statement text:
+
+- application-authored SQL definitions:
+  `pg_views_definitions_v1`, `pg_matviews_definitions_v1`,
+  `pg_triggers_definitions_v1`, `pg_functions_definitions_v1`;
+- live `pg_stat_activity` statement text: `long_running_txns_v1`,
+  `blocking_locks_v1`, `idle_in_txn_offenders_v1`,
+  `wraparound_blockers_v1`.
+
+High-sensitivity collectors run **by default** (collect-everything
+default). An operator who prefers privacy over diagnostic richness opts
+**out** by setting `signals.high_sensitivity_collectors_enabled: false`
+(or `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED=false`), which
+skips every high-sensitivity collector entirely — including the
+non-sensitive columns of those collectors. When opted out, each shall
+appear in `collector_status.json` with `status=skipped` and
+`reason=config_disabled`. The toggle is local operator control over
+data sensitivity; it is not an exfiltration boundary (Arq Signals runs
+inside the operator's own environment).
+
+`metadata.json.high_sensitivity_collectors_enabled` records the
+effective state so a consumer or auditor can tell, without parsing the
+body, whether live `pg_stat_activity` query text or SQL definitions may
+be present in the export.
+
+This default was reversed from opt-in to opt-out in 2026-05 (issue #6):
+the live query-text collectors had been default-on without proper
+classification, and gating them off by default lost diagnostically
+valuable signals (long-running transactions, blocking locks,
+idle-in-transaction, wraparound risk). Default-on with classification +
+opt-out keeps the signals available while making the sensitivity
+explicit and giving operators a clean privacy toggle.
 
 ### Configuration Validation
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -274,6 +274,11 @@ func DefaultConfig() Config {
 			MetricsEnabled:       false,
 			MetricsPath:          "/metrics",
 			Mode:                 ModeStandalone,
+			// R075 (revised 2026-05, issue #6): collect-everything default.
+			// High-sensitivity collectors (application-authored SQL
+			// definitions + live pg_stat_activity statement text) run by
+			// default; set this to false to opt OUT for privacy.
+			HighSensitivityCollectorsEnabled: true,
 		},
 		API: APIConfig{
 			ListenAddr:    "127.0.0.1:8081",

--- a/internal/pgqueries/catalog_diagnostics.go
+++ b/internal/pgqueries/catalog_diagnostics.go
@@ -109,10 +109,11 @@ func init() {
 		  AND state != 'idle'
 		  AND now() - xact_start > interval '5 minutes'
 		ORDER BY xact_start ASC`,
-		ResultKind:     ResultRowset,
-		RetentionClass: RetentionShort,
-		Timeout:        10 * time.Second,
-		Cadence:        Cadence5m,
+		ResultKind:      ResultRowset,
+		RetentionClass:  RetentionShort,
+		Timeout:         10 * time.Second,
+		Cadence:         Cadence5m,
+		HighSensitivity: true, // R075: emits live pg_stat_activity query text
 	})
 
 	// Locks and blocking chains. Uses pg_blocking_pids() which is
@@ -135,10 +136,11 @@ func init() {
 			ON blocking.pid = ANY(pg_blocking_pids(blocked.pid))
 		WHERE cardinality(pg_blocking_pids(blocked.pid)) > 0
 		ORDER BY waiting_seconds DESC`,
-		ResultKind:     ResultRowset,
-		RetentionClass: RetentionShort,
-		Timeout:        10 * time.Second,
-		Cadence:        Cadence5m,
+		ResultKind:      ResultRowset,
+		RetentionClass:  RetentionShort,
+		Timeout:         10 * time.Second,
+		Cadence:         Cadence5m,
+		HighSensitivity: true, // R075: emits live pg_stat_activity query text (blocked/blocking)
 	})
 
 	// Login roles with dangerous privileges.

--- a/internal/pgqueries/catalog_survival.go
+++ b/internal/pgqueries/catalog_survival.go
@@ -124,10 +124,11 @@ func init() {
 		WHERE state IN ('idle in transaction', 'idle in transaction (aborted)')
 		  AND pid != pg_backend_pid()
 		ORDER BY xact_start ASC NULLS LAST`,
-		ResultKind:     ResultRowset,
-		RetentionClass: RetentionShort,
-		Timeout:        5 * time.Second,
-		Cadence:        Cadence5m,
+		ResultKind:      ResultRowset,
+		RetentionClass:  RetentionShort,
+		Timeout:         5 * time.Second,
+		Cadence:         Cadence5m,
+		HighSensitivity: true, // R075: emits live pg_stat_activity query text
 	})
 
 	// Database sizes: all non-template databases with sizes, wraparound

--- a/internal/pgqueries/catalog_wraparound.go
+++ b/internal/pgqueries/catalog_wraparound.go
@@ -95,9 +95,10 @@ func init() {
 		  AND state != 'idle'
 		ORDER BY xact_start ASC
 		LIMIT 20`,
-		ResultKind:     ResultRowset,
-		RetentionClass: RetentionShort,
-		Timeout:        10 * time.Second,
-		Cadence:        Cadence5m,
+		ResultKind:      ResultRowset,
+		RetentionClass:  RetentionShort,
+		Timeout:         10 * time.Second,
+		Cadence:         Cadence5m,
+		HighSensitivity: true, // R075: emits live pg_stat_activity query text
 	})
 }

--- a/internal/pgqueries/types.go
+++ b/internal/pgqueries/types.go
@@ -77,9 +77,13 @@ type QueryDef struct {
 	RetentionClass    RetentionClass
 	Timeout           time.Duration
 	Cadence           Cadence
-	// HighSensitivity flags collectors that emit application-authored SQL
-	// text (view/matview/trigger/function definitions). Per R075 these
-	// run only when the operator opts in.
+	// HighSensitivity flags collectors that emit application-authored
+	// SQL text (view/matview/trigger/function definitions) or live
+	// pg_stat_activity statement text (long-running txns, blocking
+	// locks, idle-in-txn, wraparound blockers). Per R075 these run by
+	// default (collect-everything default); operators opt **out** by
+	// setting `high_sensitivity_collectors_enabled = false`, which
+	// skips every collector with this flag.
 	HighSensitivity bool
 }
 

--- a/tests/signals_high_sensitivity_test.go
+++ b/tests/signals_high_sensitivity_test.go
@@ -40,6 +40,13 @@ var highSensitivityCollectors = []string{
 	"pg_policies_v1",
 	// pg_rules_v1 (#219) emits the rewrite-rule action — arbitrary SQL.
 	"pg_rules_v1",
+	// R075 (revised 2026-05, issue #6): live pg_stat_activity statement
+	// text. Default-on with an opt-out — collectors run by default,
+	// `high_sensitivity_collectors_enabled = false` skips them.
+	"long_running_txns_v1",
+	"blocking_locks_v1",
+	"idle_in_txn_offenders_v1",
+	"wraparound_blockers_v1",
 }
 
 // TestHighSensitivityCollectorsAreFlagged verifies all four definition

--- a/tests/signals_highsens_default_test.go
+++ b/tests/signals_highsens_default_test.go
@@ -1,0 +1,83 @@
+// Tests for R075 (revised 2026-05, issue #6): high-sensitivity
+// collectors are default-on with an opt-out, and the live
+// pg_stat_activity query-text collectors are properly classified
+// HighSensitivity=true.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/elevarq/arq-signals/internal/config"
+	"github.com/elevarq/arq-signals/internal/pgqueries"
+)
+
+func TestDefaultConfigHighSensitivityIsDefaultOn(t *testing.T) {
+	cfg := config.DefaultConfig()
+	if !cfg.Signals.HighSensitivityCollectorsEnabled {
+		t.Fatal("DefaultConfig().Signals.HighSensitivityCollectorsEnabled = false, want true " +
+			"(R075 revised 2026-05: high-sensitivity collectors run by default, opt-out skips them)")
+	}
+}
+
+func TestLiveQueryTextCollectorsAreHighSensitivity(t *testing.T) {
+	ids := []string{
+		"long_running_txns_v1",
+		"blocking_locks_v1",
+		"idle_in_txn_offenders_v1",
+		"wraparound_blockers_v1",
+	}
+	for _, id := range ids {
+		q := pgqueries.ByID(id)
+		if q == nil {
+			t.Errorf("%s not registered", id)
+			continue
+		}
+		if !q.HighSensitivity {
+			t.Errorf("%s.HighSensitivity = false, want true — it emits live pg_stat_activity query text and must be classified per R075", id)
+		}
+	}
+}
+
+func TestFilterDropsHighSensitivityWhenOptedOut(t *testing.T) {
+	livesensIDs := map[string]bool{
+		"long_running_txns_v1":     true,
+		"blocking_locks_v1":        true,
+		"idle_in_txn_offenders_v1": true,
+		"wraparound_blockers_v1":   true,
+	}
+
+	hasAll := func(qs []pgqueries.QueryDef) bool {
+		got := map[string]bool{}
+		for _, q := range qs {
+			got[q.ID] = true
+		}
+		for id := range livesensIDs {
+			if !got[id] {
+				return false
+			}
+		}
+		return true
+	}
+
+	// PG 18 + no extensions: the four collectors have no extension
+	// dependency and no MinPGVersion above 18, so eligibility is gated
+	// only by HighSensitivityEnabled.
+	on := pgqueries.Filter(pgqueries.FilterParams{
+		PGMajorVersion:         18,
+		HighSensitivityEnabled: true,
+	})
+	if !hasAll(on) {
+		t.Errorf("with HighSensitivityEnabled=true, all four live-sensitive collectors must be eligible")
+	}
+
+	off := pgqueries.Filter(pgqueries.FilterParams{
+		PGMajorVersion:         18,
+		HighSensitivityEnabled: false,
+	})
+	for _, q := range off {
+		if livesensIDs[q.ID] {
+			t.Errorf("with HighSensitivityEnabled=false, %s leaked through the gate — opt-out must drop high-sensitivity collectors entirely", q.ID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Resolves #6 (revised, P1). Reverses R075 from opt-in to opt-out: the live `pg_stat_activity` query-text collectors (`long_running_txns_v1`, `blocking_locks_v1`, `idle_in_txn_offenders_v1`, `wraparound_blockers_v1`) were running by default *without* proper classification, while gating them off entirely lost diagnostically valuable signals. **Collect-everything default + explicit classification + a clean privacy opt-out** keeps the signals available, makes the sensitivity surface explicit, and gives operators one toggle.

## Changes

- Mark the four live query-text collectors `HighSensitivity = true`.
- Flip `DefaultConfig().Signals.HighSensitivityCollectorsEnabled` from `false` to **`true`**. The R075 gate logic is unchanged — `enabled=true` runs them, `enabled=false` skips them — so opt-out is `signals.high_sensitivity_collectors_enabled: false` (or `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED=false`).
- `types.go` `HighSensitivity` doc broadened to cover live `pg_stat_activity` statement text in addition to SQL definitions.
- `metadata.json.high_sensitivity_collectors_enabled` already records the effective state, so auditors can tell whether sensitive data may be present without parsing the body.

**Consequence:** flipping the shared flag default also makes the existing DDL high-sensitivity collectors (view/matview/trigger/function definitions) default-on. Consistent with the "collect everything by default" decision; consider a separate per-class flag in a follow-up if you ever want them split.

## STDD

- Spec: **R075** rewritten (default-on, opt-out skips entirely; new collectors listed).
- Failing tests first: default-on assertion, four collectors flagged `HighSensitivity=true`, `Filter` drops them when opted out.
- The existing `highSensitivityCollectors` hand-roll list in `signals_high_sensitivity_test.go` grew to include the four new IDs — matching the canonical R075 set.

## Verification

Full suite green; gofmt/vet clean; `golangci-lint` 0 issues; boundary tests pass.

Closes #6