### PR TITLE
security(ci): bump Go toolchain to 1.25.11 (govulncheck GO-2026-5037/5039)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.11"
           cache: true
 
       - name: Download modules
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.11"
           cache-dependency-path: go.sum
 
       - name: Trivy filesystem scan (vuln + secret)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.11"
           cache: true
 
       - name: Download modules
@@ -411,7 +411,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.11"
           cache: true
 
       - name: Build binaries

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elevarq/arq-signals
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/jackc/pgx/v5 v5.9.2


### PR DESCRIPTION
Fixes the `govulncheck` failure on `main`: GO-2026-5037 (crypto/x509) + GO-2026-5039 (net/textproto), Go stdlib CVEs *Fixed in go1.25.11*. `setup-go` `go-version: "1.25"` was resolving to the runner-cached 1.25.10; pinned to `1.25.11` (present in the Actions Go manifest) across ci.yml + release.yml, and bumped go.mod `go 1.25.11`. closes #64