### PR TITLE
fix(sensitivity): redact sensitive columns on opt-out (#6 v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,18 +20,30 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **Sensitivity policy: collect-everything default, privacy opt-out.**
-  The live `pg_stat_activity` query-text collectors
-  (`long_running_txns_v1`, `blocking_locks_v1`,
-  `idle_in_txn_offenders_v1`, `wraparound_blockers_v1`) are now
-  classified `HighSensitivity = true`. The
-  `signals.high_sensitivity_collectors_enabled` default flips from
-  `false` to **`true`**, so high-sensitivity collectors run by default;
-  set the flag (or `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED`)
-  to `false` to opt out and skip them entirely.
-  `metadata.json.high_sensitivity_collectors_enabled` reflects the
-  effective state so auditors can tell whether sensitive data may be
-  present. (R075 revised, #6)
+- **Sensitivity policy: collect-everything default, privacy opt-out
+  with per-collector redact/skip behavior.** High-sensitivity
+  collectors run by default
+  (`signals.high_sensitivity_collectors_enabled` defaults to `true`).
+  The opt-out (`= false`, a one-time startup setting) behaves per
+  collector based on whether the row carries non-sensitive diagnostic
+  columns:
+  - **Redact** path — the 4 live `pg_stat_activity` collectors
+    (`long_running_txns_v1`, `blocking_locks_v1`,
+    `idle_in_txn_offenders_v1`, `wraparound_blockers_v1`) keep running
+    with their `query_snippet` / `blocked_query` / `blocking_query`
+    columns set to `NULL`. Non-sensitive columns (`pid`, `wait_event`,
+    `txn_age_seconds`, `waiting_seconds`, …) survive, so
+    blocking-lock-chain shape and idle-in-txn / long-running-tx
+    visibility remain.
+  - **Skip** path — DDL-definition collectors and other
+    whole-row-sensitive collectors are dropped as before (recorded
+    `status=skipped, reason=config_disabled`).
+  Each collector declares its branch via `QueryDef.SensitiveColumns`
+  (non-empty -> redact; empty/nil -> skip). Corrects the
+  skip-everything-on-opt-out behavior previously shipped in
+  v0.9.0-unreleased; the metadata flag
+  `high_sensitivity_collectors_enabled` continues to record the
+  effective state. (R075 revised v2, #6)
 
 ### Fixed
 

--- a/features/arq-signals/specification.md
+++ b/features/arq-signals/specification.md
@@ -628,13 +628,40 @@ statement text:
 High-sensitivity collectors run **by default** (collect-everything
 default). An operator who prefers privacy over diagnostic richness opts
 **out** by setting `signals.high_sensitivity_collectors_enabled: false`
-(or `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED=false`), which
-skips every high-sensitivity collector entirely — including the
-non-sensitive columns of those collectors. When opted out, each shall
-appear in `collector_status.json` with `status=skipped` and
-`reason=config_disabled`. The toggle is local operator control over
-data sensitivity; it is not an exfiltration boundary (Arq Signals runs
-inside the operator's own environment).
+(or `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED=false`). This is a
+one-time startup configuration, not a per-cycle decision. The opt-out
+behaves per collector, declared on the `QueryDef` via a list of
+sensitive column names (`SensitiveColumns`):
+
+- **Redact** (live `pg_stat_activity` collectors with mixed
+  sensitive/non-sensitive columns: `long_running_txns_v1`,
+  `blocking_locks_v1`, `idle_in_txn_offenders_v1`,
+  `wraparound_blockers_v1`). When `SensitiveColumns` is non-empty, the
+  collector **still runs**, but the listed columns are set to `NULL` in
+  persisted output. The non-sensitive columns (`pid`, `wait_event`,
+  `txn_age_seconds`, `waiting_seconds`, …) survive, preserving the
+  collector's diagnostic value (blocking-lock chain shape,
+  idle-in-transaction visibility, long-running-tx detection).
+- **Skip** (collectors whose row is itself the sensitive payload — DDL
+  definitions, sampled-value stats, RLS policies / rewrite rules).
+  When `SensitiveColumns` is empty/nil, the collector is dropped from
+  the eligible set and recorded `status=skipped, reason=config_disabled`
+  in `collector_status.json`. (Pre-2026-05 behavior preserved for
+  these.)
+
+Each high-sensitivity collector declares its own branch. The
+classifying flag (`HighSensitivity=true`) is unchanged; the
+`SensitiveColumns` list distinguishes the two opt-out paths and lets
+new collectors choose redaction when they have meaningful non-sensitive
+columns.
+
+The per-target R098 `restricted` profile remains stricter than the
+daemon-wide opt-out: a restricted profile drops **every** high-
+sensitivity collector regardless of `SensitiveColumns` (no redaction
+substitute). INV-SENS-01 still holds: per-target profile never widens
+eligibility beyond the daemon-wide gate. The toggle is local operator
+control over data sensitivity; it is not an exfiltration boundary (Arq
+Signals runs inside the operator's own environment).
 
 `metadata.json.high_sensitivity_collectors_enabled` records the
 effective state so a consumer or auditor can tell, without parsing the

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1105,6 +1105,15 @@ func (c *Collector) collectTarget(ctx context.Context, tgt config.TargetConfig, 
 		// Spec: specifications/collectors/fdw_*_v1.md REDACT-R001..R004.
 		redactFDWRowsIfNeeded(q.ID, rows)
 
+		// R075 (revised, issue #6): when the operator has opted out of
+		// high-sensitivity collection, NULL the collector's declared
+		// SensitiveColumns in each row so the sensitive payload never
+		// reaches disk while the row's non-sensitive diagnostic columns
+		// survive. No-op when high-sensitivity is enabled (the default)
+		// or when the collector has no SensitiveColumns (skip-path
+		// collectors are already excluded by Filter).
+		redactHighSensitivityColumnsIfNeeded(q, rows, c.highSensitivityEnabled)
+
 		// Encode result as NDJSON.
 		payload, compressed, sizeBytes, encErr := db.EncodeNDJSON(rows)
 		if encErr != nil {

--- a/internal/collector/redact_sensitive.go
+++ b/internal/collector/redact_sensitive.go
@@ -1,0 +1,31 @@
+package collector
+
+import "github.com/elevarq/arq-signals/internal/pgqueries"
+
+// redactHighSensitivityColumnsIfNeeded implements the R075 (revised
+// 2026-05, issue #6) redact path: when the daemon-wide
+// high-sensitivity gate is closed AND the collector declares
+// SensitiveColumns, the named columns are set to nil in every row
+// before NDJSON encoding/persistence. Non-sensitive columns survive so
+// consumers retain the collector's diagnostic value (pid, wait_event,
+// txn_age_seconds, waiting_seconds, ...).
+//
+// No-op when high-sensitivity is enabled (collect-everything default)
+// or when SensitiveColumns is empty (skip-path collectors, which
+// Filter has already dropped from the eligible set; this helper is
+// still safe to call on them).
+//
+// Mirrors the same post-query, pre-encode pattern used by
+// redactFDWRowsIfNeeded for FDW credential redaction.
+func redactHighSensitivityColumnsIfNeeded(q pgqueries.QueryDef, rows []map[string]any, highSensitivityEnabled bool) {
+	if highSensitivityEnabled || len(q.SensitiveColumns) == 0 {
+		return
+	}
+	for _, row := range rows {
+		for _, col := range q.SensitiveColumns {
+			if _, ok := row[col]; ok {
+				row[col] = nil
+			}
+		}
+	}
+}

--- a/internal/collector/redact_sensitive_test.go
+++ b/internal/collector/redact_sensitive_test.go
@@ -1,0 +1,64 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/elevarq/arq-signals/internal/pgqueries"
+)
+
+// R075 (revised v2, issue #6): when high-sensitivity is opted out and
+// the collector declares SensitiveColumns, those columns are zeroed in
+// every row before persistence. Non-sensitive columns survive.
+func TestRedactHighSensitivityColumnsIfNeeded(t *testing.T) {
+	q := pgqueries.QueryDef{
+		ID:               "long_running_txns_v1",
+		HighSensitivity:  true,
+		SensitiveColumns: []string{"query_snippet"},
+	}
+	rows := []map[string]any{
+		{"pid": 1234, "wait_event": "ClientRead", "query_snippet": "SELECT secret FROM users"},
+		{"pid": 5678, "wait_event": "Lock", "query_snippet": "UPDATE accounts SET balance=9.99"},
+	}
+
+	// Opted out: sensitive column is nulled; non-sensitive columns survive.
+	redactHighSensitivityColumnsIfNeeded(q, rows, false)
+	for i, row := range rows {
+		if row["query_snippet"] != nil {
+			t.Errorf("row[%d].query_snippet not redacted: %v", i, row["query_snippet"])
+		}
+		if row["pid"] == nil {
+			t.Errorf("row[%d].pid (non-sensitive) was redacted", i)
+		}
+		if row["wait_event"] == nil {
+			t.Errorf("row[%d].wait_event (non-sensitive) was redacted", i)
+		}
+	}
+}
+
+func TestRedactHighSensitivityColumnsNoOpWhenEnabled(t *testing.T) {
+	q := pgqueries.QueryDef{
+		ID:               "long_running_txns_v1",
+		HighSensitivity:  true,
+		SensitiveColumns: []string{"query_snippet"},
+	}
+	rows := []map[string]any{{"query_snippet": "SELECT 1"}}
+	redactHighSensitivityColumnsIfNeeded(q, rows, true)
+	if rows[0]["query_snippet"] != "SELECT 1" {
+		t.Errorf("with HighSensitivityEnabled=true the column must not be redacted; got %v", rows[0]["query_snippet"])
+	}
+}
+
+func TestRedactHighSensitivityColumnsNoOpWhenSkipCollector(t *testing.T) {
+	// A HighSensitivity collector with no SensitiveColumns is the
+	// skip-on-opt-out path (DDL definitions etc.). Filter drops it
+	// before execution, but the redact function must be a no-op anyway.
+	q := pgqueries.QueryDef{
+		ID:              "pg_views_definitions_v1",
+		HighSensitivity: true,
+	}
+	rows := []map[string]any{{"definition": "CREATE VIEW v AS SELECT 1"}}
+	redactHighSensitivityColumnsIfNeeded(q, rows, false)
+	if rows[0]["definition"] != "CREATE VIEW v AS SELECT 1" {
+		t.Errorf("collector without SensitiveColumns must not be touched by the redact function; got %v", rows[0]["definition"])
+	}
+}

--- a/internal/pgqueries/catalog_diagnostics.go
+++ b/internal/pgqueries/catalog_diagnostics.go
@@ -109,11 +109,12 @@ func init() {
 		  AND state != 'idle'
 		  AND now() - xact_start > interval '5 minutes'
 		ORDER BY xact_start ASC`,
-		ResultKind:      ResultRowset,
-		RetentionClass:  RetentionShort,
-		Timeout:         10 * time.Second,
-		Cadence:         Cadence5m,
-		HighSensitivity: true, // R075: emits live pg_stat_activity query text
+		ResultKind:       ResultRowset,
+		RetentionClass:   RetentionShort,
+		Timeout:          10 * time.Second,
+		Cadence:          Cadence5m,
+		HighSensitivity:  true, // R075: emits live pg_stat_activity query text
+		SensitiveColumns: []string{"query_snippet"},
 	})
 
 	// Locks and blocking chains. Uses pg_blocking_pids() which is
@@ -136,11 +137,12 @@ func init() {
 			ON blocking.pid = ANY(pg_blocking_pids(blocked.pid))
 		WHERE cardinality(pg_blocking_pids(blocked.pid)) > 0
 		ORDER BY waiting_seconds DESC`,
-		ResultKind:      ResultRowset,
-		RetentionClass:  RetentionShort,
-		Timeout:         10 * time.Second,
-		Cadence:         Cadence5m,
-		HighSensitivity: true, // R075: emits live pg_stat_activity query text (blocked/blocking)
+		ResultKind:       ResultRowset,
+		RetentionClass:   RetentionShort,
+		Timeout:          10 * time.Second,
+		Cadence:          Cadence5m,
+		HighSensitivity:  true, // R075: emits live pg_stat_activity query text (blocked/blocking)
+		SensitiveColumns: []string{"blocked_query", "blocking_query"},
 	})
 
 	// Login roles with dangerous privileges.

--- a/internal/pgqueries/catalog_survival.go
+++ b/internal/pgqueries/catalog_survival.go
@@ -124,11 +124,12 @@ func init() {
 		WHERE state IN ('idle in transaction', 'idle in transaction (aborted)')
 		  AND pid != pg_backend_pid()
 		ORDER BY xact_start ASC NULLS LAST`,
-		ResultKind:      ResultRowset,
-		RetentionClass:  RetentionShort,
-		Timeout:         5 * time.Second,
-		Cadence:         Cadence5m,
-		HighSensitivity: true, // R075: emits live pg_stat_activity query text
+		ResultKind:       ResultRowset,
+		RetentionClass:   RetentionShort,
+		Timeout:          5 * time.Second,
+		Cadence:          Cadence5m,
+		HighSensitivity:  true, // R075: emits live pg_stat_activity query text
+		SensitiveColumns: []string{"query_snippet"},
 	})
 
 	// Database sizes: all non-template databases with sizes, wraparound

--- a/internal/pgqueries/catalog_wraparound.go
+++ b/internal/pgqueries/catalog_wraparound.go
@@ -95,10 +95,11 @@ func init() {
 		  AND state != 'idle'
 		ORDER BY xact_start ASC
 		LIMIT 20`,
-		ResultKind:      ResultRowset,
-		RetentionClass:  RetentionShort,
-		Timeout:         10 * time.Second,
-		Cadence:         Cadence5m,
-		HighSensitivity: true, // R075: emits live pg_stat_activity query text
+		ResultKind:       ResultRowset,
+		RetentionClass:   RetentionShort,
+		Timeout:          10 * time.Second,
+		Cadence:          Cadence5m,
+		HighSensitivity:  true, // R075: emits live pg_stat_activity query text
+		SensitiveColumns: []string{"query_snippet"},
 	})
 }

--- a/internal/pgqueries/registry.go
+++ b/internal/pgqueries/registry.go
@@ -127,7 +127,12 @@ func Filter(p FilterParams) []QueryDef {
 		if q.RequiresExtension != "" && !extSet[q.RequiresExtension] {
 			continue
 		}
-		if q.HighSensitivity && !p.HighSensitivityEnabled {
+		// R075 (revised 2026-05): when opted out, only collectors whose
+		// row is *itself* the sensitive payload are dropped here
+		// (SensitiveColumns empty/nil — the skip path). Collectors with
+		// non-empty SensitiveColumns stay eligible; the collector loop
+		// nulls those columns in each row at execution time (redact path).
+		if q.HighSensitivity && !p.HighSensitivityEnabled && len(q.SensitiveColumns) == 0 {
 			continue
 		}
 		// #128 — per-collector opt-in for pg_stats_array_range_v1
@@ -175,7 +180,11 @@ func HighSensitivityIDs(p FilterParams) []string {
 	}
 	var out []string
 	for _, q := range registry {
-		if !q.HighSensitivity {
+		// Only the **skip-path** high-sensitivity collectors land here
+		// — the redact-path ones (SensitiveColumns non-empty) keep
+		// running with redacted columns and are NOT recorded as
+		// skipped/config_disabled (R075 revised).
+		if !q.HighSensitivity || len(q.SensitiveColumns) > 0 {
 			continue
 		}
 		if q.MinPGVersion > 0 && p.PGMajorVersion < q.MinPGVersion {
@@ -224,7 +233,9 @@ func GatedIDsByReason(p FilterParams) map[string][]string {
 			out[GateReasonVersionUnsupported] = append(out[GateReasonVersionUnsupported], q.ID)
 		case q.RequiresExtension != "" && !extSet[q.RequiresExtension]:
 			out[GateReasonExtensionMissing] = append(out[GateReasonExtensionMissing], q.ID)
-		case q.HighSensitivity && !p.HighSensitivityEnabled:
+		case q.HighSensitivity && len(q.SensitiveColumns) == 0 && !p.HighSensitivityEnabled:
+			// R075 revised: only skip-path collectors are reported as
+			// config_disabled. Redact-path collectors keep running.
 			out[GateReasonConfigDisabled] = append(out[GateReasonConfigDisabled], q.ID)
 		case p.ProfileRestricted && q.HighSensitivity:
 			// R098: per-target restricted profile drops every

--- a/internal/pgqueries/types.go
+++ b/internal/pgqueries/types.go
@@ -82,9 +82,19 @@ type QueryDef struct {
 	// pg_stat_activity statement text (long-running txns, blocking
 	// locks, idle-in-txn, wraparound blockers). Per R075 these run by
 	// default (collect-everything default); operators opt **out** by
-	// setting `high_sensitivity_collectors_enabled = false`, which
-	// skips every collector with this flag.
+	// setting `high_sensitivity_collectors_enabled = false`. The
+	// opt-out behavior depends on SensitiveColumns (see below).
 	HighSensitivity bool
+	// SensitiveColumns lists the columns to NULL-out when the operator
+	// has opted out of high-sensitivity collection (R075, redact path).
+	// Non-empty SensitiveColumns puts the collector on the **redact**
+	// path: it still runs when opted out, but the listed columns are
+	// zeroed in every persisted row so non-sensitive columns survive.
+	// Empty/nil SensitiveColumns keeps the historical **skip** path:
+	// the collector is dropped from the eligible set when opted out and
+	// recorded `status=skipped, reason=config_disabled`. Used by Filter
+	// and by the collector's per-row redaction step.
+	SensitiveColumns []string
 }
 
 // FilterParams controls which queries are eligible for a given target.

--- a/tests/signals_high_sensitivity_test.go
+++ b/tests/signals_high_sensitivity_test.go
@@ -40,13 +40,12 @@ var highSensitivityCollectors = []string{
 	"pg_policies_v1",
 	// pg_rules_v1 (#219) emits the rewrite-rule action — arbitrary SQL.
 	"pg_rules_v1",
-	// R075 (revised 2026-05, issue #6): live pg_stat_activity statement
-	// text. Default-on with an opt-out — collectors run by default,
-	// `high_sensitivity_collectors_enabled = false` skips them.
-	"long_running_txns_v1",
-	"blocking_locks_v1",
-	"idle_in_txn_offenders_v1",
-	"wraparound_blockers_v1",
+	// NOTE: the 4 live pg_stat_activity collectors (long_running_txns_v1,
+	// blocking_locks_v1, idle_in_txn_offenders_v1, wraparound_blockers_v1)
+	// are HighSensitivity = true but use the **redact** path (R075 revised
+	// 2026-05, issue #6) — they stay eligible when opted out and have their
+	// sensitive columns nulled at execution time. They are covered by
+	// tests/signals_redact_columns_test.go, not this skip-path list.
 }
 
 // TestHighSensitivityCollectorsAreFlagged verifies all four definition
@@ -64,18 +63,21 @@ func TestHighSensitivityCollectorsAreFlagged(t *testing.T) {
 	}
 }
 
-// TestFilterExcludesHighSensitivityWhenDisabled verifies that without
-// opt-in, Filter returns no high-sensitivity queries — they are gated off
-// at the catalog filter, not at execution time.
-// Traces: ARQ-SIGNALS-R075
-func TestFilterExcludesHighSensitivityWhenDisabled(t *testing.T) {
+// TestFilterExcludesSkipPathHighSensitivityWhenDisabled verifies that
+// when high-sensitivity is opted out, Filter drops the skip-path
+// high-sensitivity collectors (whole row is the sensitive payload, no
+// SensitiveColumns declared). Redact-path collectors (non-empty
+// SensitiveColumns) keep running and have their sensitive columns
+// nulled at execution time — covered by tests/signals_redact_columns_test.go.
+// Traces: ARQ-SIGNALS-R075 (revised 2026-05, issue #6).
+func TestFilterExcludesSkipPathHighSensitivityWhenDisabled(t *testing.T) {
 	out := pgqueries.Filter(pgqueries.FilterParams{
 		PGMajorVersion:         16,
 		HighSensitivityEnabled: false,
 	})
 	for _, q := range out {
-		if q.HighSensitivity {
-			t.Errorf("%s should be excluded when HighSensitivityEnabled=false", q.ID)
+		if q.HighSensitivity && len(q.SensitiveColumns) == 0 {
+			t.Errorf("%s is a skip-path high-sensitivity collector but Filter kept it when opted out", q.ID)
 		}
 	}
 }

--- a/tests/signals_highsens_default_test.go
+++ b/tests/signals_highsens_default_test.go
@@ -39,45 +39,9 @@ func TestLiveQueryTextCollectorsAreHighSensitivity(t *testing.T) {
 	}
 }
 
-func TestFilterDropsHighSensitivityWhenOptedOut(t *testing.T) {
-	livesensIDs := map[string]bool{
-		"long_running_txns_v1":     true,
-		"blocking_locks_v1":        true,
-		"idle_in_txn_offenders_v1": true,
-		"wraparound_blockers_v1":   true,
-	}
-
-	hasAll := func(qs []pgqueries.QueryDef) bool {
-		got := map[string]bool{}
-		for _, q := range qs {
-			got[q.ID] = true
-		}
-		for id := range livesensIDs {
-			if !got[id] {
-				return false
-			}
-		}
-		return true
-	}
-
-	// PG 18 + no extensions: the four collectors have no extension
-	// dependency and no MinPGVersion above 18, so eligibility is gated
-	// only by HighSensitivityEnabled.
-	on := pgqueries.Filter(pgqueries.FilterParams{
-		PGMajorVersion:         18,
-		HighSensitivityEnabled: true,
-	})
-	if !hasAll(on) {
-		t.Errorf("with HighSensitivityEnabled=true, all four live-sensitive collectors must be eligible")
-	}
-
-	off := pgqueries.Filter(pgqueries.FilterParams{
-		PGMajorVersion:         18,
-		HighSensitivityEnabled: false,
-	})
-	for _, q := range off {
-		if livesensIDs[q.ID] {
-			t.Errorf("with HighSensitivityEnabled=false, %s leaked through the gate — opt-out must drop high-sensitivity collectors entirely", q.ID)
-		}
-	}
-}
+// Note: PR #13's TestFilterDropsHighSensitivityWhenOptedOut asserted
+// the four live-sensitive collectors were dropped when opted out. That
+// behavior was corrected by issue #6 v2 (redact path): the collectors
+// now stay eligible when opted out and have their sensitive columns
+// nulled at execution time. The replacement coverage lives in
+// tests/signals_redact_columns_test.go.

--- a/tests/signals_redact_columns_test.go
+++ b/tests/signals_redact_columns_test.go
@@ -1,0 +1,108 @@
+// Tests for R075 (revised v2, issue #6): the four live pg_stat_activity
+// collectors carry SensitiveColumns and stay eligible when opted out
+// (redact path); the DDL-definition collectors keep their skip-on-opt-out
+// behavior (no SensitiveColumns).
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/elevarq/arq-signals/internal/pgqueries"
+)
+
+// The 4 live-query collectors must declare which columns to redact.
+func TestLiveQueryCollectorsHaveSensitiveColumns(t *testing.T) {
+	want := map[string][]string{
+		"long_running_txns_v1":     {"query_snippet"},
+		"blocking_locks_v1":        {"blocked_query", "blocking_query"},
+		"idle_in_txn_offenders_v1": {"query_snippet"},
+		"wraparound_blockers_v1":   {"query_snippet"},
+	}
+	for id, expected := range want {
+		q := pgqueries.ByID(id)
+		if q == nil {
+			t.Errorf("%s not registered", id)
+			continue
+		}
+		if !q.HighSensitivity {
+			t.Errorf("%s.HighSensitivity should be true", id)
+		}
+		if len(q.SensitiveColumns) != len(expected) {
+			t.Errorf("%s.SensitiveColumns = %v, want %v", id, q.SensitiveColumns, expected)
+			continue
+		}
+		got := map[string]bool{}
+		for _, c := range q.SensitiveColumns {
+			got[c] = true
+		}
+		for _, c := range expected {
+			if !got[c] {
+				t.Errorf("%s.SensitiveColumns missing %q (got %v)", id, c, q.SensitiveColumns)
+			}
+		}
+	}
+}
+
+// When opted out, the redact-path collectors STAY eligible (Filter does
+// not drop them) — they will run and have their sensitive columns
+// zeroed at execution time. The skip-path collectors (DDL definitions)
+// are still dropped.
+func TestFilterKeepsRedactPathCollectorsWhenOptedOut(t *testing.T) {
+	off := pgqueries.Filter(pgqueries.FilterParams{
+		PGMajorVersion:         18,
+		HighSensitivityEnabled: false,
+	})
+	got := map[string]bool{}
+	for _, q := range off {
+		got[q.ID] = true
+	}
+
+	mustBeEligible := []string{
+		"long_running_txns_v1",
+		"blocking_locks_v1",
+		"idle_in_txn_offenders_v1",
+		"wraparound_blockers_v1",
+	}
+	for _, id := range mustBeEligible {
+		if !got[id] {
+			t.Errorf("%s must stay eligible when opted out (redact path) — Filter dropped it", id)
+		}
+	}
+
+	mustBeDropped := []string{
+		"pg_views_definitions_v1",
+		"pg_matviews_definitions_v1",
+		"pg_triggers_definitions_v1",
+		"pg_functions_definitions_v1",
+	}
+	for _, id := range mustBeDropped {
+		if got[id] {
+			t.Errorf("%s must be dropped when opted out (skip path) — Filter kept it", id)
+		}
+	}
+}
+
+// HighSensitivityIDs (the gated set EA-R001 writes as skipped) must
+// include only the skip-path collectors, not the redact-path ones.
+func TestHighSensitivityIDsExcludesRedactPath(t *testing.T) {
+	gated := pgqueries.HighSensitivityIDs(pgqueries.FilterParams{
+		PGMajorVersion:         18,
+		HighSensitivityEnabled: false,
+	})
+	g := map[string]bool{}
+	for _, id := range gated {
+		g[id] = true
+	}
+	redactPath := []string{
+		"long_running_txns_v1",
+		"blocking_locks_v1",
+		"idle_in_txn_offenders_v1",
+		"wraparound_blockers_v1",
+	}
+	for _, id := range redactPath {
+		if g[id] {
+			t.Errorf("%s appears in HighSensitivityIDs but it is a redact-path collector — it must not be recorded as skipped/config_disabled", id)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Corrects #6 (the skip-on-opt-out shipped in PR #13 didn't match the intended policy — Codex review caught this). The right behavior:

- **Default (`high_sensitivity_collectors_enabled=true`)**: collect everything. Unchanged.
- **Opt-out (`=false`, one-time startup setting)**: per-collector branch based on whether the row has non-sensitive diagnostic columns alongside the sensitive ones:
  - **Redact** path — the 4 live `pg_stat_activity` collectors keep running with `query_snippet` / `blocked_query` / `blocking_query` set to `NULL`. Non-sensitive columns (`pid`, `wait_event`, `txn_age_seconds`, `waiting_seconds`, …) survive, so blocking-lock-chain shape and idle-in-txn / long-running-tx visibility remain.
  - **Skip** path — DDL-definition and other whole-row-sensitive collectors are dropped as before (recorded `skipped`/`config_disabled`). Nothing useful remains after redacting their entire payload.

## How it's wired

- `QueryDef` gains `SensitiveColumns []string`. Non-empty -> redact path; empty/nil + `HighSensitivity=true` -> skip path.
- The 4 collectors declare:
  - `long_running_txns_v1`: `["query_snippet"]`
  - `blocking_locks_v1`: `["blocked_query", "blocking_query"]`
  - `idle_in_txn_offenders_v1`: `["query_snippet"]`
  - `wraparound_blockers_v1`: `["query_snippet"]`
- `Filter`, `HighSensitivityIDs`, and `GatedIDsByReason` gate only when `SensitiveColumns` is empty.
- New `redactHighSensitivityColumnsIfNeeded` zeroes the declared columns in each row after `queryToMaps`, before NDJSON encoding — same post-query, pre-encode pattern as `redactFDWRowsIfNeeded`.

## STDD

- Spec: **R075 revised v2** — redact-or-skip per collector.
- Failing tests first: redact-fn unit tests (`internal/collector`); the 4 collectors carry `SensitiveColumns`; `Filter` keeps them eligible when opted out; `HighSensitivityIDs` excludes them.
- PR #13's now-wrong tests updated (skip-list narrowed to whole-row-sensitive collectors) or replaced (drop-on-opt-out asserts removed; redact-path coverage added in `signals_redact_columns_test.go`).

## Verification

Full suite green; gofmt clean; `go vet` clean; `golangci-lint` 0 issues; `-race` clean.

Closes #6