### PR TITLE
fix(ci): pin semgrep to 1.166.0 to resolve Scorecard PinnedDependenciesID alert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       # google/osv-scanner-action wrapper is not used directly
       # because its setup subpath doesn't ship an action.yml.
       - name: Install Semgrep
-        run: pipx install semgrep || python3 -m pip install --user semgrep
+        run: pip3 install "semgrep==1.166.0"  # pinned — resolves Scorecard PinnedDependenciesID (#45)
 
       - name: Install OSV-Scanner
         run: go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.2.4


### PR DESCRIPTION
Closes #45.

Replaces `pipx install semgrep || python3 -m pip install --user semgrep` with `pip3 install "semgrep==1.166.0"`. Pinning to an explicit version resolves the last open Scorecard PinnedDependenciesID alert for this repo.