### PR TITLE
feat(auth): implement mTLS client-certificate provider (closes #98)

### DIFF
--- a/docs/database-connections.md
+++ b/docs/database-connections.md
@@ -62,7 +62,7 @@ The recipes below add the method-specific binding on top of this role.
 | `azure_entra` | Azure Database for PostgreSQL — Flexible Server | Entra OAuth2 token (~75 min) | Shipped (#95) |
 | `gcp_cloudsql_iam` | Google Cloud SQL for PostgreSQL | Google OAuth2 token (~60 min) | Shipped (#96) |
 | `secret_store` | Self-managed PostgreSQL whose password lives in a cloud vault | Password fetched from AWS/Azure/GCP vault | Shipped (#97) |
-| `mtls` | Client-certificate auth | Client cert + key | Planned (#98) |
+| `mtls` | Client-certificate auth (on-prem / self-managed) | Client cert + key | Shipped (#98) |
 
 Omitting `auth_method` keeps the existing password behaviour exactly —
 no migration is required for current deployments (NFR003).
@@ -297,12 +297,42 @@ a rotation is picked up immediately.
 
 ---
 
-## `mtls` — client-certificate auth (planned)
+## `mtls` — client-certificate auth (self-managed)
 
-Client-certificate authentication (`sslcert` / `sslkey` target fields)
-is specified in #98 and **not yet available**. Until it ships, use one
-of the methods above. This page will gain a recipe when the provider
-lands.
+For on-prem / self-managed PostgreSQL that mandates mutual TLS: the
+collector presents a client X.509 certificate instead of a password or
+token. The cert/key are local PEM files; the database maps the cert to
+the role server-side (`pg_hba.conf` `clientcert=verify-full` +
+`pg_ident.conf`).
+
+**1. Database — trust + map the client cert** (`pg_hba.conf`):
+
+```
+hostssl  appdb  arq_signals  <collector-cidr>  cert  clientcert=verify-full
+```
+
+Map the certificate's CN to the role in `pg_ident.conf` if the CN differs
+from `arq_signals`, then `GRANT pg_monitor TO arq_signals;`.
+
+**2. Target config:**
+
+```yaml
+  - name: onprem-mtls
+    host: db.internal
+    port: 5432
+    dbname: appdb
+    user: arq_signals
+    auth_method: mtls
+    sslcert: /etc/arq/client.crt        # PEM client certificate
+    sslkey: /etc/arq/client.key         # PEM private key
+    sslkey_passphrase_file: /etc/arq/key.pass  # optional; for an encrypted key
+    sslmode: verify-full                # required
+    sslrootcert_file: /etc/arq/ca.pem   # verifies the server
+```
+
+The private key is read at connect time and **never logged or exported**;
+a rotated cert/key is picked up on the next reconnect. `verify-full` is
+required — a client certificate is only presented to a verified server.
 
 ---
 

--- a/features/arq-signals/traceability.md
+++ b/features/arq-signals/traceability.md
@@ -208,3 +208,17 @@ Spec: `features/arq-signals/credential-provider-secret-store.md` (ACTIVE), deriv
 | ARQ-SIGNALS-AUTH-SECRET-AC-013 | Live rotation validation (optional, opt-in): rotate the stored secret, force a re-fetch, reconnect with the new value | `TestLive_SecretStorePasswordlessConnect` | COVERED | INTEGRATION | Opt-in via `ARQ_TEST_SECRET_ROTATE=1`; rotation-on-reconnect fully covered in default CI by AC-004's unit cache test. |
 | ARQ-SIGNALS-AUTH-SECRET-INV004 (empty secret) | Empty fetched value (or extracted key) is a hard failure, not an empty password | `TestResolveSecretStoreEmptySecretFails` | COVERED | BEHAVIORAL | FC-SECRET-004. |
 | ARQ-SIGNALS-AUTH-SECRET-INV005 (backend isolation) | Only the inferred backend's SDK is invoked for a target; deferred Azure/GCP backends report `errSecretBackendUnavailable` (not redacted, carries no secret) | `TestProductionSecretFetcherRouting` | COVERED | BEHAVIORAL | `productionSecretFetcher` routes on `ref.Backend`; AWS wired, Azure/GCP nil → unavailable. |
+
+## Credential providers — `mtls` (#98)
+
+Spec: `features/arq-signals/credential-provider-mtls.md` (ACTIVE), deriving from `credential-providers.md` (keystone, #93). The only certificate-kind credential: `Credential.ClientCert` applied to `cfg.TLSConfig.Certificates` in the `BeforeConnect` hook (`internal/collector/collector.go`). Provider + cert loader in `internal/collector/credprovider_mtls.go`; `sslcert`/`sslkey`/`sslkey_passphrase_file` config + validation in `internal/config/config.go`. Unit tests `internal/collector/credprovider_mtls_test.go` + `internal/config/authmethod_mtls_test.go`.
+
+| Rule ID | Rule Summary | Test ID(s) | Coverage Status | Evidence Type | Notes |
+|---------|-------------|------------|-----------------|---------------|-------|
+| ARQ-SIGNALS-AUTH-MTLS-AC-001 | Valid cert/key pair loads, applied as certificate kind, `ExpiresAt` = cert `NotAfter`; no password | `TestFileCertLoaderLoadsValidPair`, `TestResolveMTLSCertKindAndExpiry` | COVERED | BEHAVIORAL | In-test self-signed cert; no operator material (NFR003). |
+| ARQ-SIGNALS-AUTH-MTLS-AC-002 | Encrypted key + correct passphrase loads; wrong passphrase fails without echoing passphrase/key | `TestFileCertLoaderEncryptedKey` | COVERED | BEHAVIORAL | FC-MTLS-003; stdlib legacy-PEM decryption (NFR001). |
+| ARQ-SIGNALS-AUTH-MTLS-AC-003 | Loader re-reads files each call; rotated cert/key picked up without restart (no cache) | `TestFileCertLoaderRotation` | COVERED | BEHAVIORAL | INV-MTLS-003. |
+| ARQ-SIGNALS-AUTH-MTLS-AC-004 | `mtls` without `sslcert`/`sslkey` → hard startup error naming both fields | `TestValidateRejectsMTLSWithoutCertOrKey` | COVERED | BEHAVIORAL | FC-MTLS-001. |
+| ARQ-SIGNALS-AUTH-MTLS-AC-005 | `mtls` requires `verify-full` in every env; rejects weaker; accepts verify-full | `TestValidateRejectsMTLSWithoutVerifyFull`, `TestValidateAcceptsMTLS` | COVERED | BEHAVIORAL | FC-MTLS-004 / INV-MTLS-004. |
+| ARQ-SIGNALS-AUTH-MTLS-AC-006 | `mtls` + any inline password source → hard startup error (auth is by certificate) | `TestValidateRejectsMTLSWithPasswordSource` | COVERED | BEHAVIORAL | FC-MTLS-005. |
+| ARQ-SIGNALS-AUTH-MTLS-AC-007 | Mismatched pair / non-PEM key → redacted error; key material never in the error | `TestFileCertLoaderMismatchedPair`, `TestFileCertLoaderNonPEMKey` | COVERED | BEHAVIORAL | FC-MTLS-002 + INV-MTLS-001. |

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1254,16 +1255,30 @@ func (c *Collector) getPool(ctx context.Context, tgt config.TargetConfig) (*pgxp
 
 	// Re-resolve the credential on each new connection: password targets
 	// re-read their secret to support rotation; aws_rds_iam targets mint
-	// or reuse a cached, short-lived IAM token (#93/#94). The resolver
-	// dispatches on auth_method; the resolved value is the connection
-	// password in both cases.
+	// or reuse a cached, short-lived IAM token (#93/#94); mtls targets
+	// re-read the client cert/key so a rotated cert is picked up without a
+	// restart (#98). The resolver dispatches on auth_method; the resolved
+	// value is applied as a password or a TLS client certificate per Kind.
 	poolCfg.BeforeConnect = func(ctx context.Context, cfg *pgx.ConnConfig) error {
 		cred, err := c.credResolver.Resolve(ctx, tgt)
 		if err != nil {
 			slog.Error("failed to resolve credential for target", "target", tgt.Name, "auth_method", tgt.EffectiveAuthMethod(), "err", redactError(err))
 			return fmt.Errorf("resolve credential: %w", redactError(err))
 		}
-		cfg.Password = cred.Password
+		switch cred.Kind {
+		case CredKindCertificate:
+			// mtls (#98): present the client certificate during the TLS
+			// handshake. verify-full is enforced at config validation, so
+			// pgx has built a TLSConfig we extend (never replace).
+			if cfg.TLSConfig == nil {
+				return fmt.Errorf("mtls target %s: connection has no TLS config (sslmode must be verify-full)", tgt.Name)
+			}
+			if cred.ClientCert != nil {
+				cfg.TLSConfig.Certificates = []tls.Certificate{*cred.ClientCert}
+			}
+		default:
+			cfg.Password = cred.Password
+		}
 		return nil
 	}
 

--- a/internal/collector/credprovider.go
+++ b/internal/collector/credprovider.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"crypto/tls"
 	"log/slog"
 	"sync"
 	"time"
@@ -22,6 +23,10 @@ const (
 	// Both the default password provider and aws_rds_iam produce this
 	// kind — for AWS the password value is the short-lived IAM token.
 	CredKindPassword CredKind = iota
+	// CredKindCertificate is a credential applied as a client certificate
+	// in the connection's TLS config (the mtls provider, #98). The cert is
+	// presented during the TLS handshake; there is no password.
+	CredKindCertificate
 )
 
 // Credential is the resolved authentication material for one connection
@@ -32,9 +37,16 @@ type Credential struct {
 	Kind CredKind
 	// Password is the secret value (a stored password, or for
 	// aws_rds_iam the minted IAM token). Never logged or persisted.
+	// Set when Kind == CredKindPassword.
 	Password string
+	// ClientCert is the parsed client certificate + private key, applied to
+	// the connection's TLS config. Set when Kind == CredKindCertificate
+	// (mtls, #98). The private key material is never logged or persisted
+	// (INV-MTLS-001).
+	ClientCert *tls.Certificate
 	// ExpiresAt is the credential's expiry. Zero means "no expiry"
-	// (a static password); a non-zero value drives cache refresh.
+	// (a static password); a non-zero value drives cache refresh. For mtls
+	// it is the client cert's NotAfter (advisory only — no re-mint).
 	ExpiresAt time.Time
 }
 
@@ -62,8 +74,12 @@ type credentialResolver struct {
 	// the secret_store provider (#97). Like the minters it is a seam so unit
 	// tests inject a fake and make no real cloud call (NFR003).
 	secretFetcher secretFetcher
-	now           func() time.Time
-	logger        *slog.Logger
+	// certLoader loads + validates the client cert/key for the mtls provider
+	// (#98). A seam so unit tests inject in-memory fixtures and read no
+	// operator key material (NFR003).
+	certLoader certLoader
+	now        func() time.Time
+	logger     *slog.Logger
 }
 
 // newCredentialResolver builds the production resolver: a real AWS token
@@ -84,6 +100,7 @@ func newCredentialResolver(logger *slog.Logger) *credentialResolver {
 		// fetchers are deferred behind the same seam and report
 		// errSecretBackendUnavailable until wired.
 		secretFetcher: productionSecretFetcher{aws: awsSecretsManagerFetcher{}},
+		certLoader:    fileCertLoader{},
 		now:           time.Now,
 		logger:        logger,
 	}
@@ -103,6 +120,8 @@ func (r *credentialResolver) Resolve(ctx context.Context, tgt config.TargetConfi
 		return r.resolveGCP(ctx, tgt)
 	case config.AuthMethodSecretStore:
 		return r.resolveSecretStore(ctx, tgt)
+	case config.AuthMethodMTLS:
+		return r.resolveMTLS(ctx, tgt)
 	default:
 		password, err := ResolvePassword(tgt)
 		if err != nil {

--- a/internal/collector/credprovider_mtls.go
+++ b/internal/collector/credprovider_mtls.go
@@ -1,0 +1,101 @@
+package collector
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/elevarq/arq-signals/internal/config"
+)
+
+// certLoader loads and validates a client certificate + private key for the
+// mtls provider (ARQ-SIGNALS-AUTH-MTLS-, #98). It is a seam so unit tests
+// inject in-memory fixtures and read no operator key material (NFR003).
+type certLoader interface {
+	Load(certFile, keyFile, passphraseFile string) (*tls.Certificate, error)
+}
+
+// fileCertLoader is the production loader: it reads PEM cert/key from the
+// filesystem and, when a passphrase file is given, decrypts a legacy
+// PEM-encrypted key (stdlib only, NFR001).
+type fileCertLoader struct{}
+
+func (fileCertLoader) Load(certFile, keyFile, passphraseFile string) (*tls.Certificate, error) {
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		// Redacted: names the field + failure class, never file contents.
+		return nil, fmt.Errorf("read sslcert: %w", err)
+	}
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("read sslkey: %w", err)
+	}
+	if passphraseFile != "" {
+		keyPEM, err = decryptKeyPEM(keyPEM, passphraseFile)
+		if err != nil {
+			return nil, err
+		}
+	}
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		// Covers a non-PEM file, a mismatched cert/key pair, or an encrypted
+		// key with no passphrase. The error never includes key bytes.
+		return nil, fmt.Errorf("load client cert/key (invalid pair, bad PEM, or encrypted key without sslkey_passphrase_file): %w", err)
+	}
+	// Parse the leaf for the NotAfter metadata (advisory ExpiresAt, #98).
+	if cert.Leaf == nil && len(cert.Certificate) > 0 {
+		if leaf, perr := x509.ParseCertificate(cert.Certificate[0]); perr == nil {
+			cert.Leaf = leaf
+		}
+	}
+	return &cert, nil
+}
+
+// decryptKeyPEM decrypts a legacy PEM-encrypted private key with the
+// passphrase in passphraseFile and returns an unencrypted PEM that
+// tls.X509KeyPair accepts. An unencrypted key is returned unchanged.
+func decryptKeyPEM(keyPEM []byte, passphraseFile string) ([]byte, error) {
+	pass, err := os.ReadFile(passphraseFile)
+	if err != nil {
+		return nil, fmt.Errorf("read sslkey_passphrase_file: %w", err)
+	}
+	pass = []byte(strings.TrimRight(string(pass), "\r\n"))
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		return nil, fmt.Errorf("sslkey is not valid PEM")
+	}
+	//nolint:staticcheck // x509.IsEncryptedPEMBlock/DecryptPEMBlock are the only
+	// stdlib path for legacy PEM-encrypted keys (NFR001: stdlib-only, no dep).
+	if !x509.IsEncryptedPEMBlock(block) {
+		return keyPEM, nil // not encrypted; passphrase not needed
+	}
+	//nolint:staticcheck // see note above
+	der, err := x509.DecryptPEMBlock(block, pass)
+	if err != nil {
+		// Never echo the passphrase or key material.
+		return nil, fmt.Errorf("decrypt sslkey: wrong passphrase or unsupported key encryption")
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: block.Type, Bytes: der}), nil
+}
+
+// resolveMTLS loads the client cert/key for an mtls target (#98). The
+// certificate-kind credential is re-read on every connection so a rotated
+// cert/key is picked up without a daemon restart (INV-MTLS-003); there is no
+// token to mint and nothing to cache. The private key material is carried in
+// the Credential and applied to the TLS config by the caller — never logged
+// (INV-MTLS-001).
+func (r *credentialResolver) resolveMTLS(_ context.Context, tgt config.TargetConfig) (Credential, error) {
+	cert, err := r.certLoader.Load(tgt.SSLCert, tgt.SSLKey, tgt.SSLKeyPassphraseFile)
+	if err != nil {
+		return Credential{}, redactError(err)
+	}
+	cred := Credential{Kind: CredKindCertificate, ClientCert: cert}
+	if cert.Leaf != nil {
+		cred.ExpiresAt = cert.Leaf.NotAfter // advisory only
+	}
+	return cred, nil
+}

--- a/internal/collector/credprovider_mtls_test.go
+++ b/internal/collector/credprovider_mtls_test.go
@@ -1,0 +1,232 @@
+package collector
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elevarq/arq-signals/internal/config"
+)
+
+// genCertKeyPEM produces a self-signed cert + its EC private key as PEM, in
+// test only (NFR003 — no operator key material is read).
+func genCertKeyPEM(t *testing.T, notAfter time.Time) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "arq_signals"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+// writePair writes cert+key PEM to files in dir, returning their paths.
+func writePair(t *testing.T, dir string, certPEM, keyPEM []byte) (certFile, keyFile string) {
+	t.Helper()
+	certFile = filepath.Join(dir, "client.crt")
+	keyFile = filepath.Join(dir, "client.key")
+	if err := os.WriteFile(certFile, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certFile, keyFile
+}
+
+// AC-MTLS-001 — a valid cert/key pair loads; ExpiresAt = cert NotAfter.
+func TestFileCertLoaderLoadsValidPair(t *testing.T) {
+	dir := t.TempDir()
+	notAfter := time.Now().Add(48 * time.Hour).Truncate(time.Second)
+	certPEM, keyPEM := genCertKeyPEM(t, notAfter)
+	certFile, keyFile := writePair(t, dir, certPEM, keyPEM)
+
+	cert, err := (fileCertLoader{}).Load(certFile, keyFile, "")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cert.Leaf == nil {
+		t.Fatal("expected leaf parsed for NotAfter metadata")
+	}
+	if !cert.Leaf.NotAfter.Equal(notAfter) {
+		t.Errorf("NotAfter = %v, want %v", cert.Leaf.NotAfter, notAfter)
+	}
+}
+
+// AC-MTLS-001 — resolveMTLS returns a certificate-kind credential carrying the
+// cert, with advisory ExpiresAt = NotAfter.
+func TestResolveMTLSCertKindAndExpiry(t *testing.T) {
+	dir := t.TempDir()
+	notAfter := time.Now().Add(72 * time.Hour).Truncate(time.Second)
+	certPEM, keyPEM := genCertKeyPEM(t, notAfter)
+	certFile, keyFile := writePair(t, dir, certPEM, keyPEM)
+
+	r := &credentialResolver{certLoader: fileCertLoader{}, now: time.Now}
+	tgt := config.TargetConfig{Name: "t", AuthMethod: config.AuthMethodMTLS, SSLCert: certFile, SSLKey: keyFile}
+
+	cred, err := r.resolveMTLS(context.Background(), tgt)
+	if err != nil {
+		t.Fatalf("resolveMTLS: %v", err)
+	}
+	if cred.Kind != CredKindCertificate {
+		t.Errorf("Kind = %v, want CredKindCertificate", cred.Kind)
+	}
+	if cred.ClientCert == nil {
+		t.Error("ClientCert is nil")
+	}
+	if cred.Password != "" {
+		t.Error("certificate-kind credential must carry no password")
+	}
+	if !cred.ExpiresAt.Equal(notAfter) {
+		t.Errorf("ExpiresAt = %v, want %v", cred.ExpiresAt, notAfter)
+	}
+}
+
+// AC-MTLS-007 — a mismatched cert/key pair fails with an error that does not
+// leak key material.
+func TestFileCertLoaderMismatchedPair(t *testing.T) {
+	dir := t.TempDir()
+	certPEM, _ := genCertKeyPEM(t, time.Now().Add(time.Hour))
+	_, otherKeyPEM := genCertKeyPEM(t, time.Now().Add(time.Hour))
+	certFile, keyFile := writePair(t, dir, certPEM, otherKeyPEM)
+
+	_, err := (fileCertLoader{}).Load(certFile, keyFile, "")
+	if err == nil {
+		t.Fatal("expected error for mismatched cert/key pair")
+	}
+	if strings.Contains(err.Error(), "PRIVATE KEY") || strings.Contains(err.Error(), string(otherKeyPEM)) {
+		t.Errorf("error leaks key material: %v", err)
+	}
+}
+
+// AC-MTLS-007 — a non-PEM key file fails (redacted).
+func TestFileCertLoaderNonPEMKey(t *testing.T) {
+	dir := t.TempDir()
+	certPEM, _ := genCertKeyPEM(t, time.Now().Add(time.Hour))
+	certFile, keyFile := writePair(t, dir, certPEM, []byte("not a pem key"))
+
+	if _, err := (fileCertLoader{}).Load(certFile, keyFile, ""); err == nil {
+		t.Fatal("expected error for non-PEM key")
+	}
+}
+
+// AC-MTLS-002 — an encrypted key loads with the right passphrase and fails with
+// the wrong one (never echoing the passphrase or key).
+func TestFileCertLoaderEncryptedKey(t *testing.T) {
+	dir := t.TempDir()
+	notAfter := time.Now().Add(time.Hour)
+	certPEM, keyPEM := genCertKeyPEM(t, notAfter)
+
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		t.Fatal("decode key pem")
+	}
+	//nolint:staticcheck // legacy PEM encryption is the stdlib path under test (NFR001)
+	encBlock, err := x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes, []byte("s3cret"), x509.PEMCipherAES256)
+	if err != nil {
+		t.Fatalf("encrypt key: %v", err)
+	}
+	encKeyPEM := pem.EncodeToMemory(encBlock)
+	certFile, keyFile := writePair(t, dir, certPEM, encKeyPEM)
+	passFile := filepath.Join(dir, "pass")
+
+	// correct passphrase
+	if err := os.WriteFile(passFile, []byte("s3cret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (fileCertLoader{}).Load(certFile, keyFile, passFile); err != nil {
+		t.Fatalf("encrypted key with correct passphrase should load: %v", err)
+	}
+
+	// wrong passphrase
+	if err := os.WriteFile(passFile, []byte("wrong"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = nil
+	if _, err = (fileCertLoader{}).Load(certFile, keyFile, passFile); err == nil {
+		t.Fatal("expected error for wrong passphrase")
+	}
+	if strings.Contains(err.Error(), "wrong") && strings.Contains(err.Error(), "s3cret") {
+		t.Errorf("error must not echo the passphrase: %v", err)
+	}
+}
+
+// AC-MTLS-003 — the loader re-reads file content, so rotated material is picked
+// up on the next call (no caching).
+func TestFileCertLoaderRotation(t *testing.T) {
+	dir := t.TempDir()
+	a := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	certA, keyA := genCertKeyPEM(t, a)
+	certFile, keyFile := writePair(t, dir, certA, keyA)
+
+	c1, err := (fileCertLoader{}).Load(certFile, keyFile, "")
+	if err != nil {
+		t.Fatalf("load A: %v", err)
+	}
+
+	b := time.Now().Add(240 * time.Hour).Truncate(time.Second)
+	certB, keyB := genCertKeyPEM(t, b)
+	if err := os.WriteFile(certFile, certB, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, keyB, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := (fileCertLoader{}).Load(certFile, keyFile, "")
+	if err != nil {
+		t.Fatalf("load B: %v", err)
+	}
+	if c1.Leaf.NotAfter.Equal(c2.Leaf.NotAfter) {
+		t.Error("rotation not observed: loader returned stale certificate")
+	}
+}
+
+// AC-MTLS-009 (diagnostic facet) — BuildSafeDSN presents the client cert for
+// doctor/conntest via libpq sslcert/sslkey params, and never leaks the
+// passphrase (INV-MTLS-001).
+func TestBuildSafeDSNMTLSIncludesCertNotPassphrase(t *testing.T) {
+	tgt := config.TargetConfig{
+		Name: "t", Host: "h", Port: 5432, DBName: "db", User: "u",
+		SSLMode: "verify-full", SSLRootCertFile: "/ca.pem",
+		AuthMethod: config.AuthMethodMTLS,
+		SSLCert:    "/c.crt", SSLKey: "/c.key", SSLKeyPassphraseFile: "/k.pass",
+	}
+	dsn, err := BuildSafeDSN(tgt)
+	if err != nil {
+		t.Fatalf("BuildSafeDSN: %v", err)
+	}
+	for _, want := range []string{"sslcert='/c.crt'", "sslkey='/c.key'", "sslrootcert='/ca.pem'"} {
+		if !strings.Contains(dsn, want) {
+			t.Errorf("DSN missing %q: %s", want, dsn)
+		}
+	}
+	if strings.Contains(dsn, "/k.pass") || strings.Contains(dsn, "sslpassword") {
+		t.Errorf("passphrase must not appear in the DSN: %s", dsn)
+	}
+}

--- a/internal/collector/credprovider_mtls_test.go
+++ b/internal/collector/credprovider_mtls_test.go
@@ -167,8 +167,8 @@ func TestFileCertLoaderEncryptedKey(t *testing.T) {
 	if err := os.WriteFile(passFile, []byte("wrong"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	err = nil
-	if _, err = (fileCertLoader{}).Load(certFile, keyFile, passFile); err == nil {
+	_, err = (fileCertLoader{}).Load(certFile, keyFile, passFile)
+	if err == nil {
 		t.Fatal("expected error for wrong passphrase")
 	}
 	if strings.Contains(err.Error(), "wrong") && strings.Contains(err.Error(), "s3cret") {

--- a/internal/collector/secrets.go
+++ b/internal/collector/secrets.go
@@ -126,6 +126,23 @@ func BuildSafeDSN(tgt config.TargetConfig) (string, error) {
 	if password != "" {
 		parts = append(parts, "password="+quoteDSNValue(password))
 	}
+	// mtls (#98): present the client certificate in the diagnostic
+	// connection too (doctor/conntest). sslcert/sslkey are file paths, not
+	// secrets, so they are safe in the DSN. The optional key passphrase is
+	// deliberately NOT placed in the DSN (disclosure risk, INV-MTLS-001); an
+	// encrypted key is exercised on the live collection path, which loads it
+	// in-process. libpq loads sslcert/sslkey at connect time.
+	if tgt.EffectiveAuthMethod() == config.AuthMethodMTLS {
+		if tgt.SSLCert != "" {
+			parts = append(parts, "sslcert="+quoteDSNValue(tgt.SSLCert))
+		}
+		if tgt.SSLKey != "" {
+			parts = append(parts, "sslkey="+quoteDSNValue(tgt.SSLKey))
+		}
+		if tgt.SSLRootCertFile != "" {
+			parts = append(parts, "sslrootcert="+quoteDSNValue(tgt.SSLRootCertFile))
+		}
+	}
 	return strings.Join(parts, " "), nil
 }
 

--- a/internal/config/authmethod_mtls_test.go
+++ b/internal/config/authmethod_mtls_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// mtlsTarget returns a base mtls target that passes the generic checks, so
+// each test mutates only the field under examination.
+func mtlsTarget() TargetConfig {
+	tgt := baseValidTarget()
+	tgt.AuthMethod = AuthMethodMTLS
+	tgt.SSLMode = "verify-full"
+	tgt.SSLRootCertFile = "/etc/ca.pem"
+	tgt.SSLCert = "/etc/arq/client.crt"
+	tgt.SSLKey = "/etc/arq/client.key"
+	return tgt
+}
+
+// keystone NFR003 — mtls is a supported method whose effective value
+// round-trips.
+func TestEffectiveAuthMethodMTLS(t *testing.T) {
+	tgt := baseValidTarget()
+	tgt.AuthMethod = AuthMethodMTLS
+	if got := tgt.EffectiveAuthMethod(); got != AuthMethodMTLS {
+		t.Fatalf("EffectiveAuthMethod() = %q, want %q", got, AuthMethodMTLS)
+	}
+}
+
+// AC-MTLS-001 (config facet) — a well-formed mtls target validates clean.
+func TestValidateAcceptsMTLS(t *testing.T) {
+	if _, err := ValidateStrict(baseValidConfig(mtlsTarget())); err != nil {
+		t.Fatalf("a well-formed mtls target should validate clean, got: %v", err)
+	}
+}
+
+// AC-MTLS-004 / FC-MTLS-001 — mtls requires both sslcert and sslkey.
+func TestValidateRejectsMTLSWithoutCertOrKey(t *testing.T) {
+	cases := map[string]func(*TargetConfig){
+		"no sslcert": func(t *TargetConfig) { t.SSLCert = "" },
+		"no sslkey":  func(t *TargetConfig) { t.SSLKey = "" },
+		"neither":    func(t *TargetConfig) { t.SSLCert = ""; t.SSLKey = "" },
+	}
+	for name, mut := range cases {
+		t.Run(name, func(t *testing.T) {
+			tgt := mtlsTarget()
+			mut(&tgt)
+			_, err := ValidateStrict(baseValidConfig(tgt))
+			if err == nil {
+				t.Fatalf("expected hard error for mtls %s, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "sslcert") || !strings.Contains(err.Error(), "sslkey") {
+				t.Errorf("error should name sslcert and sslkey; got: %v", err)
+			}
+		})
+	}
+}
+
+// AC-MTLS-005 / FC-MTLS-004 — mtls requires verify-full in every environment.
+func TestValidateRejectsMTLSWithoutVerifyFull(t *testing.T) {
+	for _, mode := range []string{"", "require", "prefer", "verify-ca"} {
+		t.Run("sslmode="+mode, func(t *testing.T) {
+			tgt := mtlsTarget()
+			tgt.SSLMode = mode
+			_, err := ValidateStrict(baseValidConfig(tgt))
+			if err == nil {
+				t.Fatalf("expected hard error for mtls sslmode=%q, got nil", mode)
+			}
+			if !strings.Contains(err.Error(), "verify-full") {
+				t.Errorf("error should require verify-full; got: %v", err)
+			}
+		})
+	}
+}
+
+// AC-MTLS-006 / FC-MTLS-005 — mtls + any inline password source is a hard
+// config error; authentication is by client certificate.
+func TestValidateRejectsMTLSWithPasswordSource(t *testing.T) {
+	for _, src := range []string{"password_file", "password_env", "pgpass_file"} {
+		t.Run(src, func(t *testing.T) {
+			tgt := mtlsTarget()
+			switch src {
+			case "password_file":
+				tgt.PasswordFile = "/etc/pw"
+			case "password_env":
+				tgt.PasswordEnv = "PW"
+			case "pgpass_file":
+				tgt.PgpassFile = "/etc/pgpass"
+			}
+			_, err := ValidateStrict(baseValidConfig(tgt))
+			if err == nil {
+				t.Fatalf("expected hard error for mtls + %s, got nil", src)
+			}
+			if !strings.Contains(err.Error(), "certificate") {
+				t.Errorf("error should explain auth is by client certificate; got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/config/authmethod_test.go
+++ b/internal/config/authmethod_test.go
@@ -144,12 +144,12 @@ func TestValidateWarnsButDoesNotFailOnMissingAWSRegion(t *testing.T) {
 // hard error that names the supported set.
 func TestValidateRejectsUnsupportedAuthMethod(t *testing.T) {
 	tgt := baseValidTarget()
-	tgt.AuthMethod = "mtls" // known in keystone (#98), not implemented in this build
+	tgt.AuthMethod = "kerberos" // not a recognised auth_method in any build
 	_, err := ValidateStrict(baseValidConfig(tgt))
 	if err == nil {
 		t.Fatalf("expected hard error for unsupported auth_method, got nil")
 	}
-	if !strings.Contains(err.Error(), "mtls") || !strings.Contains(err.Error(), AuthMethodAWSRDSIAM) {
+	if !strings.Contains(err.Error(), "kerberos") || !strings.Contains(err.Error(), AuthMethodAWSRDSIAM) {
 		t.Errorf("error should name the bad method and the supported set; got: %v", err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,6 +209,20 @@ type TargetConfig struct {
 	MaxCacheTTL  time.Duration `yaml:"-"`
 	MaxCacheTTLS string        `yaml:"max_cache_ttl"`
 
+	// SSLCert / SSLKey are filesystem paths to the PEM client certificate and
+	// private key for the mtls provider (ARQ-SIGNALS-AUTH-MTLS-, #98). Both are
+	// required when auth_method is mtls (FC-MTLS-001). The cert is presented
+	// during the TLS handshake (certificate-kind credential); the key material
+	// is never logged or exported (INV-MTLS-001).
+	SSLCert string `yaml:"sslcert"`
+	SSLKey  string `yaml:"sslkey"`
+
+	// SSLKeyPassphraseFile is an optional path to a file holding the passphrase
+	// for an encrypted SSLKey (mtls only, #98). File-only — never an inline or
+	// env value. When the key is encrypted and this is unset, resolution fails
+	// (FC-MTLS-003).
+	SSLKeyPassphraseFile string `yaml:"sslkey_passphrase_file"`
+
 	// R098: per-target sensitivity profile. Empty / absent means
 	// "inherit daemon-wide". See specifications/sensitivity-profiles.md.
 	Collectors TargetCollectorConfig `yaml:"collectors"`
@@ -299,12 +313,13 @@ const (
 	AuthMethodAzureEntra     = "azure_entra"
 	AuthMethodGCPCloudSQLIAM = "gcp_cloudsql_iam"
 	AuthMethodSecretStore    = "secret_store"
+	AuthMethodMTLS           = "mtls"
 )
 
 // SupportedAuthMethods enumerates every auth_method this build can serve.
 // The empty value is equivalent to AuthMethodPassword (see
 // EffectiveAuthMethod) and is always accepted.
-var SupportedAuthMethods = []string{AuthMethodPassword, AuthMethodAWSRDSIAM, AuthMethodAzureEntra, AuthMethodGCPCloudSQLIAM, AuthMethodSecretStore}
+var SupportedAuthMethods = []string{AuthMethodPassword, AuthMethodAWSRDSIAM, AuthMethodAzureEntra, AuthMethodGCPCloudSQLIAM, AuthMethodSecretStore, AuthMethodMTLS}
 
 // EffectiveAuthMethod returns the target's auth_method, defaulting an
 // empty value to AuthMethodPassword so existing configs keep their
@@ -855,6 +870,25 @@ func ValidateStrict(cfg Config) (warnings []string, err error) {
 			// an undiscoverable workload identity for the vault is a
 			// connect-time, target-scoped failure (FC-SECRET-002), not a
 			// whole-collector startup failure.
+		case AuthMethodMTLS:
+			// FC-MTLS-005: mTLS authenticates by certificate — reject any
+			// inline password source on the target.
+			if secretCount > 0 {
+				hard = append(hard, fmt.Sprintf("target[%d] (%s): auth_method %q authenticates by client certificate — remove password_file, password_env, and pgpass_file", i, t.Name, AuthMethodMTLS))
+			}
+			// FC-MTLS-004: a client certificate must only be presented over a
+			// fully verified TLS channel, in every environment (presenting it
+			// to an unverified server risks disclosing it to an impostor).
+			if t.SSLMode != "verify-full" {
+				hard = append(hard, fmt.Sprintf("target[%d] (%s): auth_method %q requires sslmode=verify-full (got %q)", i, t.Name, AuthMethodMTLS, t.SSLMode))
+			}
+			// FC-MTLS-001: both sslcert and sslkey are required.
+			if t.SSLCert == "" || t.SSLKey == "" {
+				hard = append(hard, fmt.Sprintf("target[%d] (%s): auth_method %q requires both sslcert and sslkey", i, t.Name, AuthMethodMTLS))
+			}
+			// The optional sslkey_passphrase_file and a wrong/missing passphrase
+			// for an encrypted key are connect-time failures (FC-MTLS-003), not
+			// startup failures — the key is not read until connect time.
 		default:
 			hard = append(hard, fmt.Sprintf("target[%d] (%s): auth_method %q is not supported by this build (supported: %s)", i, t.Name, t.AuthMethod, strings.Join(SupportedAuthMethods, ", ")))
 		}


### PR DESCRIPTION
## Summary

Implements the `mtls` provider per its ACTIVE spec (#98) — the only
**certificate-kind** credential. The client cert + key are loaded at connect
time and applied to the connection's TLS config; no password, no token, no
cloud identity. Part of the #92 epic; completes the provider set.

## What's included

- **config** — `AuthMethodMTLS` + `sslcert` / `sslkey` / `sslkey_passphrase_file` fields; validation: FC-MTLS-001 (both cert+key required), FC-MTLS-004 (`verify-full` in every env), FC-MTLS-005 (no inline password).
- **credprovider** — `CredKindCertificate` + `Credential.ClientCert`; `resolveMTLS` re-reads the pair on every connection (rotation, INV-MTLS-003 — no cache).
- **credprovider_mtls.go** — `fileCertLoader`: PEM load, legacy-PEM passphrase decryption (stdlib only, NFR001), cert/key pair validation; key material never logged (INV-MTLS-001).
- **collector** — `BeforeConnect` applies the cert to `cfg.TLSConfig.Certificates`.
- **secrets** — `BuildSafeDSN` presents `sslcert`/`sslkey` for doctor/conntest; the passphrase is deliberately omitted from the DSN (disclosure risk).
- **docs** — `database-connections.md` mTLS section flipped from "planned" to a shipped recipe.
- **traceability.md** — AC-MTLS-001..007 mapped to tests.

## Tests

`internal/config` + `internal/collector` green. In-test self-signed certs;
no operator key material (NFR003). Covers valid load, cert-kind + advisory
`ExpiresAt`, encrypted-key + passphrase (and wrong passphrase), mismatched /
non-PEM pair (redacted), rotation, the three config validations, and the
diagnostic-DSN cert/no-passphrase.

closes #98