### PR TITLE
docs: add OpenSSF Best Practices passing badge (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- OpenSSF Best Practices **passing** badge awarded
+  ([bestpractices.dev/projects/13020](https://www.bestpractices.dev/projects/13020));
+  badge added to README, SECURITY.md, and `docs/release-verification.md`.
+  Clears the last Scorecard `CIIBestPracticesID` finding. (#31)
+
 ## [0.10.0-beta.3] - 2026-05-28
 
 **Re-cut after release-pipeline fix.** `v0.10.0-beta.2`'s container

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ From [Elevarq](https://elevarq.com) — PostgreSQL tools for engineering teams.
 [![CI](https://github.com/elevarq/arq-signals/actions/workflows/ci.yml/badge.svg)](https://github.com/elevarq/arq-signals/actions/workflows/ci.yml)
 [![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/elevarq/arq-signals)](https://goreportcard.com/report/github.com/elevarq/arq-signals)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13020/badge)](https://www.bestpractices.dev/projects/13020)
 
 > **Read-only by design** — three independent enforcement layers prevent
 > any write operations. Unsafe roles (superuser, replication) are blocked

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Policy
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13020/badge)](https://www.bestpractices.dev/projects/13020)
+
 ## Reporting a vulnerability
 
 If you find a vulnerability in Arq Signals, please report it privately.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,5 +1,7 @@
 # Release verification
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13020/badge)](https://www.bestpractices.dev/projects/13020)
+
 Every Arq Signals release publishes a multi-arch container image to
 `ghcr.io/elevarq/arq-signals` along with:
 


### PR DESCRIPTION
## Summary

Project earned the OpenSSF Best Practices **passing** tier:
https://www.bestpractices.dev/projects/13020

This PR wires the badge into the three operator-facing entry points
and records the milestone in the changelog.

## Changes

- **README.md** — badge added to the badge row alongside CI / license / Go Report Card.
- **SECURITY.md** — badge added under the title (security landing page).
- **docs/release-verification.md** — badge added under the title (supply-chain story).
- **CHANGELOG.md** — `[Unreleased]` entry under `Added`.

## Effect on Scorecard

This is the last code-actionable item from the original 58-finding sweep.
Remaining open Scorecard items after this lands:

- `CIIBestPracticesID` — auto-clears on next nightly run now that the badge is published.
- `MaintainedID` — auto-clears at 90 days repo age (#33; ~2026-08-25).
- `PinnedDependenciesID` (semgrep \`pipx install\`) — code-actionable but deferred to #45 (\`pip install --require-hashes\`).

## Verification

Visit the badge URL — it serves a green "passing" SVG:
https://www.bestpractices.dev/projects/13020/badge

The justification record (each criterion + the evidence we submitted) is on the project page.

closes #31