### PR TITLE
fix(status, docs): array-range opt-out surfaces as skipped; sensitivity docs realigned (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,29 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `pg_stats_array_range_v1` no longer disappears silently when its
+  per-collector opt-in (`collect_array_range_histograms`, default
+  `false`) is off. The collector now appears in `collector_status.json`
+  as `status=skipped, reason=config_disabled` — matching the EA-R001
+  status-completeness guarantee already provided for
+  `version_unsupported` / `extension_missing` / `config_disabled`. This
+  gap mattered more once `high_sensitivity_collectors_enabled` defaulted
+  to `true` (#6 v2). (#18)
+
+### Documentation
+
+- Operator-facing sensitivity docs realigned with R075 (revised v2):
+  `appendix-b-configuration-schema.md` example, env-var table, and the
+  "High-sensitivity collectors" section now reflect the default-on /
+  opt-out-redact-or-skip semantics. `specifications/sensitivity-profiles.md`
+  step 2 distinguishes the redact-path (collectors stay eligible,
+  sensitive columns nulled) from the skip-path (collector dropped),
+  and clarifies that the `restricted` per-target profile is stricter
+  than the daemon-wide opt-out (drops all `HighSensitivity=true`
+  regardless of `SensitiveColumns`). (#18)
+
+### Fixed
+
 - `GET /status.target_count` now matches the number of enabled targets
   surfaced in the response (was using the unfiltered `GetTargets()`
   count, so disabled targets still bumped it). Restores

--- a/features/arq-signals/appendix-b-configuration-schema.md
+++ b/features/arq-signals/appendix-b-configuration-schema.md
@@ -30,11 +30,19 @@ signals:
   max_concurrent_targets: 4  # Max targets collected in parallel
   target_timeout: 60s        # Per-target collection time budget
   query_timeout: 10s         # Per-query execution timeout
-  high_sensitivity_collectors_enabled: false  # Opt-in for collectors
-                              # that emit application-authored SQL text
-                              # (view/matview/trigger definitions and
-                              # function bodies). See "High-sensitivity
-                              # collectors" below. Default: false.
+  high_sensitivity_collectors_enabled: true   # Default: true (collect-
+                              # everything default). High-sensitivity
+                              # collectors run by default; set to
+                              # `false` to opt OUT, which either
+                              # redacts the listed `SensitiveColumns`
+                              # (collectors with mixed sensitive /
+                              # non-sensitive columns — the live
+                              # pg_stat_activity collectors) or skips
+                              # the collector entirely (collectors
+                              # whose row is itself the sensitive
+                              # payload — DDL definitions etc.). See
+                              # "High-sensitivity collectors" below
+                              # (R075 revised 2026-05, issue #6).
   metrics_enabled: false      # Expose the Prometheus /metrics endpoint
                               # on the API listener. Default: false.
                               # The endpoint emits operational metrics
@@ -93,7 +101,7 @@ fields:
 | `ARQ_SIGNALS_MAX_CONCURRENT_TARGETS` | `signals.max_concurrent_targets` | `4` | |
 | `ARQ_SIGNALS_TARGET_TIMEOUT` | `signals.target_timeout` | `60s` | |
 | `ARQ_SIGNALS_QUERY_TIMEOUT` | `signals.query_timeout` | `10s` | |
-| `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED` | `signals.high_sensitivity_collectors_enabled` | `false` | Opt-in for definition/body collectors |
+| `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED` | `signals.high_sensitivity_collectors_enabled` | `true` | Default-on (collect-everything default, R075 revised). Set to `false` to opt out — redact-path collectors run with `SensitiveColumns` nulled, skip-path collectors are skipped. |
 | `ARQ_SIGNALS_METRICS_ENABLED` | `signals.metrics_enabled` | `false` | Enable the Prometheus `/metrics` endpoint (R079) |
 | `ARQ_SIGNALS_METRICS_PATH` | `signals.metrics_path` | `/metrics` | Path for the metrics endpoint when enabled |
 | `ARQ_SIGNALS_EXPORT_PER_COLLECTOR_FILES` | `signals.export_per_collector_files` | `false` | Add `per-collector/<id>.json` files to export ZIPs (R080) |
@@ -150,37 +158,49 @@ rotation without restart.
 
 A subset of collectors emit application-authored SQL text — view
 definitions, materialized view definitions, trigger source, and
-stored procedure bodies. These can include proprietary business
-logic, embedded literals, or commentary the operator may not want
-in every snapshot, even when the snapshot stays inside the operator's
-own environment.
+stored procedure bodies — or live `pg_stat_activity` query text. These
+can include proprietary business logic, embedded literals, or
+commentary the operator may not want in every snapshot, even when the
+snapshot stays inside the operator's own environment.
 
-These collectors are **disabled by default** and require explicit
-opt-in via:
+These collectors are **enabled by default** (collect-everything
+default, R075 revised 2026-05). Operators opt **out** by setting:
 
-- `signals.high_sensitivity_collectors_enabled: true` in the YAML
+- `signals.high_sensitivity_collectors_enabled: false` in the YAML
   config, or
-- `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED=true` env var
+- `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED=false` env var
 
-Collectors classified as high-sensitivity:
+The opt-out behaves per collector based on whether the row carries
+non-sensitive diagnostic columns alongside the sensitive ones:
 
-| Collector | Emits |
-|---|---|
-| `pg_views_definitions_v1` | Full view SQL via `pg_get_viewdef()` |
-| `pg_matviews_definitions_v1` | Full materialized-view SQL |
-| `pg_triggers_definitions_v1` | Full `CREATE TRIGGER` via `pg_get_triggerdef()` |
-| `pg_functions_definitions_v1` | Function/procedure body (`pg_proc.prosrc`) |
+| Collector | Opt-out branch | Emits |
+|---|---|---|
+| `pg_views_definitions_v1` | **skip** | Full view SQL via `pg_get_viewdef()` |
+| `pg_matviews_definitions_v1` | **skip** | Full materialized-view SQL |
+| `pg_triggers_definitions_v1` | **skip** | Full `CREATE TRIGGER` via `pg_get_triggerdef()` |
+| `pg_functions_definitions_v1` | **skip** | Function/procedure body (`pg_proc.prosrc`) |
+| `long_running_txns_v1` | **redact** `query_snippet` | Live txn metadata (pid, wait_event, txn_age) + query text |
+| `blocking_locks_v1` | **redact** `blocked_query`, `blocking_query` | Blocking-lock chain (pid, wait_event, waiting_seconds) + query text |
+| `idle_in_txn_offenders_v1` | **redact** `query_snippet` | Idle-in-txn metadata + query text |
+| `wraparound_blockers_v1` | **redact** `query_snippet` | XID-blocker metadata + query text |
 
-When the opt-in flag is `false` (the default), each high-sensitivity
-collector appears in `collector_status.json` with `status=skipped`
-and `reason=config_disabled`.
+**Skip path** (collectors whose row IS the sensitive payload): the
+collector is dropped from the eligible set and recorded
+`status=skipped, reason=config_disabled` in `collector_status.json`.
+
+**Redact path** (collectors with mixed sensitive / non-sensitive
+columns): the collector still runs; the listed columns are set to
+`NULL` in persisted output. Non-sensitive diagnostic columns survive.
 
 This control is for **local operator control over data sensitivity**,
 not exfiltration prevention — Arq Signals runs inside the customer's
 environment and the snapshot file does not leave the site. The
-default-off posture exists because some operators do not want SQL
-bodies materialized into the snapshot artifact at all, even for
-internal analysis.
+collect-everything default exists because the diagnostic value of
+these collectors is high (long-running transactions, blocking chains,
+DDL inventory) and the export ZIP self-identifies the effective
+sensitivity state via `metadata.json.high_sensitivity_collectors_enabled`
+so an auditor can tell at a glance whether sensitive data may be
+present.
 
 ## TLS validation
 

--- a/internal/pgqueries/registry.go
+++ b/internal/pgqueries/registry.go
@@ -237,6 +237,14 @@ func GatedIDsByReason(p FilterParams) map[string][]string {
 			// R075 revised: only skip-path collectors are reported as
 			// config_disabled. Redact-path collectors keep running.
 			out[GateReasonConfigDisabled] = append(out[GateReasonConfigDisabled], q.ID)
+		case RequiresArrayRangeOptIn[q.ID] && !p.CollectArrayRangeHistograms:
+			// #128 / issue #18: the array-range per-collector opt-in
+			// narrows eligibility on top of HighSensitivityEnabled. When
+			// the opt-in is off but the collector is otherwise eligible
+			// it must still surface in collector_status.json as
+			// skipped/config_disabled (EA-R001) — silent absence would
+			// hide a coverage gap from operators.
+			out[GateReasonConfigDisabled] = append(out[GateReasonConfigDisabled], q.ID)
 		case p.ProfileRestricted && q.HighSensitivity:
 			// R098: per-target restricted profile drops every
 			// HighSensitivity collector. The reason channel is

--- a/specifications/sensitivity-profiles.md
+++ b/specifications/sensitivity-profiles.md
@@ -82,11 +82,23 @@ For each (target, collector) pair, eligibility resolves in order:
 1. **Version / extension gates** (R081). A collector that doesn't
    match the target's PG major or required extension is filtered out
    first, regardless of profile. (Same as today.)
-2. **Daemon-wide `high_sensitivity_collectors_enabled`** (R075).
-   When false, HighSensitivity collectors are filtered out
-   globally. (Same as today.)
+2. **Daemon-wide `high_sensitivity_collectors_enabled`** (R075,
+   revised 2026-05). Default `true` (collect-everything). When `false`:
+   - HighSensitivity collectors with **empty/nil** `SensitiveColumns`
+     (skip-path — DDL definitions, sampled-value stats, RLS policies,
+     rewrite rules) are filtered out globally and reported as
+     `status=skipped, reason=config_disabled`.
+   - HighSensitivity collectors with **non-empty** `SensitiveColumns`
+     (redact-path — the live `pg_stat_activity` collectors) stay
+     eligible at this step; the named columns are NULL-ed in the
+     persisted rows at execution time, preserving the non-sensitive
+     diagnostic columns. The collector is **not** reported as
+     `config_disabled` since it ran.
 3. **Per-target profile** (R098, this slice). Applied on the
-   per-target subset that survives steps 1 + 2:
+   per-target subset that survives steps 1 + 2. The `restricted`
+   profile is **stricter** than the daemon-wide opt-out: it drops
+   every `HighSensitivity=true` collector regardless of
+   `SensitiveColumns` (no redaction substitute). Options:
    - `default` / empty: no change.
    - `restricted`: drop all `HighSensitivity=true`.
    - `custom` with `include`: keep only the listed IDs.

--- a/tests/signals_array_range_status_test.go
+++ b/tests/signals_array_range_status_test.go
@@ -1,0 +1,56 @@
+// Test for issue #18: pg_stats_array_range_v1 (and any future
+// RequiresArrayRangeOptIn collector) must appear in
+// collector_status.json as status=skipped, reason=config_disabled when
+// CollectArrayRangeHistograms is false — same status-completeness
+// guarantee EA-R001 already provides for version_unsupported,
+// extension_missing, and config_disabled (R075).
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/elevarq/arq-signals/internal/pgqueries"
+)
+
+// With high-sensitivity enabled (the new collect-everything default)
+// but the array-range per-collector opt-in still off,
+// pg_stats_array_range_v1 must surface as config_disabled rather than
+// silently vanishing from the eligibility set.
+func TestGatedIDsByReasonIncludesArrayRangeOptOut(t *testing.T) {
+	gated := pgqueries.GatedIDsByReason(pgqueries.FilterParams{
+		PGMajorVersion:              18,
+		HighSensitivityEnabled:      true,
+		CollectArrayRangeHistograms: false,
+	})
+
+	found := false
+	for _, id := range gated[pgqueries.GateReasonConfigDisabled] {
+		if id == "pg_stats_array_range_v1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("pg_stats_array_range_v1 must appear under %q when "+
+			"CollectArrayRangeHistograms=false (EA-R001 status completeness, "+
+			"specifications/collectors/pg_stats_array_range_v1.md). gated = %v",
+			pgqueries.GateReasonConfigDisabled, gated)
+	}
+}
+
+// Symmetric: when the array-range opt-in is true, the collector must
+// not be reported as gated by config_disabled (regression guard so the
+// new case doesn't fire when it shouldn't).
+func TestGatedIDsByReasonExcludesArrayRangeWhenOptedIn(t *testing.T) {
+	gated := pgqueries.GatedIDsByReason(pgqueries.FilterParams{
+		PGMajorVersion:              18,
+		HighSensitivityEnabled:      true,
+		CollectArrayRangeHistograms: true,
+	})
+	for _, id := range gated[pgqueries.GateReasonConfigDisabled] {
+		if id == "pg_stats_array_range_v1" {
+			t.Errorf("pg_stats_array_range_v1 must NOT appear under config_disabled when the opt-in is true")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two follow-ups from the second Codex Beta review:

### 1. `pg_stats_array_range_v1` filtered without a status entry

`Filter` dropped the collector when `CollectArrayRangeHistograms=false` (the per-collector opt-in for #128), but `GatedIDsByReason` had no matching case so the collector silently disappeared from `collector_status.json` instead of appearing as `status=skipped, reason=config_disabled` (EA-R001 status-completeness guarantee). This mattered more once `high_sensitivity_collectors_enabled` defaulted to `true` (#6 v2) — an operator who leaves the array-range opt-in at its default `false` got the gap out of the box.

**Fix:** add a `GatedIDsByReason` case for `RequiresArrayRangeOptIn` so the collector surfaces as `config_disabled` (covers any future entries in `RequiresArrayRangeOptIn` too).

### 2. Operator-facing sensitivity docs realigned

- `appendix-b-configuration-schema.md` still showed default `false` / opt-in for `high_sensitivity_collectors_enabled` (contradicted the code, default `true`).
- `specifications/sensitivity-profiles.md` step 2 still said the daemon-wide flag globally filters out all HighSensitivity collectors — no longer true for redact-path collectors.

**Fix:**
- Appendix-B example, env-var table, and 'High-sensitivity collectors' section now reflect default-on / opt-out semantics with the skip-or-redact branch.
- `sensitivity-profiles.md` step 2 distinguishes skip-path vs redact-path under the daemon-wide flag; the `restricted` per-target profile remains stricter (drops all `HighSensitivity` regardless of `SensitiveColumns`).

## STDD

- Failing test first: `TestGatedIDsByReasonIncludesArrayRangeOptOut`.
- Regression guard: `TestGatedIDsByReasonExcludesArrayRangeWhenOptedIn`.

## Verification

Full suite green; gofmt clean; `go vet` clean; `golangci-lint` 0 issues.

Closes #18