### PR TITLE
rebrand: Arq Signals → Elevarq Signals (content, binary, OCI label)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
           # labels below add the rest of the org.opencontainers.image.*
           # set so consumers can identify the build without pulling.
           labels: |
-            org.opencontainers.image.title=arq-signals
+            org.opencontainers.image.title=elevarq-signals
             org.opencontainers.image.description=Open-source PostgreSQL diagnostic signal collector — local-first, no data egress.
             org.opencontainers.image.licenses=BSD-3-Clause
             org.opencontainers.image.vendor=Elevarq

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS  = -X github.com/elevarq/arq-signals/internal/safety.Version=$(VERSION) 
            -X github.com/elevarq/arq-signals/internal/safety.BuildDate=$(DATE)
 
 build:
-	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/arq-signals ./cmd/arq-signals
+	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/elevarq-signals ./cmd/arq-signals
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/arqctl ./cmd/arqctl
 
 test:
@@ -27,4 +27,4 @@ clean:
 	rm -rf bin/
 
 docker-build:
-	docker build -t arq-signals:$(VERSION) -f Dockerfile .
+	docker build -t elevarq-signals:$(VERSION) -f Dockerfile .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Arq Signals
+# Elevarq Signals
 
-Arq Signals is a read-only PostgreSQL diagnostic collector. It runs on
+Elevarq Signals is a read-only PostgreSQL diagnostic collector. It runs on
 your infrastructure, collects statistics from your databases, and
 packages them as portable snapshots. No data leaves your machine. No AI.
 No cloud. Just structured evidence from the views PostgreSQL already
@@ -21,7 +21,7 @@ From [Elevarq](https://elevarq.com) — PostgreSQL tools for engineering teams.
 > **No cloud, no phone-home** — all data stays on your machine. No
 > telemetry, no analytics, no external network calls.
 >
-> **No AI inside** — Arq Signals is a pure data collector. No language
+> **No AI inside** — Elevarq Signals is a pure data collector. No language
 > models, no scoring, no recommendations. What you collect is what you get.
 >
 > **Built for restricted environments** — runs airgapped, as a non-root
@@ -38,7 +38,7 @@ cd arq-signals
 docker compose -f examples/docker-compose.yml up -d
 ```
 
-This starts Arq Signals alongside PostgreSQL 16 with a pre-configured
+This starts Elevarq Signals alongside PostgreSQL 16 with a pre-configured
 monitoring role. Collection begins automatically.
 
 ```bash
@@ -60,23 +60,23 @@ for what the output looks like.
 
 ---
 
-## Why Arq Signals exists
+## Why Elevarq Signals exists
 
 Every PostgreSQL instance exposes diagnostic data through built-in
 statistics views. But collecting this data consistently, safely, and in
 a format you can actually use takes tooling that most teams end up
 building themselves.
 
-Arq Signals handles the collection part so you don't have to. It
+Elevarq Signals handles the collection part so you don't have to. It
 connects with a read-only role, runs approved SQL queries on a schedule,
 and writes structured results to local storage. When you need the data
 elsewhere, it packages everything as a portable ZIP snapshot.
 
 The project is open source because we think data collection should be
-transparent. You can read every SQL query Arq Signals will run. You can
+transparent. You can read every SQL query Elevarq Signals will run. You can
 audit the binary. You own the output.
 
-## What Arq Signals does
+## What Elevarq Signals does
 
 - Connects to one or more PostgreSQL instances (14+)
 - Runs 73 read-only diagnostic collectors covering:
@@ -150,7 +150,7 @@ Every safety guarantee — read-only enforcement, role validation,
 credential handling — is formally specified, tested, and traceable.
 You can verify the claims without reading the implementation.
 
-## Why DBAs trust Arq Signals
+## Why DBAs trust Elevarq Signals
 
 - All PostgreSQL queries execute inside `READ ONLY` transactions,
   enforced at three independent layers


### PR DESCRIPTION
Closes #62 (partial — repo rename and Go module path deferred per issue scope).

## Changes
- **README.md** — all user-facing "Arq Signals" → "Elevarq Signals" (9 occurrences); URLs and module paths unchanged (repo not renamed)
- **Makefile** — binary output `bin/arq-signals` → `bin/elevarq-signals`; local docker image tag `arq-signals` → `elevarq-signals`
- **release.yml** — OCI image title label `arq-signals` → `elevarq-signals`

## Not in this PR
- Repo rename (out of scope per user decision)
- Go module path (`github.com/elevarq/arq-signals`) — deferred to Phase 2, blocked on repo rename
- Install script URLs — still point to correct repo, no change needed
- GHCR image path `ghcr.io/elevarq/arq-signals` — tied to repo name, unchanged