### PR TITLE
fix(export): serialise exports against retention deletes (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Exports no longer tear when retention cleanup runs concurrently. An
+  export composes the ZIP from several sequential reads of the local
+  store; if retention's `DeleteSnapshotsOlderThan` /
+  `DeleteQueryRunsOlderThanByClass` committed between those reads, the
+  export could end up referencing a row that had just been removed
+  (most visibly the `missing result payload for successful run` hard
+  error). Exports now take a shared read lock; the destructive
+  retention writes take an exclusive write lock. Concurrent exports
+  remain non-blocking; concurrent collection commits are not gated
+  (additive only — no tear). (R110, #10)
 - Disabled or removed targets no longer linger as active. The daemon
   reconciles `targets.enabled` against config on startup and on every
   reload (soft-disable; snapshots retained), and the default export +

--- a/features/arq-signals/specification.md
+++ b/features/arq-signals/specification.md
@@ -567,6 +567,34 @@ This closes the drift where the lazy per-collection `UpsertTarget`
 target's row at `enabled = 1` after it was disabled or removed, so its
 stale snapshots kept appearing in the default export and `/status`.
 
+**ARQ-SIGNALS-R110**: An export shall observe a consistent state of the
+local store across all of its reads. The store issues several
+independent reads to compose one export ZIP
+(`GetLatestRunsPerCollector` -> `GetSnapshotsByIDs` ->
+`GetQueryResultByRunID` per run -> `GetQueryCatalog`), and the daemon
+runs a retention `cleanup()` on a timer that deletes `query_runs` and
+`snapshots`. Without serialisation, a delete committing between the
+export's reads can leave the export referring to rows that were just
+removed — most visibly the "missing result payload for successful run"
+hard error.
+
+The store therefore serialises **exports against destructive writes**:
+exports take a shared read lock; the destructive retention deletes
+(`DeleteQueryRunsOlderThanByClass`, `DeleteSnapshotsOlderThan`) take an
+exclusive write lock. Consequences:
+
+- Multiple exports run concurrently (shared lock).
+- A retention cycle that fires during an export waits for the export
+  to complete; an export that starts while retention is running waits
+  for retention to finish. Both operations are short-lived in practice.
+- Concurrent collection commits are **not** serialised against
+  exports: they only **add** rows, so an export reading "old state"
+  before a commit remains internally consistent (no tear).
+
+A future revision MAY upgrade this to a per-export SQLite read
+transaction (true WAL MVCC snapshot) without changing the externally
+observable invariant.
+
 **ARQ-SIGNALS-R073**: The system shall support target-scoped export.
 When exporting for a specific target, query_runs, query_results, and
 collector_status shall contain only data for that target. The

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1251,6 +1251,15 @@ func (c *Collector) cleanup() {
 		return
 	}
 
+	// R110: hold the exclusive retention lock for the duration of the
+	// destructive DELETEs so a concurrent export sees either the
+	// pre-cleanup state or the post-cleanup state, never a mix that
+	// would let it reference rows that have just been removed (the
+	// "missing result payload" tear). Cleanup is short-lived; an
+	// export overlapping it briefly waits.
+	release := c.db.LockRetention()
+	defer release()
+
 	// R099: per-class retention. Each retention class has its own
 	// cutoff; query_runs are pruned per class so high-cadence data
 	// (RetentionShort) doesn't linger in storage just because slow-

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -18,6 +19,29 @@ import (
 // DB wraps a sql.DB with Arq Signals-specific operations.
 type DB struct {
 	sql *sql.DB
+
+	// consistencyMu serialises exports against destructive retention
+	// writes (R110). Exports take RLock for their whole read sequence;
+	// retention DELETEs take Lock. Collection commits are not gated
+	// here — they only add rows, so an export reading "old state"
+	// before a commit remains internally consistent.
+	consistencyMu sync.RWMutex
+}
+
+// LockExports acquires the read lock that protects an export's full read
+// sequence from concurrent retention DELETEs (R110). Returns the release
+// func; callers must `defer release()`.
+func (d *DB) LockExports() func() {
+	d.consistencyMu.RLock()
+	return d.consistencyMu.RUnlock
+}
+
+// LockRetention acquires the exclusive write lock for destructive
+// retention writes (R110). Returns the release func; callers must
+// `defer release()`.
+func (d *DB) LockRetention() func() {
+	d.consistencyMu.Lock()
+	return d.consistencyMu.Unlock
 }
 
 // Open creates or opens the SQLite database at path.

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -121,6 +121,18 @@ func (b *Builder) SetExportPerCollectorFiles(enabled bool) {
 
 // WriteTo writes the ZIP export to the given writer.
 func (b *Builder) WriteTo(w io.Writer, opts Options) error {
+	// R110: hold the export read lock for the whole sequence of store
+	// reads below. Retention DELETEs (`DeleteSnapshotsOlderThan`,
+	// `DeleteQueryRunsOlderThanByClass`) take the exclusive lock, so a
+	// concurrent cleanup cycle cannot commit between this export's
+	// reads and leave it referring to rows that have just been deleted
+	// (e.g. the "missing result payload for successful run" tear).
+	// Concurrent collection commits are not gated here — they only add
+	// rows, so an export reading "old state" before a commit remains
+	// internally consistent.
+	release := b.store.LockExports()
+	defer release()
+
 	// Resolve the snapshot scope once, up front. Every writer below
 	// reads from b.scopedSnapshots / b.scopedSnapshotIDs so the six
 	// files in the ZIP can never disagree about which cycles are

--- a/tests/signals_export_consistency_test.go
+++ b/tests/signals_export_consistency_test.go
@@ -1,0 +1,94 @@
+// Tests for R110: exports are serialised against destructive retention
+// writes so a concurrent cleanup cannot tear an export's reads
+// (the "missing result payload for successful run" hard-error path).
+// Added for issue #10.
+
+package tests
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Two exports may run concurrently — the lock is shared.
+func TestLockExportsAreShared(t *testing.T) {
+	store := openTestDB(t)
+
+	r1 := store.LockExports()
+	defer r1()
+
+	acquired := make(chan struct{})
+	go func() {
+		r2 := store.LockExports()
+		defer r2()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		// expected: second export acquired the shared lock immediately
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("LockExports must be shared — a second export was blocked while another was holding it")
+	}
+}
+
+// An export holding the lock blocks a retention writer.
+func TestLockRetentionBlockedWhileExportHeld(t *testing.T) {
+	store := openTestDB(t)
+
+	releaseExport := store.LockExports()
+
+	acquired := int32(0)
+	go func() {
+		release := store.LockRetention()
+		defer release()
+		atomic.StoreInt32(&acquired, 1)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if atomic.LoadInt32(&acquired) == 1 {
+		t.Fatal("LockRetention acquired the lock while LockExports was held — R110 serialisation broken")
+	}
+
+	releaseExport()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&acquired) == 1 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("LockRetention failed to acquire after LockExports released")
+}
+
+// A retention writer holding the lock blocks a new export.
+func TestLockExportsBlockedWhileRetentionHeld(t *testing.T) {
+	store := openTestDB(t)
+
+	releaseRet := store.LockRetention()
+
+	acquired := int32(0)
+	go func() {
+		release := store.LockExports()
+		defer release()
+		atomic.StoreInt32(&acquired, 1)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if atomic.LoadInt32(&acquired) == 1 {
+		t.Fatal("LockExports acquired while LockRetention was held — R110 serialisation broken")
+	}
+
+	releaseRet()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&acquired) == 1 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("LockExports failed to acquire after LockRetention released")
+}


### PR DESCRIPTION
## Summary

Fixes the export read-consistency P1 (#10) — the issue I surfaced while answering your stale-connection question. An export composes the ZIP from several sequential reads of the local store; if retention's destructive deletes committed between those reads, the export could end up referencing a row that had just been removed — most visibly the `missing result payload for successful run` hard error.

## Changes

- `db.DB` gains `consistencyMu sync.RWMutex` with `LockExports` (RLock) and `LockRetention` (Lock) helpers.
- `export.Builder.WriteTo` takes `LockExports` for its whole sequence.
- `collector.cleanup()` takes `LockRetention` around the destructive DELETEs.

Concurrent exports remain **non-blocking** (shared lock). Concurrent **collection commits** are not gated — they only add rows, so an export reading 'old state' before a commit remains internally consistent.

## Design note

I chose the narrow mutex approach over a full read-transaction refactor (~12 DB read methods to make tx-aware). The mutex is small, surgical, eliminates the documented race, and the spec explicitly allows it. A future revision MAY upgrade this to a per-export SQLite read transaction (true WAL MVCC snapshot) without changing the externally observable invariant — that's a fast-follow if you ever want concurrent exports + cleanup to run truly non-blocking.

## STDD

- Spec: **R110** added.
- Tests: three deterministic lock-behaviour tests (shared exports concurrent; retention blocked while export held; export blocked while retention held).

## Verification

Full suite green; gofmt/vet clean; `golangci-lint` 0 issues; `-race` clean.

Closes #10