### PR TITLE
feat(deploy/aws): passwordless RDS IAM onboarding (Terraform + CloudFormation) (closes #111)

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -1,0 +1,110 @@
+# AWS onboarding — passwordless Elevarq Signals on RDS / Aurora
+
+Stands up a least-privilege, **passwordless** Signals collector against Amazon
+RDS / Aurora PostgreSQL using `auth_method: aws_rds_iam`. The collector's EC2
+IAM identity mints a short-lived RDS IAM token at connect time — **no password
+is stored anywhere** (INV001/INV002), and the connection is `verify-full`
+(INV003).
+
+Two equivalent implementations:
+
+- [`terraform/`](terraform/) — `terraform apply`
+- [`cloudformation/arq-signals-rds-iam.yaml`](cloudformation/arq-signals-rds-iam.yaml) — `aws cloudformation deploy`
+
+Both provision the IAM role + minimal `rds-db:connect` policy (scoped to one DB
+user), an instance profile, and an EC2 instance running the collector
+pre-wired for `aws_rds_iam`. See
+[`docs/database-connections.md`](../../docs/database-connections.md) for the
+full `auth_method` reference.
+
+## Prerequisites
+
+- An RDS / Aurora PostgreSQL instance with **IAM database authentication
+  enabled**.
+- A subnet and security group that route to the instance on its port (the SG
+  must allow egress to the DB).
+- The instance's **`DbiResourceId`**:
+
+  ```bash
+  aws rds describe-db-instances --db-instance-identifier <id> \
+    --query 'DBInstances[0].DbiResourceId' --output text
+  ```
+
+## Step 1 — Database role (one-time)
+
+Run once against the target database, as a privileged role:
+
+```sql
+CREATE ROLE arq_signals LOGIN;     -- no password (passwordless)
+GRANT rds_iam TO arq_signals;      -- enables RDS IAM authentication
+GRANT pg_monitor TO arq_signals;   -- least-privilege read-only monitoring
+```
+
+See [`docs/postgres-role.md`](../../docs/postgres-role.md) for the role
+rationale.
+
+## Step 2a — Terraform
+
+```bash
+cd terraform
+terraform init
+terraform apply \
+  -var region=us-east-1 \
+  -var db_host=mydb.abc123.us-east-1.rds.amazonaws.com \
+  -var db_name=appdb \
+  -var db_resource_id=db-ABCDEFGH00000000000000 \
+  -var subnet_id=subnet-0123456789abcdef0 \
+  -var 'security_group_ids=["sg-0123456789abcdef0"]'
+```
+
+## Step 2b — CloudFormation
+
+```bash
+aws cloudformation deploy \
+  --template-file cloudformation/arq-signals-rds-iam.yaml \
+  --stack-name arq-signals-rds-iam \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+    DbHost=mydb.abc123.us-east-1.rds.amazonaws.com \
+    DbName=appdb \
+    DbResourceId=db-ABCDEFGH00000000000000 \
+    SubnetId=subnet-0123456789abcdef0 \
+    SecurityGroupIds=sg-0123456789abcdef0
+```
+
+## Verify (live)
+
+Live verification provisions real infrastructure and is operator-gated —
+it is not part of default CI (mirrors the provider live smokes, #94). After
+apply/deploy, on the collector instance:
+
+```bash
+# the collector container should be running and collecting
+docker logs arq-signals 2>&1 | grep -iE "collector|snapshot|connected"
+# trigger an export to confirm a successful passwordless connection
+docker exec arq-signals arqctl export --output /data/snapshot.zip
+```
+
+A healthy run connects with **no password in config**, mints a token from the
+instance role, and collects at least one snapshot. If the connection is
+rejected for `rds_iam`, re-check Step 1 and that the EC2 role's
+`rds-db:connect` resource ARN matches the instance `DbiResourceId` + DB user.
+
+## Security notes
+
+- **No secrets** in any input or on disk — the token is minted from the EC2
+  instance role at connect time and never persisted.
+- **`rds-db:connect` is scoped** to exactly `db_user` on this one instance
+  (`arn:aws:rds-db:<region>:<acct>:dbuser:<DbiResourceId>/<db_user>`).
+- TLS is **`verify-full`** against the RDS global CA bundle (fetched to
+  `/etc/arq/rds-ca.pem`).
+- IMDSv2 is enforced (`http_tokens = required`); the root volume is encrypted;
+  the API listener binds to `127.0.0.1` only.
+
+## Reusing the identity elsewhere
+
+If you run the collector on ECS or EKS instead of the bundled EC2 instance,
+take the `collector_role_arn` output (Terraform) / `CollectorRoleArn` output
+(CloudFormation) and attach it as the task role / IRSA role; the
+`rds-db:connect` policy is identical. For Kubernetes, see the Helm chart
+(`deploy/helm/arq-signals/`) and #114.

--- a/deploy/aws/cloudformation/arq-signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/arq-signals-rds-iam.yaml
@@ -1,0 +1,146 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Elevarq Signals — passwordless onboarding for Amazon RDS / Aurora PostgreSQL
+  (#111). Provisions the collector's IAM identity with a minimal rds-db:connect
+  policy scoped to one DB user, and runs the collector on EC2 pre-wired for
+  auth_method: aws_rds_iam over verify-full TLS. No secrets are stored — the
+  credential is a short-lived RDS IAM token minted from this identity at
+  connect time (INV001/INV002). The DB-side grant (GRANT rds_iam / pg_monitor)
+  is a one-time SQL step; see ../README.md.
+
+Parameters:
+  DbHost:
+    Type: String
+    Description: RDS/Aurora endpoint hostname.
+  DbPort:
+    Type: Number
+    Default: 5432
+  DbName:
+    Type: String
+    Description: Database name to connect to.
+  DbUser:
+    Type: String
+    Default: arq_signals
+    Description: PostgreSQL role granted rds_iam + pg_monitor.
+  DbResourceId:
+    Type: String
+    Description: >-
+      RDS instance/cluster DbiResourceId (e.g. db-ABCDEFGH...), NOT the DB
+      identifier. Scopes the rds-db:connect policy.
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+    Description: Subnet for the collector (must route to the RDS instance).
+  SecurityGroupIds:
+    Type: List<AWS::EC2::SecurityGroup::Id>
+    Description: Security group(s) — must allow egress to the DB on DbPort.
+  InstanceType:
+    Type: String
+    Default: t3.small
+  ImageUri:
+    Type: String
+    Default: ghcr.io/elevarq/arq-signals:0.10.0-beta.5
+    Description: Elevarq Signals container image (pinned tag).
+  ArqEnv:
+    Type: String
+    Default: prod
+    AllowedValues: [prod, lab, dev]
+  PollInterval:
+    Type: String
+    Default: 5m
+  LatestAl2023Ami:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
+
+Resources:
+  CollectorRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: rds-iam-connect
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: RDSIAMConnect
+                Effect: Allow
+                Action: rds-db:connect
+                Resource: !Sub "arn:aws:rds-db:${AWS::Region}:${AWS::AccountId}:dbuser:${DbResourceId}/${DbUser}"
+
+  CollectorInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref CollectorRole
+
+  CollectorInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref LatestAl2023Ami
+      InstanceType: !Ref InstanceType
+      SubnetId: !Ref SubnetId
+      SecurityGroupIds: !Ref SecurityGroupIds
+      IamInstanceProfile: !Ref CollectorInstanceProfile
+      MetadataOptions:
+        HttpTokens: required
+        HttpEndpoint: enabled
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            Encrypted: true
+            VolumeSize: 20
+      Tags:
+        - Key: Name
+          Value: arq-signals-collector
+        - Key: app.kubernetes.io/name
+          Value: arq-signals
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -euo pipefail
+          dnf install -y docker
+          systemctl enable --now docker
+          mkdir -p /etc/arq
+          curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+            -o /etc/arq/rds-ca.pem
+          cat > /etc/arq/signals.yaml <<'YAML'
+          env: ${ArqEnv}
+          signals:
+            poll_interval: ${PollInterval}
+          database:
+            path: /data/arq-signals.db
+            wal: true
+          api:
+            listen_addr: "127.0.0.1:8081"
+          targets:
+            - name: ${DbName}-rds
+              host: ${DbHost}
+              port: ${DbPort}
+              dbname: ${DbName}
+              user: ${DbUser}
+              auth_method: aws_rds_iam
+              region: ${AWS::Region}
+              sslmode: verify-full
+              sslrootcert_file: /etc/arq/rds-ca.pem
+          YAML
+          docker run -d --name arq-signals --restart=always \
+            -v /etc/arq:/etc/arq:ro \
+            -v arq-data:/data \
+            -p 127.0.0.1:8081:8081 \
+            ${ImageUri} --config /etc/arq/signals.yaml
+
+Outputs:
+  CollectorRoleArn:
+    Description: IAM role the collector runs under.
+    Value: !GetAtt CollectorRole.Arn
+  RdsConnectResourceArn:
+    Description: The rds-db:connect resource ARN scoped to DbUser on this instance.
+    Value: !Sub "arn:aws:rds-db:${AWS::Region}:${AWS::AccountId}:dbuser:${DbResourceId}/${DbUser}"
+  InstanceId:
+    Description: Collector EC2 instance id.
+    Value: !Ref CollectorInstance

--- a/deploy/aws/cloudformation/arq-signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/arq-signals-rds-iam.yaml
@@ -78,6 +78,11 @@ Resources:
       Roles:
         - !Ref CollectorRole
 
+  # IMDSv2 is enforced below via MetadataOptions.HttpTokens=required. Trivy's
+  # CloudFormation adapter for AVD-AWS-0028 does not read MetadataOptions (the
+  # equivalent Terraform in ../terraform passes the same check), so this is a
+  # false positive. Remove when Trivy's CFN adapter reads MetadataOptions.
+  # trivy:ignore:AVD-AWS-0028
   CollectorInstance:
     Type: AWS::EC2::Instance
     Properties:

--- a/deploy/aws/terraform/.gitignore
+++ b/deploy/aws/terraform/.gitignore
@@ -1,0 +1,9 @@
+# Terraform working files — never commit state or the provider cache.
+.terraform/
+*.tfstate
+*.tfstate.*
+.terraform.tfstate.lock.info
+crash.log
+*.tfvars
+# .terraform.lock.hcl IS committed (pins provider versions).
+!.terraform.lock.hcl

--- a/deploy/aws/terraform/.terraform.lock.hcl
+++ b/deploy/aws/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.60"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -1,0 +1,122 @@
+# AWS passwordless onboarding for Elevarq Signals (#111).
+#
+# Provisions the collector's IAM identity (instance profile) with a minimal
+# rds-db:connect policy scoped to one DB user, and runs the collector on EC2
+# pre-wired for auth_method: aws_rds_iam over verify-full TLS. The credential
+# is a short-lived RDS IAM token minted from this identity at connect time —
+# no password is stored anywhere (INV001/INV002).
+#
+# The DB-side grant (GRANT rds_iam / GRANT pg_monitor) is a one-time SQL step;
+# see ../README.md.
+
+data "aws_caller_identity" "current" {}
+
+# Amazon Linux 2023 (x86_64) latest, via SSM public parameter.
+data "aws_ssm_parameter" "al2023" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+}
+
+locals {
+  tags = merge({ "app.kubernetes.io/name" = "arq-signals", "managed-by" = "terraform" }, var.tags)
+
+  # rds-db:connect resource ARN for exactly this DB user on this instance.
+  rds_connect_arn = "arn:aws:rds-db:${var.region}:${data.aws_caller_identity.current.account_id}:dbuser:${var.db_resource_id}/${var.db_user}"
+
+  user_data = <<-EOT
+    #!/bin/bash
+    set -euo pipefail
+    dnf install -y docker
+    systemctl enable --now docker
+    mkdir -p /etc/arq
+    # RDS server CA bundle for sslmode=verify-full.
+    curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+      -o /etc/arq/rds-ca.pem
+    cat > /etc/arq/signals.yaml <<'YAML'
+    env: ${var.arq_env}
+    signals:
+      poll_interval: ${var.poll_interval}
+    database:
+      path: /data/arq-signals.db
+      wal: true
+    api:
+      listen_addr: "127.0.0.1:8081"
+    targets:
+      - name: ${var.db_name}-rds
+        host: ${var.db_host}
+        port: ${var.db_port}
+        dbname: ${var.db_name}
+        user: ${var.db_user}
+        auth_method: aws_rds_iam
+        region: ${var.region}
+        sslmode: verify-full
+        sslrootcert_file: /etc/arq/rds-ca.pem
+    YAML
+    docker run -d --name arq-signals --restart=always \
+      -v /etc/arq:/etc/arq:ro \
+      -v arq-data:/data \
+      -p 127.0.0.1:8081:8081 \
+      ${var.image_uri} --config /etc/arq/signals.yaml
+  EOT
+}
+
+# --- IAM identity: the passwordless enabler ---------------------------------
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "collector" {
+  name               = "${var.name_prefix}-collector"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "rds_connect" {
+  statement {
+    sid       = "RDSIAMConnect"
+    actions   = ["rds-db:connect"]
+    resources = [local.rds_connect_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "rds_connect" {
+  name   = "${var.name_prefix}-rds-connect"
+  role   = aws_iam_role.collector.id
+  policy = data.aws_iam_policy_document.rds_connect.json
+}
+
+resource "aws_iam_instance_profile" "collector" {
+  name = "${var.name_prefix}-collector"
+  role = aws_iam_role.collector.name
+  tags = local.tags
+}
+
+# --- Collector compute ------------------------------------------------------
+
+resource "aws_instance" "collector" {
+  ami                         = data.aws_ssm_parameter.al2023.value
+  instance_type               = var.instance_type
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = var.security_group_ids
+  iam_instance_profile        = aws_iam_instance_profile.collector.name
+  user_data                   = local.user_data
+  user_data_replace_on_change = true
+
+  metadata_options {
+    http_tokens   = "required" # IMDSv2 only
+    http_endpoint = "enabled"
+  }
+
+  root_block_device {
+    encrypted   = true
+    volume_size = 20
+  }
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-collector" })
+}

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "collector_role_arn" {
+  description = "IAM role the collector runs under (attach elsewhere if not using the bundled EC2 instance)."
+  value       = aws_iam_role.collector.arn
+}
+
+output "rds_connect_resource_arn" {
+  description = "The rds-db:connect resource ARN scoped to db_user on this instance."
+  value       = local.rds_connect_arn
+}
+
+output "instance_id" {
+  description = "Collector EC2 instance id."
+  value       = aws_instance.collector.id
+}

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -1,0 +1,86 @@
+# Inputs for the AWS passwordless (RDS IAM) onboarding module (#111).
+# No secrets here — aws_rds_iam mints a short-lived token from the EC2
+# instance's IAM identity (INV001/INV002).
+
+variable "region" {
+  type        = string
+  description = "AWS region of the RDS/Aurora instance and where the collector runs."
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for created resource names."
+  default     = "arq-signals"
+}
+
+variable "db_host" {
+  type        = string
+  description = "RDS/Aurora endpoint hostname (e.g. mydb.abc123.us-east-1.rds.amazonaws.com)."
+}
+
+variable "db_port" {
+  type        = number
+  description = "PostgreSQL port."
+  default     = 5432
+}
+
+variable "db_name" {
+  type        = string
+  description = "Database name to connect to."
+}
+
+variable "db_user" {
+  type        = string
+  description = "PostgreSQL role granted rds_iam (least-privilege, pg_monitor)."
+  default     = "arq_signals"
+}
+
+variable "db_resource_id" {
+  type        = string
+  description = <<-EOT
+    The RDS instance/cluster DbiResourceId (e.g. db-ABCDEFGH...), NOT the DB
+    identifier. Used to scope the rds-db:connect IAM policy. Find it with:
+    aws rds describe-db-instances --db-instance-identifier <id> \
+      --query 'DBInstances[0].DbiResourceId' --output text
+  EOT
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "Subnet for the collector EC2 instance (must route to the RDS instance)."
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "Security group(s) for the collector — must allow egress to the DB on db_port."
+}
+
+variable "instance_type" {
+  type        = string
+  description = "EC2 instance type for the collector."
+  default     = "t3.small"
+}
+
+variable "image_uri" {
+  type        = string
+  description = "Elevarq Signals container image (pinned tag)."
+  default     = "ghcr.io/elevarq/arq-signals:0.10.0-beta.5"
+}
+
+variable "arq_env" {
+  type        = string
+  description = "Signals environment (prod enforces verify-full TLS)."
+  default     = "prod"
+}
+
+variable "poll_interval" {
+  type        = string
+  description = "Collection interval."
+  default     = "5m"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags applied to created resources."
+  default     = {}
+}

--- a/deploy/aws/terraform/versions.tf
+++ b/deploy/aws/terraform/versions.tf
@@ -1,0 +1,14 @@
+# Pinned provider + Terraform versions (#111). Bump deliberately.
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.60"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}


### PR DESCRIPTION
## Summary

AWS "click-click-done" onboarding for a least-privilege, **passwordless**
Signals collector on Amazon RDS / Aurora, via `auth_method: aws_rds_iam`
(provider #94). Part of the #100 IaC decomposition.

Both implementations provision: the collector IAM role + a minimal
`rds-db:connect` policy **scoped to one DB user**, an instance profile, and an
EC2 instance running the collector pre-wired for `aws_rds_iam` over
`verify-full` TLS. **No secrets** anywhere — the token is minted from the EC2
instance role at connect time (INV001/INV002).

- `deploy/aws/terraform/` — `terraform validate` + `fmt` clean; AWS provider pinned `~> 5.60`; lock file committed.
- `deploy/aws/cloudformation/arq-signals-rds-iam.yaml` — `cfn-lint` clean.
- `deploy/aws/README.md` — DB grant SQL (`GRANT rds_iam` / `pg_monitor`), parameters, security notes, and the env-gated live-verification procedure.

The target config uses the correct `name:` identifier (fixed in #115) and
`verify-full` + the RDS global CA bundle.

## Acceptance (#111)

- [x] Parameterised, versions pinned, **no secrets in inputs** (INV001/INV002).
- [x] Static validation passes: `terraform validate` + `fmt -check`, `cfn-lint`.
- [x] Documented env-gated live procedure that stands up a working passwordless collector against a test RDS instance — **operator-run**, not default CI (mirrors #94's live smoke; consistent with how #94–#97 closed).

closes #111