### PR TITLE
ci: pin govulncheck install to the v1.3.0 SHA (#28 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,15 @@ jobs:
           gitleaks version
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Pinned to the 40-char SHA of golang/vuln v1.3.0 so Scorecard's
+        # PinnedDependenciesID `goCommand not pinned by hash` finding
+        # actually clears (a version tag like @v1.3.0 still trips it —
+        # the policy specifically requires a hash). Refresh via Dependabot
+        # is not automatic for `go install` invocations; bump manually
+        # when a new golang/vuln tag lands by replacing the SHA with the
+        # new commit's SHA (the comment after `#` is the human-readable
+        # version pointer).
+        run: go install golang.org/x/vuln/cmd/govulncheck@0782b76014f15f24e22a438f30f308df42899ba1 # v1.3.0
 
       # #163: Semgrep + OSV-Scanner round out the security bundle.
       # Semgrep ships from PyPI; OSV-Scanner installs via go install


### PR DESCRIPTION
Closes Scorecard alert **#52** (`PinnedDependenciesID`, medium) — goCommand not pinned by hash. The previous attempt (closed #46) used `@v1.3.0` and Scorecard kept flagging it; the policy specifically requires a 40-char SHA.

`go install golang.org/x/vuln/cmd/govulncheck@0782b76014f15f24e22a438f30f308df42899ba1 # v1.3.0`

SHA resolved via `gh api /repos/golang/vuln/git/refs/tags/v1.3.0` (lightweight tag → commit SHA directly). Format mirrors the action-pin convention from #28 so the human-readable version stays visible alongside the hash.

Companion alert #53 (semgrep `--require-hashes`) is the bigger task in #45.