### PR TITLE
examples: TimescaleDB demo fixture exercising the full collector family

### DIFF
--- a/examples/timescaledb-demo/README.md
+++ b/examples/timescaledb-demo/README.md
@@ -1,0 +1,86 @@
+# TimescaleDB demo fixture
+
+A deterministic TimescaleDB sample workload that produces non-trivial
+output from **every** `timescaledb_*_v1` collector (R114). Built for
+Tiger Data demo work and as a reusable development fixture.
+Issue: [#76](https://github.com/Elevarq/Arq-Signals/issues/76).
+
+Collector contract: `specifications/collectors/timescaledb_family_v1.md`.
+Analyzer rule mapping: `docs/timescaledb-analyzer-roadmap.md`
+(TS-R001..TS-R009, [Elevarq/Arq#1204](https://github.com/Elevarq/Arq/issues/1204)).
+
+## Run it
+
+```bash
+docker compose -f examples/timescaledb-demo/docker-compose.yml up -d --build
+
+# Wait for the first collection cycle (or trigger one):
+curl -X POST http://localhost:8082/collect/now \
+  -H "Authorization: Bearer dev-local-only-replace-in-prod-32chars"
+
+# Export the snapshot:
+curl -o tsdemo-snapshot.zip http://localhost:8082/export \
+  -H "Authorization: Bearer dev-local-only-replace-in-prod-32chars"
+```
+
+The TimescaleDB instance itself is on `localhost:5433`
+(db `tsdemo`). An optional PostgreSQL 18 variant (database only) is
+behind the `pg18` profile on `localhost:5435`:
+
+```bash
+docker compose -f examples/timescaledb-demo/docker-compose.yml --profile pg18 up -d
+```
+
+Everything is anchored to `date_trunc('day', now())` at seed time, so
+chunk counts and the compressed/uncompressed split are stable for any
+run on a given day. The deliberately failing job means
+`total_failures` grows over time — that is the fixture working, not a
+bug.
+
+## Role variants
+
+| Role | Password | Behavior |
+|---|---|---|
+| `arq_monitor` | `monitor_pass` | Least-privilege (LOGIN + `pg_monitor`). Full hypertable/chunk/compression/jobs surface; **zero rows** in `timescaledb_job_errors_v1` — the documented partial-by-design state (`docs/postgres-role.md` § TimescaleDB targets). |
+| `arq_monitor_owner` | `monitor_owner_pass` | Same + membership in `tsdemo_owner` (the demo database-owner role) → sees the failing job's rows in `job_errors`. |
+
+The compose file wires `arq-signals` to `arq_monitor`. To demo the
+owner variant, point a second target (or `psql`) at the same database
+as `arq_monitor_owner` and compare `timescaledb_job_errors_v1`.
+
+## What the fixture produces, collector by collector
+
+| Fixture element | Collector(s) | Demo-worthy output | Future Analyzer rule |
+|---|---|---|---|
+| TimescaleDB 2.27.2, Community edition, default telemetry | `timescaledb_extension_v1` | `extversion`, `license=timescale`, capability flags (all probes true on 2.27) | edition gating for TS-R003/TS-R004 |
+| `metrics` hypertable (timestamptz + 4-partition space dimension) | `timescaledb_hypertables_v1`, `timescaledb_dimensions_v1` | 2 dimensions incl. a `Space` row; `compression_enabled=true`; `primary_dimension` (2.20+ column via dynamic capture) | TS-R002 chunk interval risk |
+| 46 daily `metrics` chunks + 10 integer-dimension `events` chunks | `timescaledb_chunks_v1`, `timescaledb_chunk_summary_v1` | mixed `is_compressed`; `range_start/range_end` AND `range_*_integer` populated; summary counts vs capped detail | TS-R001 excessive chunk count |
+| `events` hypertable (bigint dimension) | same | integer-dimension coverage — exercises the newest-created-first cap ordering | TS-R001/TS-R002 |
+| Compression: `segmentby device_id, orderby time DESC`; chunks > 14 days compressed; policy at 14 days | `timescaledb_compression_settings_v1`, `timescaledb_compression_stats_v1` | settings row; ~32/46 compressed; non-NULL before/after bytes (real ratio) | TS-R003 opportunity, TS-R004 backlog |
+| `metrics_daily` continuous aggregate, hourly refresh policy, refreshed once at seed | `timescaledb_continuous_aggregates_v1` | cagg row with materialization hypertable; `view_definition` (redacted when the R075 opt-out is active) | TS-R005 refresh lag |
+| Retention policy (`drop_after => 365 days`) | `timescaledb_jobs_v1` (`proc_name='policy_retention'`, `config`) | policy job with schedule + config JSONB | TS-R006 retention ineffective |
+| All policy + system jobs | `timescaledb_jobs_v1`, `timescaledb_job_stats_v1` | 6+ jobs (telemetry, log retention, compression, retention, cagg refresh, demo job) with run counters | TS-R007 job failures |
+| `demo_failing_job` (raises every minute, no retries) | `timescaledb_job_stats_v1`, `timescaledb_job_errors_v1` | `total_failures` > 0 visible to ANY role; per-failure rows only for `arq_monitor_owner` | TS-R007 |
+| `legacy_measurements` (plain, append-only, time-keyed, 52k rows, time-leading btree) | core collectors (`pg_columns_v1`, `pg_indexes_v1`, `largest_relations_v1`, `pg_stat_user_tables_v1`) | the "should be a hypertable" exhibit | TS-R008 hypertable candidate |
+| time-leading index + segmentby settings + size split | `timescaledb_hypertable_sizes_v1` + core index collectors | approximate table/index/toast/total bytes per hypertable | TS-R009 index recommendation |
+
+## Resetting
+
+The seed runs only on first initialization. To reset:
+
+```bash
+docker compose -f examples/timescaledb-demo/docker-compose.yml down -v
+docker compose -f examples/timescaledb-demo/docker-compose.yml up -d --build
+```
+
+## Caveats
+
+- Demo/dev only: placeholder passwords and a dev API token. Never
+  reuse any of it outside a local environment.
+- The failing job writes one `job_errors` row per minute; the
+  built-in "Job History Log Retention Policy" prunes monthly, so a
+  long-lived demo instance accumulates at a bounded rate (and
+  `timescaledb_job_errors_v1` is capped at 1000 newest rows anyway).
+- On the Apache-2 (`-oss`) image this seed would fail at the first
+  TSL feature (`timescaledb.compress`); edition demos should use the
+  plain verification flow from the #75 test matrix instead.

--- a/examples/timescaledb-demo/docker-compose.yml
+++ b/examples/timescaledb-demo/docker-compose.yml
@@ -1,0 +1,99 @@
+# TimescaleDB demo fixture (LOCAL DEV / DEMO ONLY)
+#
+# A deterministic TimescaleDB workload that produces non-trivial
+# output from every timescaledb_*_v1 collector (R114) — the data
+# substrate for Tiger Data demo material and a reusable development
+# fixture. Issue: #76.
+#
+# Start TimescaleDB (PG 17) + arq-signals:
+#   docker compose -f examples/timescaledb-demo/docker-compose.yml up -d
+#
+# Optional PostgreSQL 18 variant (port 5435, DB only): add
+#   --profile pg18
+# to the same command.
+#
+# Trigger a collection (dev-only token, see examples/docker-compose.yml):
+#   curl -X POST http://localhost:8082/collect/now \
+#     -H "Authorization: Bearer dev-local-only-replace-in-prod-32chars"
+#
+# Export snapshots:
+#   curl -o snapshot.zip http://localhost:8082/export \
+#     -H "Authorization: Bearer dev-local-only-replace-in-prod-32chars"
+#
+# Role variants (see roles.sql + docs/postgres-role.md § TimescaleDB):
+#   arq_monitor        — least-privilege (LOGIN + pg_monitor).
+#                        timescaledb_job_errors_v1 returns ZERO rows;
+#                        that is the documented expected state.
+#   arq_monitor_owner  — + membership in the demo db-owner role;
+#                        sees the failing job's rows in job_errors.
+#
+# The seed plants a deliberately failing background job, so
+# timescaledb_job_stats_v1.total_failures grows over time by design.
+
+services:
+  arq-signals:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    environment:
+      ARQ_SIGNALS_TARGET_HOST: timescaledb
+      ARQ_SIGNALS_TARGET_PORT: "5432"
+      ARQ_SIGNALS_TARGET_USER: arq_monitor
+      ARQ_SIGNALS_TARGET_DBNAME: tsdemo
+      ARQ_SIGNALS_TARGET_PASSWORD_ENV: PG_PASSWORD
+      PG_PASSWORD: monitor_pass
+      ARQ_SIGNALS_POLL_INTERVAL: 1m
+      # Dev-only API token (passes the #135 strength validator and is
+      # obviously a placeholder) — same caveats as the quick-start
+      # compose file. Never use in production.
+      ARQ_SIGNALS_API_TOKEN: dev-local-only-replace-in-prod-32chars
+      ARQ_SIGNALS_LISTEN_ADDR: "0.0.0.0:8081"
+      ARQ_ALLOW_INSECURE_PG_TLS: "true"
+      ARQ_ENV: dev
+    ports:
+      - "8082:8081"
+    volumes:
+      - tsdemo-signals-data:/data
+    depends_on:
+      timescaledb:
+        condition: service_healthy
+
+  timescaledb:
+    # Community (TSL) edition — compression, caggs, retention, and the
+    # job framework are all available. Pinned per the supply-chain
+    # baseline (no :latest).
+    image: timescale/timescaledb:2.27.2-pg17
+    environment:
+      POSTGRES_PASSWORD: postgres_pass
+      POSTGRES_DB: postgres
+    ports:
+      - "5433:5432"
+    volumes:
+      - ./roles.sql:/docker-entrypoint-initdb.d/900-roles.sql
+      - ./seed.sql:/docker-entrypoint-initdb.d/910-seed.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # Optional PG 18 lane (DB only; point clients at port 5435).
+  timescaledb-pg18:
+    profiles: ["pg18"]
+    image: timescale/timescaledb:2.27.2-pg18
+    environment:
+      POSTGRES_PASSWORD: postgres_pass
+      POSTGRES_DB: postgres
+    ports:
+      - "5435:5432"
+    volumes:
+      - ./roles.sql:/docker-entrypoint-initdb.d/900-roles.sql
+      - ./seed.sql:/docker-entrypoint-initdb.d/910-seed.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  tsdemo-signals-data:

--- a/examples/timescaledb-demo/roles.sql
+++ b/examples/timescaledb-demo/roles.sql
@@ -1,0 +1,40 @@
+-- TimescaleDB demo fixture — roles + demo database (issue #76).
+-- Runs once at first container start (docker-entrypoint-initdb.d),
+-- executed as the postgres superuser BEFORE seed.sql.
+--
+-- Role model (docs/postgres-role.md § TimescaleDB targets):
+--
+--   tsdemo_owner       Owns the demo database and every fixture
+--                      object/job, so the job_errors visibility demo
+--                      does not require granting membership in a
+--                      superuser role. Must be LOGIN: TimescaleDB
+--                      runs policy/compression background workers AS
+--                      the owning role and refuses to start them for
+--                      a NOLOGIN role ("permission denied to start
+--                      background process"). The password exists only
+--                      to satisfy LOGIN; nothing connects with it.
+--   arq_monitor        Least-privilege collector role: LOGIN +
+--                      pg_monitor. Sees the full hypertable / chunk /
+--                      compression / jobs / job_stats surface, and
+--                      ZERO rows in timescaledb_information.job_errors
+--                      — the documented partial-by-design state.
+--   arq_monitor_owner  Same, plus membership in tsdemo_owner (the
+--                      database-owner role), which is what unlocks
+--                      job_errors row visibility.
+
+CREATE ROLE tsdemo_owner LOGIN PASSWORD 'tsdemo_owner_pass'
+    NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+
+CREATE ROLE arq_monitor LOGIN PASSWORD 'monitor_pass'
+    NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+GRANT pg_monitor TO arq_monitor;
+
+CREATE ROLE arq_monitor_owner LOGIN PASSWORD 'monitor_owner_pass'
+    NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+GRANT pg_monitor TO arq_monitor_owner;
+GRANT tsdemo_owner TO arq_monitor_owner;
+
+-- The demo database. The timescale image installs the extension into
+-- template1, so tsdemo inherits it; the explicit CREATE EXTENSION in
+-- seed.sql is a belt-and-suspenders no-op in that case.
+CREATE DATABASE tsdemo OWNER tsdemo_owner;

--- a/examples/timescaledb-demo/seed.sql
+++ b/examples/timescaledb-demo/seed.sql
@@ -1,0 +1,147 @@
+-- TimescaleDB demo fixture — sample workload (issue #76).
+-- Runs once at first container start, after roles.sql, as the
+-- postgres superuser. Every fixture object and job is created as
+-- tsdemo_owner so the job_errors ownership demo works (see roles.sql).
+--
+-- Determinism: all series are anchored to date_trunc('day', now()),
+-- so chunk counts, compressed/uncompressed split, and cagg bucket
+-- counts are stable for any demo run on a given day.
+--
+-- What each element produces (full map in README.md):
+--   metrics            46 daily chunks (32 compressed / 14 not),
+--                      space dimension, compression + retention
+--                      policies, daily continuous aggregate
+--   events             integer-dimension hypertable (10 chunks)
+--   legacy_measurements plain time-keyed table — the future
+--                      "hypertable candidate" (TS-R008) exhibit
+--   demo_failing_job   fails every run → job_stats.total_failures
+--                      grows; rows visible in job_errors only with
+--                      db-owner membership
+
+\c tsdemo
+
+-- No-op on the timescale image (extension inherited via template1);
+-- kept for portability to other base images.
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+SET ROLE tsdemo_owner;
+
+-- ---------------------------------------------------------------
+-- metrics: timestamptz dimension + space dimension, 45 days of
+-- hourly samples for 4 devices (~4.3k rows, 46 daily chunks).
+-- ---------------------------------------------------------------
+CREATE TABLE metrics (
+    time      timestamptz       NOT NULL,
+    device_id int               NOT NULL,
+    cpu       double precision  NOT NULL,
+    mem       double precision  NOT NULL
+);
+SELECT create_hypertable('metrics', 'time',
+                         chunk_time_interval => interval '1 day');
+SELECT add_dimension('metrics', 'device_id', number_partitions => 4);
+
+INSERT INTO metrics (time, device_id, cpu, mem)
+SELECT g, d,
+       50 + 40 * sin(extract(epoch FROM g) / 86400.0 + d),
+       30 + 20 * cos(extract(epoch FROM g) / 43200.0 + d)
+FROM generate_series(date_trunc('day', now()) - interval '45 days',
+                     date_trunc('day', now()),
+                     interval '1 hour') AS g,
+     generate_series(1, 4) AS d;
+
+-- Compression: configured + a mixed compressed/uncompressed state
+-- (chunks older than 14 days compressed now; the policy keeps up
+-- from here).
+ALTER TABLE metrics SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby   = 'time DESC'
+);
+SELECT count(*) AS chunks_compressed_at_seed FROM (
+    SELECT compress_chunk(c)
+    FROM show_chunks('metrics', older_than => interval '14 days') AS c
+) AS s;
+SELECT add_compression_policy('metrics', compress_after => interval '14 days');
+
+-- Retention: long enough that demo data never disappears mid-demo.
+SELECT add_retention_policy('metrics', drop_after => interval '365 days');
+
+-- Continuous aggregate + refresh policy; refreshed once at seed time
+-- so the materialization hypertable has data and job_stats records a
+-- success before the first scheduled run.
+CREATE MATERIALIZED VIEW metrics_daily
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day', time) AS day,
+       device_id,
+       avg(cpu) AS avg_cpu,
+       max(cpu) AS max_cpu,
+       avg(mem) AS avg_mem
+FROM metrics
+GROUP BY 1, 2
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('metrics_daily',
+    start_offset      => interval '30 days',
+    end_offset        => interval '1 hour',
+    schedule_interval => interval '1 hour');
+
+CALL refresh_continuous_aggregate('metrics_daily', NULL, now() - interval '1 hour');
+
+-- ---------------------------------------------------------------
+-- events: integer-dimension hypertable (exercises the
+-- range_*_integer columns and the creation-time chunk ordering).
+-- 10 chunks of 86400 "ticks" each.
+-- ---------------------------------------------------------------
+CREATE TABLE events (
+    ts      bigint NOT NULL,
+    kind    text   NOT NULL,
+    payload int    NOT NULL
+);
+SELECT create_hypertable('events', 'ts', chunk_time_interval => 86400);
+
+INSERT INTO events (ts, kind, payload)
+SELECT t, (ARRAY['create', 'update', 'delete'])[1 + (t / 3600) % 3], t % 100
+FROM generate_series(0, 863999, 3600) AS t;
+
+-- ---------------------------------------------------------------
+-- legacy_measurements: a plain, append-mostly, time-keyed table —
+-- deliberately NOT a hypertable. This is the exhibit for the future
+-- TS-R008 "hypertable candidate" Analyzer rule (large table, leading
+-- timestamptz column + time-leading btree, insert-only stats).
+-- ---------------------------------------------------------------
+CREATE TABLE legacy_measurements (
+    recorded_at timestamptz      NOT NULL,
+    sensor_id   int              NOT NULL,
+    reading     double precision NOT NULL
+);
+CREATE INDEX legacy_measurements_recorded_at_idx
+    ON legacy_measurements (recorded_at, sensor_id);
+
+INSERT INTO legacy_measurements (recorded_at, sensor_id, reading)
+SELECT g, s, random() * 100
+FROM generate_series(date_trunc('day', now()) - interval '30 days',
+                     date_trunc('day', now()),
+                     interval '10 minutes') AS g,
+     generate_series(1, 12) AS s;
+
+-- ---------------------------------------------------------------
+-- demo_failing_job: a user-defined action that fails on every run,
+-- so timescaledb_job_stats_v1 shows total_failures > 0 and
+-- timescaledb_information.job_errors accumulates rows (visible to
+-- arq_monitor_owner; arq_monitor correctly sees none).
+-- ---------------------------------------------------------------
+CREATE PROCEDURE demo_failing_job(job_id int, config jsonb)
+LANGUAGE plpgsql AS
+$func$
+BEGIN
+    RAISE EXCEPTION 'tsdemo: deliberate failure (job_stats / job_errors demo)';
+END
+$func$;
+
+SELECT alter_job(
+    add_job('demo_failing_job', schedule_interval => interval '1 minute'),
+    max_retries => 0);
+
+-- Fresh planner stats for every collector that reads estimates.
+RESET ROLE;
+ANALYZE;


### PR DESCRIPTION
Closes #76.

## Summary

`examples/timescaledb-demo/` — a deterministic TimescaleDB sample workload + compose stack producing non-trivial output from **every** `timescaledb_*_v1` collector, for Tiger Data demo work and collector development.

- **Compose**: pinned `timescale/timescaledb:2.27.2-pg17` + arq-signals built from the repo Dockerfile (port 8082); optional `--profile pg18` DB lane (2.27.2-pg18, port 5435).
- **Seed (now()-day-anchored, deterministic per demo day)**: `metrics` hypertable with a 4-partition space dimension → 153 chunks (93 compressed at seed + compression policy), retention policy, `metrics_daily` cagg (refreshed at seed) + hourly refresh policy, `events` integer-dimension hypertable, `legacy_measurements` plain time-keyed table (the future TS-R008 exhibit), and `demo_failing_job` raising every minute.
- **Roles**: `tsdemo_owner` owns db + jobs (must be LOGIN — TimescaleDB refuses to start policy workers as a NOLOGIN owner, found the hard way); `arq_monitor` least-privilege (job_errors correctly empty); `arq_monitor_owner` adds db-owner membership (sees per-failure rows).
- **README** maps each fixture element → collector output → TS-R001..TS-R009 (Elevarq/Arq#1204).

## Verified end-to-end

- Seed boots clean on first init; counts as designed (2 hypertables, 153 chunks, 93 compressed, 6 jobs, populated cagg).
- Failing-job visibility confirmed from both role variants (job_stats failures visible to all; job_errors rows only with ownership).
- Integration test green against the fixture as `arq_monitor` (all 12 members).
- Full stack (`up --build`, includes the #77/#78 Dockerfile fix): live collection + `/export` ZIP whose `collector_status.json` shows all 12 `timescaledb_*_v1` entries `status=success`.

yamllint: zero errors (document-start warning matches existing examples house style; yamllint is not a CI gate).