### PR TITLE
Bump Go toolchain to 1.26.4 to clear govulncheck stdlib CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.26.4"
           cache: true
 
       - name: Download modules
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.26.4"
           cache-dependency-path: go.sum
 
       - name: Trivy filesystem scan (vuln + secret)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.26.4"
           cache: true
 
       - name: Download modules
@@ -444,7 +444,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.26.4"
           cache: true
 
       - name: Build binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.25.11-alpine@sha256:4e4bc7d311e0313d8a562972e78ba15abaa9faf63d3fc39200147d320fceaad6 AS builder
+FROM golang:1.26.4-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14 AS builder
 
 RUN apk add --no-cache git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elevarq/arq-signals
 
-go 1.25.11
+go 1.26.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0


### PR DESCRIPTION
## Summary

`govulncheck` flagged two **reachable** stdlib CVEs present on `main` (not introduced by any feature PR):

- **GO-2026-5039** — `net/textproto`: arbitrary inputs included in errors without escaping. Reached via `api.Server.Start` → `http.Server.Serve` → `textproto.Reader.ReadMIMEHeader`.
- **GO-2026-5037** — `crypto/x509`: inefficient candidate hostname parsing. Reached via the same server path and `doctor.CheckCollectorPrerequisites`.

Both are fixed in the Go **1.26.4** standard library. This PR bumps the toolchain consistently across every pin site.

## Changes

| Pin site | From | To |
|---|---|---|
| `go.mod` go directive | `1.25.11` | `1.26.4` |
| `.github/workflows/ci.yml` (×2) | `1.25.11` | `1.26.4` |
| `.github/workflows/release.yml` (×2) | `1.25.11` | `1.26.4` |
| `Dockerfile` builder base | `golang:1.25.11-alpine@sha256:4e4bc7d3…` | `golang:1.26.4-alpine@sha256:f1ddd9fe…` |

No application code changes.

## Verification

Full local preflight passes under go1.26.4 — gofmt, vet, build, `go test -race`, gitleaks, **govulncheck (No vulnerabilities found)**, semgrep, osv-scanner, kube-lint, golangci-lint.

## Acceptance (#109)

- [x] Toolchain version consistently updated (go.mod + CI + Docker)
- [x] CI uses the same Go version
- [x] Docker/release builds use the same Go version
- [x] govulncheck no longer reports the stdlib CVEs
- [x] No unrelated code changes

resolves #109