### PR TITLE
docs: align two remaining collector specs with default-on R075 v2 (#20 follow-up)

### DIFF
--- a/specifications/collectors/pg_policies_v1.md
+++ b/specifications/collectors/pg_policies_v1.md
@@ -69,8 +69,15 @@ Excludes system schemas (`pg_catalog`, `information_schema`,
 **HighSensitivity.** Policy `qual` / `with_check` are arbitrary SQL
 expressions that can embed column references, literals, and function
 calls — the same class as view / function / trigger definition text.
-Gated off by default; enabled via the R075 daemon flag or an R098
-per-target profile, like the other `*_definitions` collectors.
+Classified `HighSensitivity = true` on the **skip-path** (no
+`SensitiveColumns` declared) — its `qual` / `with_check` columns ARE
+the sensitive payload, so redaction would leave a near-empty row.
+Runs by default under R075 v2 (collect-everything default); an
+operator who opts out via
+`signals.high_sensitivity_collectors_enabled: false` (or an R098
+`restricted` per-target profile) drops the collector and it appears
+in `collector_status.json` as `status=skipped, reason=config_disabled`
+(EA-R001).
 
 ## Downstream use
 

--- a/specifications/collectors/pg_stats_extended_v1.acceptance.md
+++ b/specifications/collectors/pg_stats_extended_v1.acceptance.md
@@ -54,7 +54,11 @@ no SELECT *).
 
 **Scenario:** The output contains real customer data
 (most_common_vals, histogram_bounds), so the collector must be
-gated off by default.
+classified `HighSensitivity = true` on the skip-path (no
+`SensitiveColumns` declared). Under R075 v2 (default-on /
+collect-everything default), an operator opt-out via
+`signals.high_sensitivity_collectors_enabled: false` drops it
+entirely with `status=skipped, reason=config_disabled`.
 
 **Given:**
 - The QueryDef.

--- a/specifications/collectors/pg_stats_extended_v1.md
+++ b/specifications/collectors/pg_stats_extended_v1.md
@@ -10,11 +10,19 @@ deliberately excludes.
 ## Status
 
 **Active.** Implemented in
-`internal/pgqueries/catalog_schema.go`. Gated off by default
-via the registry's `HighSensitivity` flag (R075); runs only
-when the operator opts in via `HighSensitivityEnabled` on
-`FilterParams`. Configuration plumbing — the
-`signals.collect_histograms` / `ARQ_SIGNALS_COLLECT_HISTOGRAMS`
+`internal/pgqueries/catalog_schema.go`. Classified
+`HighSensitivity = true` on the **skip-path** (no `SensitiveColumns`
+declared) via the registry. Under R075 v2 (revised 2026-05) the
+daemon-wide gate `HighSensitivityEnabled` defaults to **true**
+(collect-everything default) so the collector **runs by default**.
+An operator who opts out via
+`signals.high_sensitivity_collectors_enabled: false` drops the
+collector from the eligible set — it then appears in
+`collector_status.json` as `status=skipped, reason=config_disabled`
+(EA-R001). The collector is on the skip-path because its row (MCV
+and histogram values) IS the sensitive payload; nothing meaningful
+would remain after redacting those columns. Configuration plumbing
+— the `signals.collect_histograms` / `ARQ_SIGNALS_COLLECT_HISTOGRAMS`
 shape described below — is provided by the existing
 high-sensitivity surface.
 
@@ -69,8 +77,12 @@ pg_toast, pg_temp_%, pg_toast_temp_%.
 - Empty result serializes as []
 - Stable output column order (explicit SELECT, no SELECT *)
 - Read-only query, passes linter
-- Disabled by default — requires explicit opt-in
-- When disabled, collector_status reports reason=config_disabled
+- Runs by default under R075 v2 (collect-everything default);
+  skip-path classification means an operator opt-out via
+  `signals.high_sensitivity_collectors_enabled: false` drops the
+  collector entirely.
+- When gated off, collector_status reports `reason=config_disabled`
+  (EA-R001) so the operator's coverage gap is never silent.
 
 ## Configuration
 
@@ -78,9 +90,11 @@ pg_toast, pg_temp_%, pg_toast_temp_%.
 - Cadence: 24h (CadenceDaily)
 - Retention: RetentionShort (sampled values should not persist long)
 - Min PG version: 10
-- **Enabled by default: no**
-- Config key: `signals.collect_histograms: true`
-- Env override: `ARQ_SIGNALS_COLLECT_HISTOGRAMS=true`
+- **Enabled by default: yes** (R075 v2: collect-everything default).
+  Operators opt out with
+  `signals.high_sensitivity_collectors_enabled: false` (or
+  `ARQ_SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED=false`), which
+  skips this collector entirely (skip-path).
 
 ## Sensitivity
 
@@ -94,8 +108,11 @@ For example:
 
 ### Mitigations
 
-1. **Disabled by default.** The collector never runs unless the
-   operator explicitly sets `collect_histograms: true`.
+1. **Skip-path under operator privacy opt-out.** Runs by default
+   (R075 v2: collect-everything default); an operator who needs to
+   keep sampled values out of the artifact sets
+   `signals.high_sensitivity_collectors_enabled: false` to drop the
+   collector entirely (skip-path classification).
 2. **All data stays local.** Arq Signals stores collected data only
    in the local SQLite database and export ZIPs. No external
    transmission occurs.


### PR DESCRIPTION
## Summary

Codex's verification on `origin/main` at `0163da9` cleared the data-collection code for Beta but found two more spec pages with stale opt-in / gated-off-by-default wording.

## Updated

- **specifications/collectors/pg_stats_extended_v1.md** — Status, Invariants, Configuration, and Mitigations sections rewritten for default-on / skip-path classification.
- **specifications/collectors/pg_stats_extended_v1.acceptance.md** — "Sensitivity gating" rule aligned.
- **specifications/collectors/pg_policies_v1.md** — HighSensitivity section rewritten.

All three frame the collectors as: classified `HighSensitivity=true` on the **skip-path** (no `SensitiveColumns` declared) — the row IS the sensitive payload, so redaction would leave nothing useful. Runs by default under R075 v2; operator opt-out (`signals.high_sensitivity_collectors_enabled: false`) drops the collector with `status=skipped, reason=config_disabled`.

A final sweep across all markdown returns clean for R075 wording — remaining "off by default" references are about `/metrics`, the per-collector export view, and the unsafe-role override (all genuinely off-by-default).

## Verification

Docs-only; `go test ./...` still green.

Closes the docs follow-up from Codex's last review pass.