### PR TITLE
Helm: wire passwordless cloud auth + per-platform identity examples

### DIFF
--- a/deploy/helm/arq-signals/README.md
+++ b/deploy/helm/arq-signals/README.md
@@ -1,0 +1,195 @@
+# arq-signals Helm chart
+
+Deploys the arq-signals collector. The collector reads a single
+PostgreSQL target from the mounted `signals.yaml` ConfigMap. Set
+`target.host` to render that target; leave it empty and no target
+block is emitted.
+
+> Cloud-side setup (DB roles, IAM bindings, CA bundles) lives in
+> [`docs/database-connections.md`](../../../docs/database-connections.md).
+> This README covers only the Helm wiring.
+
+## Authentication methods
+
+`target.authMethod` selects how the collector authenticates. The
+default (empty) is the password method; the rest are **passwordless** —
+the pod's ambient cloud identity mints the credential at connect time.
+
+| `authMethod` | Credential source | Password? |
+|---|---|---|
+| `""` (default) | Kubernetes Secret → `PG_PASSWORD` | yes |
+| `aws_rds_iam` | RDS IAM token from the pod's AWS identity | no |
+| `azure_entra` | Entra OAuth2 token from the pod's Azure identity | no |
+| `gcp_cloudsql_iam` | Google OAuth2 token from the pod's GCP identity | no |
+| `secret_store` | Password fetched from a cloud vault | no |
+
+Invariants enforced by the chart and the collector:
+
+- **FC005** — passwordless methods carry no password source. Setting
+  `target.passwordSecretName` together with a non-empty `authMethod` is
+  ignored: neither `password_env` nor the `PG_PASSWORD` secret mount is
+  rendered.
+- **FC006** — cloud methods require `sslmode: verify-full`. In `prod`,
+  `verify-ca`/`verify-full` also hard-require `target.sslRootCertFile`
+  pointing at a mounted CA bundle (see `extraVolumes` below).
+
+## Password method (default)
+
+```yaml
+target:
+  host: db.internal
+  dbname: appdb
+  user: arq_signals
+  sslmode: verify-full
+  sslRootCertFile: /etc/ssl/db/ca.pem
+  passwordSecretName: pg-cred     # Secret holding the password
+  passwordSecretKey: password
+```
+
+The password is injected as `PG_PASSWORD` via `secretKeyRef`; it never
+lands in the ConfigMap or any rendered manifest beyond the Secret name.
+
+## Per-platform passwordless wiring
+
+### AWS — EKS IRSA (`aws_rds_iam`)
+
+Bind the IAM role through the ServiceAccount annotation. IRSA injects
+the web-identity token automatically.
+
+```yaml
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::<account>:role/arq-signals-irsa
+
+target:
+  host: mydb.abc123.us-east-1.rds.amazonaws.com
+  dbname: appdb
+  user: arq_signals
+  authMethod: aws_rds_iam
+  region: us-east-1                 # optional; inferred from AWS_REGION / IMDS
+  sslmode: verify-full
+  sslRootCertFile: /etc/ssl/db/rds-global-bundle.pem
+
+extraVolumes:
+  - name: db-ca
+    secret:
+      secretName: rds-ca-bundle
+extraVolumeMounts:
+  - name: db-ca
+    mountPath: /etc/ssl/db
+    readOnly: true
+```
+
+### AWS — EKS Pod Identity (`aws_rds_iam`)
+
+Pod Identity needs **no** ServiceAccount annotation — the association
+between the SA and the IAM role is created out-of-band
+(`aws eks create-pod-identity-association`). Keep `serviceAccount.create:
+true` so there is a stable SA to associate.
+
+```yaml
+serviceAccount:
+  create: true
+  annotations: {}                   # association is created out-of-band
+
+target:
+  host: mydb.abc123.us-east-1.rds.amazonaws.com
+  dbname: appdb
+  user: arq_signals
+  authMethod: aws_rds_iam
+  sslmode: verify-full
+  sslRootCertFile: /etc/ssl/db/rds-global-bundle.pem
+# ... extraVolumes / extraVolumeMounts as above
+```
+
+### GCP — GKE Workload Identity (`gcp_cloudsql_iam`)
+
+Bind the Google service account through the ServiceAccount annotation.
+
+```yaml
+serviceAccount:
+  create: true
+  annotations:
+    iam.gke.io/gcp-service-account: signals-collector@<project>.iam.gserviceaccount.com
+
+target:
+  host: 10.0.0.5                    # private IP or Cloud SQL proxy endpoint
+  dbname: appdb
+  user: "signals-collector@<project>.iam"   # SA email without .gserviceaccount.com
+  authMethod: gcp_cloudsql_iam
+  sslmode: verify-full
+  sslRootCertFile: /etc/ssl/db/server-ca.pem
+
+extraVolumes:
+  - name: db-ca
+    secret:
+      secretName: cloudsql-ca
+extraVolumeMounts:
+  - name: db-ca
+    mountPath: /etc/ssl/db
+    readOnly: true
+```
+
+### Azure — AKS Workload Identity (`azure_entra`)
+
+AKS workload identity needs **both** the ServiceAccount annotation and
+a pod label so the webhook injects the projected federated token.
+
+```yaml
+serviceAccount:
+  create: true
+  annotations:
+    azure.workload.identity/client-id: <client-id>
+
+podLabels:
+  azure.workload.identity/use: "true"
+
+target:
+  host: myserver.postgres.database.azure.com
+  dbname: appdb
+  user: arq_signals                 # must equal the Entra principal name
+  authMethod: azure_entra
+  azureClientId: <client-id>        # optional; user-assigned MI disambiguation
+  sslmode: verify-full
+  sslRootCertFile: /etc/ssl/db/DigiCertGlobalRootCA.crt.pem
+
+extraVolumes:
+  - name: db-ca
+    secret:
+      secretName: azure-db-ca
+extraVolumeMounts:
+  - name: db-ca
+    mountPath: /etc/ssl/db
+    readOnly: true
+```
+
+### `secret_store` — password in a cloud vault
+
+Use any of the platform identity bindings above (IRSA / Pod Identity /
+GKE WI / AKS WI) to authorize the vault read, then point `secretRef` at
+the secret. The backend is inferred from the `secretRef` shape.
+
+```yaml
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::<account>:role/arq-signals-vault
+
+target:
+  host: db.internal
+  dbname: appdb
+  user: arq_signals
+  authMethod: secret_store
+  secretRef: arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/arq_signals-AbCdEf
+  sslmode: verify-full
+  sslRootCertFile: /etc/ssl/db/ca.pem
+# ... extraVolumes / extraVolumeMounts for the CA bundle
+```
+
+## CA bundles for `verify-full`
+
+`verify-full` needs a CA bundle on disk. Mount it with `extraVolumes` /
+`extraVolumeMounts` (from a Secret or ConfigMap — never inline secrets
+in values) and set `target.sslRootCertFile` to the mount path. In
+`prod`, a cloud method without `sslRootCertFile` fails at startup.

--- a/deploy/helm/arq-signals/templates/configmap.yaml
+++ b/deploy/helm/arq-signals/templates/configmap.yaml
@@ -18,3 +18,44 @@ data:
       wal: true
     api:
       listen_addr: "0.0.0.0:{{ .Values.api.port }}"
+    {{- if .Values.target.host }}
+    {{- /*
+      #114 — single target rendered into the mounted config. The
+      collector reads auth_method and the cloud parameters
+      (region / azure_client_id / gcp_impersonate_service_account /
+      secret_ref) ONLY from this YAML block; the env single-target
+      builder does not populate them (internal/config/config.go).
+      Optional fields render only when set so the default password
+      target stays byte-for-byte minimal.
+    */}}
+    targets:
+      - name: default
+        host: {{ .Values.target.host }}
+        port: {{ .Values.target.port }}
+        dbname: {{ .Values.target.dbname }}
+        user: {{ .Values.target.user }}
+        sslmode: {{ .Values.target.sslmode }}
+        {{- with .Values.target.sslRootCertFile }}
+        sslrootcert_file: {{ . }}
+        {{- end }}
+        {{- with .Values.target.authMethod }}
+        auth_method: {{ . }}
+        {{- end }}
+        {{- with .Values.target.region }}
+        region: {{ . }}
+        {{- end }}
+        {{- with .Values.target.azureClientId }}
+        azure_client_id: {{ . }}
+        {{- end }}
+        {{- with .Values.target.gcpImpersonateServiceAccount }}
+        gcp_impersonate_service_account: {{ . }}
+        {{- end }}
+        {{- with .Values.target.secretRef }}
+        secret_ref: {{ . }}
+        {{- end }}
+        {{- /* Password source only for the default (password) method —
+               token/secret methods are passwordless (FC005). */}}
+        {{- if and (not .Values.target.authMethod) .Values.target.passwordSecretName }}
+        password_env: PG_PASSWORD
+        {{- end }}
+    {{- end }}

--- a/deploy/helm/arq-signals/templates/deployment.yaml
+++ b/deploy/helm/arq-signals/templates/deployment.yaml
@@ -16,6 +16,12 @@ spec:
       labels:
         app.kubernetes.io/name: arq-signals
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- /* #114: AKS workload identity needs the pod to carry
+              azure.workload.identity/use: "true" so the webhook injects
+              the projected federated token. */}}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Release.Name }}-arq-signals
@@ -44,16 +50,12 @@ spec:
           env:
             - name: ARQ_ENV
               value: {{ .Values.env | quote }}
-            - name: ARQ_SIGNALS_TARGET_HOST
-              value: {{ .Values.target.host | quote }}
-            - name: ARQ_SIGNALS_TARGET_PORT
-              value: {{ .Values.target.port | quote }}
-            - name: ARQ_SIGNALS_TARGET_DBNAME
-              value: {{ .Values.target.dbname | quote }}
-            - name: ARQ_SIGNALS_TARGET_USER
-              value: {{ .Values.target.user | quote }}
-            - name: ARQ_SIGNALS_TARGET_SSLMODE
-              value: {{ .Values.target.sslmode | quote }}
+            {{- /* #114: the target (host/port/dbname/user/sslmode AND
+                  auth_method + cloud params) is delivered through the
+                  mounted signals.yaml `targets:` block, not env — the
+                  collector only reads auth_method from YAML. Env target
+                  vars are intentionally not set here to avoid a
+                  duplicate target. */}}
             - name: ARQ_SIGNALS_POLL_INTERVAL
               value: {{ .Values.collector.pollInterval | quote }}
             - name: ARQ_SIGNALS_RETENTION_DAYS
@@ -64,9 +66,12 @@ spec:
               value: {{ .Values.collector.queryTimeout | quote }}
             - name: ARQ_SIGNALS_LISTEN_ADDR
               value: "0.0.0.0:{{ .Values.api.port }}"
-            {{- if .Values.target.passwordSecretName }}
-            - name: ARQ_SIGNALS_TARGET_PASSWORD_ENV
-              value: PG_PASSWORD
+            {{- /* #114: password source only for the default (password)
+                  method. Token/secret methods are passwordless (FC005) —
+                  no PG_PASSWORD is injected even if a secret name leaks
+                  through values. The configmap renders password_env
+                  under the same guard, so the two stay in lockstep. */}}
+            {{- if and (not .Values.target.authMethod) .Values.target.passwordSecretName }}
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -92,6 +97,12 @@ spec:
               readOnly: true
             - name: data
               mountPath: /data
+            {{- /* #114: operator-supplied mounts, e.g. a CA bundle for
+                  sslmode: verify-full (point target.sslRootCertFile at
+                  the mount path). */}}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -117,3 +128,6 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/deploy/helm/arq-signals/values.yaml
+++ b/deploy/helm/arq-signals/values.yaml
@@ -5,14 +5,40 @@ image:
   tag: "0.10.0-beta.5"
   pullPolicy: IfNotPresent
 
-# PostgreSQL target configuration
+# PostgreSQL target configuration. Rendered into the mounted
+# signals.yaml ConfigMap as a single `targets:` entry (the collector
+# reads auth_method and the cloud parameters only from that block, not
+# from env — internal/config/config.go). No target block is emitted
+# until `host` is set.
 target:
   host: ""           # Required: PostgreSQL hostname
   port: 5432
   dbname: postgres
   user: arq_signals
-  sslmode: prefer
-  # Credential source (choose one):
+  sslmode: prefer    # token methods (below) require verify-full (FC006)
+
+  # Passwordless cloud auth (#93 credential-providers; recipe:
+  # docs/database-connections.md). Leave authMethod empty for the
+  # default password method. Token/secret methods are passwordless —
+  # do NOT set passwordSecretName with them (FC005) — and require
+  # sslmode: verify-full in every environment (FC006). The collector's
+  # ambient cloud identity (IRSA / Pod Identity / Workload Identity)
+  # mints the credential; see deploy/helm/arq-signals/README.md for
+  # per-platform values snippets.
+  authMethod: ""     # "" | aws_rds_iam | azure_entra | gcp_cloudsql_iam | secret_store
+  region: ""         # aws_rds_iam: optional (also read from AWS_REGION / IMDS)
+  azureClientId: ""  # azure_entra: optional user-assigned MI disambiguation (also AZURE_CLIENT_ID)
+  gcpImpersonateServiceAccount: ""  # gcp_cloudsql_iam: optional impersonation target
+  secretRef: ""      # secret_store: cloud vault reference (NOT a secret — an ARN/URI/name)
+
+  # verify-full needs a CA bundle. Mount it via extraVolumes /
+  # extraVolumeMounts (below) and point this at the mounted path. In
+  # `prod`, verify-ca/verify-full hard-require this (config.go prod-TLS gate).
+  sslRootCertFile: ""
+
+  # Password method only (authMethod empty). The Secret is referenced
+  # by name; the password never lands in a ConfigMap or rendered
+  # manifest beyond the Secret reference (injected as PG_PASSWORD).
   passwordSecretName: ""    # Kubernetes secret containing the password
   passwordSecretKey: password
 
@@ -71,7 +97,34 @@ env: dev
 # affordance. Disable only if your platform mandates a shared SA.
 serviceAccount:
   create: true
-  annotations: {}     # e.g. for IRSA / Workload Identity
+  # Per-platform identity binding (#114). Examples:
+  #   IRSA:        eks.amazonaws.com/role-arn: arn:aws:iam::<acct>:role/<role>
+  #   GKE WI:      iam.gke.io/gcp-service-account: <gsa>@<proj>.iam.gserviceaccount.com
+  #   AKS WI:      azure.workload.identity/client-id: <client-id>
+  #   EKS Pod ID:  (no annotation — the association is created out-of-band)
+  annotations: {}
+
+# Pod template labels (#114). AKS workload identity requires the POD
+# to carry `azure.workload.identity/use: "true"` so the webhook injects
+# the projected federated token. e.g.:
+#   podLabels:
+#     azure.workload.identity/use: "true"
+podLabels: {}
+
+# Extra volumes / mounts (#114). Use to mount a CA bundle for
+# sslmode: verify-full (set target.sslRootCertFile to the mount path),
+# or any other operator-supplied file. No secrets in values — mount a
+# Secret/ConfigMap by reference. e.g.:
+#   extraVolumes:
+#     - name: db-ca
+#       secret:
+#         secretName: db-ca-bundle
+#   extraVolumeMounts:
+#     - name: db-ca
+#       mountPath: /etc/ssl/db
+#       readOnly: true
+extraVolumes: []
+extraVolumeMounts: []
 
 # NetworkPolicy (#140). Opt-in. When enabled, the policy denies
 # all ingress + egress by default and explicitly allows:

--- a/tests/signals_helm_passwordless_auth_test.go
+++ b/tests/signals_helm_passwordless_auth_test.go
@@ -1,0 +1,191 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+)
+
+// #114 — the Helm chart wires passwordless cloud auth. The collector
+// only reads auth_method (and region / azure_client_id /
+// gcp_impersonate_service_account / secret_ref) from the YAML
+// `targets:` block — the env single-target builder in
+// internal/config/config.go does NOT populate those fields. So the
+// chart must render the target into the mounted ConfigMap, and the
+// auth settings must reach that rendered collector config.
+//
+// These tests assert the rendered manifest stream carries each
+// supported auth_method end-to-end, honours the credential-providers
+// invariants (FC005 passwordless methods carry no password source;
+// FC006 cloud methods use sslmode=verify-full), and exposes the
+// per-platform identity hooks (ServiceAccount annotations for
+// IRSA / GKE WI / AKS WI, pod labels for AKS workload identity).
+
+// targetHost is the minimal --set that makes the chart render a
+// `targets:` block at all (parity with the env builder, which only
+// appended a target when ARQ_SIGNALS_TARGET_HOST was non-empty).
+const targetHost = "target.host=db.internal"
+
+func TestHelm_DefaultRenderHasNoTargetsBlock(t *testing.T) {
+	// With no target.host the chart must not emit a targets block,
+	// exactly as the env builder added no target for an empty host.
+	out := renderHelm(t)
+	if strings.Contains(out, "targets:") {
+		t.Errorf("default render (empty target.host) should emit no targets block:\n%s", out)
+	}
+}
+
+func TestHelm_TargetRendersIntoConfigMap(t *testing.T) {
+	out := renderHelm(t, targetHost)
+	for _, want := range []string{"targets:", "name: default", "host: db.internal"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered config missing %q (target not wired into ConfigMap):\n%s", want, out)
+		}
+	}
+}
+
+func TestHelm_PasswordMethodRendersPasswordEnv(t *testing.T) {
+	// Default (empty) auth_method is password: the rendered target
+	// references the secret-injected PG_PASSWORD via password_env, and
+	// no auth_method key is emitted.
+	out := renderHelm(t, targetHost, "target.passwordSecretName=pg-cred")
+	if !strings.Contains(out, "password_env: PG_PASSWORD") {
+		t.Errorf("password method should wire password_env: PG_PASSWORD:\n%s", out)
+	}
+	if !strings.Contains(out, "secretKeyRef") || !strings.Contains(out, "name: pg-cred") {
+		t.Errorf("password method should inject PG_PASSWORD from the named secret:\n%s", out)
+	}
+	if strings.Contains(out, "auth_method:") {
+		t.Errorf("default password method must not emit an auth_method key:\n%s", out)
+	}
+}
+
+func TestHelm_AWSRDSIAMReachesConfig(t *testing.T) {
+	out := renderHelm(t,
+		targetHost,
+		"target.authMethod=aws_rds_iam",
+		"target.sslmode=verify-full",
+		"target.region=us-east-1",
+	)
+	for _, want := range []string{
+		"auth_method: aws_rds_iam",
+		"sslmode: verify-full",
+		"region: us-east-1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("aws_rds_iam config missing %q:\n%s", want, out)
+		}
+	}
+	// FC005: passwordless — no password source may be rendered.
+	if strings.Contains(out, "password_env") {
+		t.Errorf("aws_rds_iam is passwordless; password_env must not render (FC005):\n%s", out)
+	}
+}
+
+func TestHelm_AzureEntraReachesConfig(t *testing.T) {
+	out := renderHelm(t,
+		targetHost,
+		"target.authMethod=azure_entra",
+		"target.sslmode=verify-full",
+		"target.azureClientId=00000000-0000-0000-0000-000000000000",
+	)
+	for _, want := range []string{
+		"auth_method: azure_entra",
+		"azure_client_id: 00000000-0000-0000-0000-000000000000",
+		"sslmode: verify-full",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("azure_entra config missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHelm_GCPCloudSQLIAMReachesConfig(t *testing.T) {
+	out := renderHelm(t,
+		targetHost,
+		"target.authMethod=gcp_cloudsql_iam",
+		"target.sslmode=verify-full",
+		"target.gcpImpersonateServiceAccount=collector@my-proj.iam.gserviceaccount.com",
+	)
+	for _, want := range []string{
+		"auth_method: gcp_cloudsql_iam",
+		"gcp_impersonate_service_account: collector@my-proj.iam.gserviceaccount.com",
+		"sslmode: verify-full",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("gcp_cloudsql_iam config missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHelm_SecretStoreReachesConfig(t *testing.T) {
+	out := renderHelm(t,
+		targetHost,
+		"target.authMethod=secret_store",
+		"target.sslmode=verify-full",
+		"target.secretRef=arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/arq_signals-AbCdEf",
+	)
+	for _, want := range []string{
+		"auth_method: secret_store",
+		"secret_ref: arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/arq_signals-AbCdEf",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("secret_store config missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "password_env") {
+		t.Errorf("secret_store is passwordless; password_env must not render (FC005):\n%s", out)
+	}
+}
+
+func TestHelm_ServiceAccountAnnotationsRender(t *testing.T) {
+	// IRSA / GKE Workload Identity bind the cloud identity through a
+	// ServiceAccount annotation. The chart already exposes
+	// serviceAccount.annotations; verify it reaches the SA resource.
+	out := renderHelm(t,
+		`serviceAccount.annotations.eks\.amazonaws\.com/role-arn=arn:aws:iam::111122223333:role/arq-signals-irsa`,
+	)
+	if !strings.Contains(out, "eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/arq-signals-irsa") {
+		t.Errorf("IRSA role-arn annotation not rendered on the ServiceAccount:\n%s", out)
+	}
+}
+
+func TestHelm_PodLabelsRenderForAzureWorkloadIdentity(t *testing.T) {
+	// AKS workload identity requires the pod itself to carry
+	// azure.workload.identity/use: "true" so the webhook injects the
+	// projected token. The chart exposes podLabels for this.
+	out := renderHelm(t,
+		`podLabels.azure\.workload\.identity/use=true`,
+	)
+	if !strings.Contains(out, "azure.workload.identity/use:") {
+		t.Errorf("podLabels not rendered on the pod template (AKS workload identity needs it):\n%s", out)
+	}
+}
+
+func TestHelm_ExtraVolumesAndMountsRender(t *testing.T) {
+	// verify-full needs a CA bundle; operators mount it via
+	// extraVolumes/extraVolumeMounts (e.g. a Secret holding the CA).
+	out := renderHelm(t,
+		"extraVolumes[0].name=ca",
+		"extraVolumes[0].secret.secretName=db-ca",
+		"extraVolumeMounts[0].name=ca",
+		"extraVolumeMounts[0].mountPath=/etc/ssl/db",
+	)
+	for _, want := range []string{"name: ca", "secretName: db-ca", "mountPath: /etc/ssl/db"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("extraVolumes/extraVolumeMounts not wired: missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHelm_TokenMethodShipsNoSecret(t *testing.T) {
+	// A token-auth install with no passwordSecretName must not emit a
+	// Secret-bound PG_PASSWORD anywhere (no secrets in values, INV001/2).
+	out := renderHelm(t,
+		targetHost,
+		"target.authMethod=aws_rds_iam",
+		"target.sslmode=verify-full",
+	)
+	if strings.Contains(out, "PG_PASSWORD") {
+		t.Errorf("token method with no password secret must not reference PG_PASSWORD:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

The collector reads `auth_method` and the cloud parameters (`region` / `azure_client_id` / `gcp_impersonate_service_account` / `secret_ref`) **only** from the YAML `targets:` block, never from env (`internal/config/config.go`). The chart previously delivered the single target purely through `ARQ_SIGNALS_TARGET_*` env vars, so a passwordless cloud method could not be configured through Helm at all.

This PR:

- Renders the target into the mounted `signals.yaml` ConfigMap and removes the env target injection (no duplicate target).
- Exposes the cloud auth knobs on `target.*`: `authMethod`, `region`, `azureClientId`, `gcpImpersonateServiceAccount`, `secretRef`, `sslRootCertFile`.
- Adds the platform identity hooks: `serviceAccount.annotations` (IRSA / GKE WI / AKS WI), `podLabels` (AKS workload identity), `extraVolumes` / `extraVolumeMounts` (CA bundles for `verify-full`).
- Adds `deploy/helm/arq-signals/README.md` with EKS IRSA, EKS Pod Identity, GKE Workload Identity, AKS Workload Identity, and `secret_store` values snippets.

## Invariants (kept in lockstep across ConfigMap + Deployment)

- **FC005** — `password_env` / `PG_PASSWORD` render only for the default password method (`authMethod` empty). A `passwordSecretName` set alongside a cloud method is ignored in both templates.
- **FC006** — cloud methods use `sslmode: verify-full`; the prod TLS gate needs `sslRootCertFile` mounted via `extraVolumes`.

## Tests

`tests/signals_helm_passwordless_auth_test.go` renders the chart and asserts each `auth_method` (password, `aws_rds_iam`, `azure_entra`, `gcp_cloudsql_iam`, `secret_store`) reaches the collector config end-to-end, that the passwordless invariants hold, and that the per-platform identity hooks render. Written red-first; all pass with the implementation.

Full preflight passes except `govulncheck`, which fails only on the two pre-existing stdlib CVEs (`net/textproto`, `crypto/x509`, fixed in go1.26.4) — the documented toolchain blocker, unrelated to this change (no Go source touched beyond the new test).

resolves #114