### PR TITLE
fix(api,reload): /status.target_count counts enabled only; Reload propagates reconcile error (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,19 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `GET /status.target_count` now matches the number of enabled targets
+  surfaced in the response (was using the unfiltered `GetTargets()`
+  count, so disabled targets still bumped it). Restores
+  INV-SIGNALS-14 agreement with the default export's active-target
+  set. (#16)
+- `collector.Reload` now returns an `error` and propagates
+  `ReconcileEnabledTargets` failures instead of logging-and-swallowing
+  them. The reconcile runs **before** the in-memory target swap, so a
+  reconcile failure aborts the reload cleanly without mutating
+  in-memory state. `POST /reload` returns 500 on failure; the SIGHUP
+  path audit-logs `config_reload_rejected` with
+  `reason=reconcile_failed` (matching the load/validate-rejected
+  pattern). (#16)
 - Exports no longer tear when retention cleanup runs concurrently. An
   export composes the ZIP from several sequential reads of the local
   store; if retention's `DeleteSnapshotsOlderThan` /

--- a/cmd/arq-signals/main.go
+++ b/cmd/arq-signals/main.go
@@ -323,7 +323,17 @@ func run() error {
 						"actor", "signal_handler", "reason", "validate_failed", "error", redacted)
 					continue
 				}
-				coll.Reload(newCfg.Targets)
+				// R109/#16: propagate reconcile failures rather than
+				// leaving DB enablement stale. Reload aborts before any
+				// in-memory mutation on failure, matching the
+				// load/validate-rejected pattern above.
+				if err := coll.Reload(newCfg.Targets); err != nil {
+					redacted := redactReloadErr(err)
+					slog.Error("SIGHUP reload: reconcile failed", "err", redacted)
+					safety.AuditLog("config_reload_rejected",
+						"actor", "signal_handler", "reason", "reconcile_failed", "error", redacted)
+					continue
+				}
 				slog.Info("SIGHUP reload applied", "target_count", len(newCfg.Targets))
 				safety.AuditLog("config_reload_applied",
 					"actor", "signal_handler", "target_count", len(newCfg.Targets))

--- a/internal/api/reload.go
+++ b/internal/api/reload.go
@@ -47,7 +47,19 @@ func handleConfigReload(deps *Deps, configPath string) http.HandlerFunc {
 			return
 		}
 
-		deps.Collector.Reload(newCfg.Targets)
+		// R109/#16: Reload propagates a reconcile failure so we surface
+		// it to the operator instead of silently leaving DB enablement
+		// stale. Reload aborts before any in-memory mutation on
+		// failure, so the daemon stays consistent.
+		if err := deps.Collector.Reload(newCfg.Targets); err != nil {
+			redacted := redactReloadErr(err)
+			safety.AuditLog("config_reload_rejected",
+				"actor", actor, "reason", "reconcile_failed", "error", redacted)
+			writeJSON(w, http.StatusInternalServerError, map[string]any{
+				"error": fmt.Sprintf("reload %s: %s", configPath, redacted),
+			})
+			return
+		}
 
 		safety.AuditLog("config_reload_applied",
 			"actor", actor, "target_count", len(newCfg.Targets))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -202,9 +202,14 @@ func handleStatus(deps *Deps) http.HandlerFunc {
 		}
 
 		resp := map[string]any{
-			"instance_id":         instanceID,
-			"version":             safety.Version,
-			"target_count":        len(targets),
+			"instance_id": instanceID,
+			"version":     safety.Version,
+			// R109 / INV-SIGNALS-14: target_count must match the
+			// active-target set surfaced in targetInfo (which already
+			// filters out enabled=0). Counting the unfiltered
+			// GetTargets() result would let a disabled or removed
+			// target still bump the count.
+			"target_count":        len(targetInfo),
 			"targets":             targetInfo,
 			"snapshot_count":      snapCount,
 			"query_catalog_count": len(queryCatalog),

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -314,7 +314,25 @@ func (c *Collector) Targets() []config.TargetConfig {
 //
 // Callers that need broader config swap should follow up via a
 // separate issue.
-func (c *Collector) Reload(newTargets []config.TargetConfig) {
+func (c *Collector) Reload(newTargets []config.TargetConfig) error {
+	// R109: reconcile the persisted `targets.enabled` column FIRST. If
+	// reconcile fails, we return the error WITHOUT mutating any
+	// in-memory state, so the caller sees a clean abort and the
+	// daemon stays in a consistent (old) state — rather than a split
+	// where the in-memory target list says one thing and the DB
+	// `enabled` column says another. (#16: previously this error was
+	// logged warn-only after the in-memory swap, so /reload + SIGHUP
+	// could appear successful while persistence was stale.)
+	enabledNames := make([]string, 0, len(newTargets))
+	for _, t := range newTargets {
+		if t.Enabled {
+			enabledNames = append(enabledNames, t.Name)
+		}
+	}
+	if err := c.db.ReconcileEnabledTargets(enabledNames); err != nil {
+		return fmt.Errorf("reconcile enabled targets: %w", err)
+	}
+
 	c.runtimeMu.Lock()
 	prev := c.targets
 	c.targets = make([]config.TargetConfig, len(newTargets))
@@ -356,19 +374,7 @@ func (c *Collector) Reload(newTargets []config.TargetConfig) {
 		}
 	}
 
-	// R109: reconcile the persisted `targets.enabled` column so a target
-	// disabled in the new config, or removed from it, stops appearing in
-	// the default export and /status. Soft-disable only — snapshots are
-	// retained for `--all`.
-	enabledNames := make([]string, 0, len(newTargets))
-	for _, t := range newTargets {
-		if t.Enabled {
-			enabledNames = append(enabledNames, t.Name)
-		}
-	}
-	if err := c.db.ReconcileEnabledTargets(enabledNames); err != nil {
-		slog.Warn("reload: reconcile enabled targets failed", "err", err)
-	}
+	return nil
 }
 
 // sameConnection returns true when the network-identity fields of

--- a/tests/signals_api_reload_regressions_test.go
+++ b/tests/signals_api_reload_regressions_test.go
@@ -155,7 +155,9 @@ func TestCollectNow_HonoursReloadedTargetList(t *testing.T) {
 	reloaded := []config.TargetConfig{
 		{Name: "new-target", Host: "127.0.0.1", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 	}
-	deps.Collector.Reload(reloaded)
+	if err := deps.Collector.Reload(reloaded); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
 
 	// 1. /collect/now naming the NEW target must accept it (200).
 	body := []byte(`{"targets":["new-target"]}`)
@@ -218,7 +220,9 @@ func TestCollectNow_AllEnabledUsesReloadedList(t *testing.T) {
 		{Name: "alpha", Host: "127.0.0.1", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 		{Name: "beta", Host: "127.0.0.1", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 	}
-	deps.Collector.Reload(reloaded)
+	if err := deps.Collector.Reload(reloaded); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
 
 	out := captureSlog(t, func() {
 		req, _ := http.NewRequest("POST", ts.URL+"/collect/now", bytes.NewReader([]byte(`{}`)))

--- a/tests/signals_config_reload_test.go
+++ b/tests/signals_config_reload_test.go
@@ -39,7 +39,9 @@ func TestReload_NoOpWhenTargetsUnchanged(t *testing.T) {
 		{Name: "a", Host: "h", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 	}
 	c, _ := newReloadTestCollector(t, tgts)
-	c.Reload(tgts)
+	if err := c.Reload(tgts); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
 	got := c.Targets()
 	if len(got) != 1 || got[0].Name != "a" {
 		t.Errorf("Reload no-op: got %+v, want one target named a", got)
@@ -51,10 +53,12 @@ func TestReload_AddsNewTarget(t *testing.T) {
 	c, _ := newReloadTestCollector(t, []config.TargetConfig{
 		{Name: "a", Host: "h", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 	})
-	c.Reload([]config.TargetConfig{
+	if err := c.Reload([]config.TargetConfig{
 		{Name: "a", Host: "h", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 		{Name: "b", Host: "h2", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
-	})
+	}); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
 	got := c.Targets()
 	if len(got) != 2 {
 		t.Fatalf("expected 2 targets after Reload-add, got %d", len(got))
@@ -74,9 +78,11 @@ func TestReload_RemovesTarget(t *testing.T) {
 		{Name: "a", Host: "h", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 		{Name: "b", Host: "h", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 	})
-	c.Reload([]config.TargetConfig{
+	if err := c.Reload([]config.TargetConfig{
 		{Name: "a", Host: "h", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
-	})
+	}); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
 	got := c.Targets()
 	if len(got) != 1 || got[0].Name != "a" {
 		t.Errorf("expected only 'a' after Reload-remove; got %+v", got)
@@ -117,11 +123,15 @@ func TestReload_ConcurrentReadsAreSafe(t *testing.T) {
 	}()
 
 	for ctx.Err() == nil {
-		c.Reload([]config.TargetConfig{
+		// Discard the error in this race-stress loop — the test asserts
+		// concurrency safety, not reconcile success. (#16 returns error
+		// from Reload; a stray reconcile failure here would still be
+		// surfaced by the dedicated #16 propagation test.)
+		_ = c.Reload([]config.TargetConfig{
 			{Name: "a", Host: "h", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 			{Name: "b", Host: "h", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 		})
-		c.Reload([]config.TargetConfig{
+		_ = c.Reload([]config.TargetConfig{
 			{Name: "a", Host: "h", Port: 5432, DBName: "d", User: "u", SSLMode: "disable", Enabled: true},
 		})
 	}

--- a/tests/signals_status_count_reload_test.go
+++ b/tests/signals_status_count_reload_test.go
@@ -1,0 +1,114 @@
+// Tests for issue #16 (Codex Beta review polish):
+//   - /status.target_count must reflect only enabled targets.
+//   - collector.Reload must propagate a ReconcileEnabledTargets error
+//     so a /reload or SIGHUP that can't update DB enablement is reported,
+//     not silently logged.
+
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/elevarq/arq-signals/internal/api"
+	"github.com/elevarq/arq-signals/internal/collector"
+	"github.com/elevarq/arq-signals/internal/config"
+	"github.com/elevarq/arq-signals/internal/db"
+	"github.com/elevarq/arq-signals/internal/export"
+)
+
+// Build a real api handler over a real store so we can seed targets and
+// hit /status end-to-end without copying makeTestHandler's full body.
+func makeStatusTestStack(t *testing.T) (*db.DB, http.Handler, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := db.Open(filepath.Join(dir, "status-test.db"), false)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if err := store.Migrate(); err != nil {
+		_ = store.Close()
+		t.Fatalf("Migrate: %v", err)
+	}
+	if _, err := store.EnsureInstanceID(); err != nil {
+		_ = store.Close()
+		t.Fatalf("EnsureInstanceID: %v", err)
+	}
+	coll := collector.New(store, nil, time.Hour, 30)
+	exp := export.NewBuilder(store, "test-id")
+	srv := api.NewServer("127.0.0.1:0", 10*time.Second, 10*time.Second, testAPIToken, &api.Deps{
+		DB: store, Collector: coll, Exporter: exp,
+	})
+	return store, srv.Handler(), func() { _ = store.Close() }
+}
+
+// TC-#16 (1): /status.target_count must count only enabled targets so it
+// stays consistent with the targetInfo slice (which already filters
+// disabled per #7) and with INV-SIGNALS-14.
+func TestStatusTargetCountExcludesDisabled(t *testing.T) {
+	store, handler, cleanup := makeStatusTestStack(t)
+	defer cleanup()
+
+	if _, err := store.UpsertTarget("target-A", "host-a", 5432, "postgres", "arq", "disable", "NONE", "", true); err != nil {
+		t.Fatalf("UpsertTarget A: %v", err)
+	}
+	if _, err := store.UpsertTarget("target-B", "host-b", 5432, "postgres", "arq", "disable", "NONE", "", true); err != nil {
+		t.Fatalf("UpsertTarget B: %v", err)
+	}
+	// Soft-disable B (the reload path would do this on a config change).
+	if err := store.ReconcileEnabledTargets([]string{"target-A"}); err != nil {
+		t.Fatalf("ReconcileEnabledTargets: %v", err)
+	}
+
+	r := httptest.NewRequest("GET", "/status", nil)
+	r.Header.Set("Authorization", "Bearer "+testAPIToken)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /status status = %d, want 200", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode /status: %v", err)
+	}
+
+	got := int(body["target_count"].(float64))
+	if got != 1 {
+		t.Errorf("/status.target_count = %d, want 1 (target-B is disabled and must not be counted)", got)
+	}
+	if targets, _ := body["targets"].([]any); len(targets) != 1 {
+		t.Errorf("/status.targets length = %d, want 1 (must match target_count, INV-SIGNALS-14)", len(targets))
+	}
+}
+
+// TC-#16 (2): collector.Reload must propagate a reconcile failure, NOT
+// log-and-swallow. Forcing the failure: close the store before calling
+// Reload, which makes ReconcileEnabledTargets return an error.
+func TestReloadPropagatesReconcileFailure(t *testing.T) {
+	dir := t.TempDir()
+	store, err := db.Open(filepath.Join(dir, "reload-test.db"), false)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if err := store.Migrate(); err != nil {
+		_ = store.Close()
+		t.Fatalf("Migrate: %v", err)
+	}
+	coll := collector.New(store, nil, time.Hour, 30)
+
+	// Force reconcile to fail by closing the DB beneath the collector.
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	err = coll.Reload([]config.TargetConfig{
+		{Name: "t1", Host: "h", Port: 5432, DBName: "db", User: "u", SSLMode: "disable", Enabled: true},
+	})
+	if err == nil {
+		t.Fatal("Reload returned nil after store close; reconcile failure must propagate (#16)")
+	}
+}


### PR DESCRIPTION
## Summary

Two beta-polish gaps Codex flagged after #7 landed:

### 1. `GET /status.target_count` still counted disabled targets

`internal/api/server.go` filtered disabled targets from the `targets` slice (per #7) but reported `target_count: len(targets)` using the **unfiltered** `GetTargets()` result — so a disabled or removed target still bumped the count. Violates INV-SIGNALS-14 (status and default export agree on the active-target set).

**Fix:** use `len(targetInfo)` after the enabled-only filter.

### 2. `collector.Reload` swallowed `ReconcileEnabledTargets` errors

`Reload` logged `slog.Warn` on reconcile failure but didn't return an error, so `POST /reload` and the SIGHUP path appeared successful while persisted target enablement remained stale.

**Fix:**
- `Reload` now returns `error`.
- The reconcile runs **before** any in-memory mutation, so a reconcile failure aborts the reload cleanly (no split between in-memory and DB state).
- `/reload` handler maps failures to **500** + audit `config_reload_rejected` with `reason=reconcile_failed`.
- SIGHUP path mirrors the same audit pattern as the existing load/validate-rejected branches.

## Tests

- `TestStatusTargetCountExcludesDisabled`: seed two enabled targets, soft-disable one via `ReconcileEnabledTargets`, hit `GET /status`, assert `target_count == 1` and `len(targets) == 1`.
- `TestReloadPropagatesReconcileFailure`: close the store beneath the collector to force `ReconcileEnabledTargets` to error; assert `Reload` returns the error.

Existing `Reload` callers in test files updated to check the returned error (race-loop stress test acknowledges with `_ =` since it's not testing reconcile success).

## Verification

Full suite green; gofmt clean; `go vet` clean; `golangci-lint` 0 issues; `-race` clean on the new tests.

Closes #16