### PR TITLE
Add Azure passwordless onboarding templates (Bicep + Terraform)

### DIFF
--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -1,0 +1,115 @@
+# Azure onboarding — passwordless Elevarq Signals on Flexible Server
+
+Stands up a least-privilege, **passwordless** Signals collector against Azure
+Database for PostgreSQL Flexible Server using `auth_method: azure_entra`. The
+collector VM's **user-assigned managed identity** mints a short-lived Entra
+OAuth2 token at connect time — **no password is stored anywhere**
+(INV001/INV002), and the connection is `verify-full` (INV003).
+
+Two equivalent implementations:
+
+- [`terraform/`](terraform/) — `terraform apply`
+- [`bicep/main.bicep`](bicep/main.bicep) — `az deployment group create`
+
+Both provision the user-assigned managed identity, a NIC on an existing
+subnet, and a Linux VM running the collector pre-wired for `azure_entra`. See
+[`docs/database-connections.md`](../../docs/database-connections.md) for the
+full `auth_method` reference.
+
+## Prerequisites
+
+- An Azure Database for PostgreSQL **Flexible Server** with **Microsoft Entra
+  authentication** enabled and an Entra administrator configured.
+- An existing VNet/subnet that routes to the server (the server's firewall /
+  private access must allow the collector subnet).
+- The `azure_client_id` of the created identity is produced as an output — you
+  do not supply it.
+
+## Step 1 — Identity + database principal (one-time)
+
+Apply the module first so the managed identity exists, then map it. The PG
+principal name **must equal the managed identity display name**
+(`<name_prefix>-collector`, default `arq-signals-collector`).
+
+Run once against the target database, **as an Entra administrator**:
+
+```sql
+-- name MUST equal the managed identity display name
+SELECT * FROM pgaadauth_create_principal('arq-signals-collector', false, false);
+GRANT pg_monitor TO "arq-signals-collector";   -- least-privilege read-only monitoring
+```
+
+See [`docs/postgres-role.md`](../../docs/postgres-role.md) for the role
+rationale and [`docs/database-connections.md`](../../docs/database-connections.md)
+(the `azure_entra` section) for the Entra mapping detail.
+
+## Step 2a — Terraform
+
+```bash
+cd terraform
+terraform init
+terraform apply \
+  -var resource_group_name=my-rg \
+  -var location=westeurope \
+  -var db_host=myserver.postgres.database.azure.com \
+  -var db_name=appdb \
+  -var subnet_id=/subscriptions/<sub>/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/collector \
+  -var 'admin_ssh_public_key=ssh-ed25519 AAAA... you@example.com'
+```
+
+`terraform output collector_identity_name` prints the exact name to use in
+Step 1.
+
+## Step 2b — Bicep
+
+```bash
+# edit bicep/main.bicepparam first (dbHost, dbName, subnetId, adminSshPublicKey)
+az deployment group create \
+  --resource-group my-rg \
+  --template-file bicep/main.bicep \
+  --parameters bicep/main.bicepparam
+```
+
+The deployment emits `collectorIdentityName` and `collectorIdentityClientId`
+as outputs.
+
+## Verify (live)
+
+Live verification provisions real infrastructure and is operator-gated — it is
+not part of default CI (mirrors the provider live smokes, #95). After
+apply/deploy, SSH to the collector VM:
+
+```bash
+# the collector container should be running and collecting
+docker logs arq-signals 2>&1 | grep -iE "collector|snapshot|connected"
+# trigger an export to confirm a successful passwordless connection
+docker exec arq-signals arqctl export --output /data/snapshot.zip
+```
+
+A healthy run connects with **no password in config**, mints a token from the
+managed identity, and collects at least one snapshot. If the connection is
+rejected, re-check Step 1 (principal name == identity display name) and that
+the server's network rules admit the collector subnet.
+
+## Security notes
+
+- **No secrets** in any input or on disk — the token is minted from the
+  managed identity at connect time and never persisted. The SSH public key is
+  a public credential, not a secret.
+- The VM uses **SSH key auth only** (`disablePasswordAuthentication: true`).
+- The identity is **user-assigned and dedicated** to the collector; scope its
+  database grant to `pg_monitor` only.
+- TLS is **`verify-full`** against the Azure CA bundle (fetched to
+  `/etc/arq/azure-ca.pem`); override `db_ca_cert_url` / `dbCaCertUrl` if your
+  server chains to a different root.
+- The API listener binds to `127.0.0.1` only.
+- Network egress is governed by the **subnet's NSG** by default. To pin a
+  NIC-level NSG (allowing only egress to the DB on `db_port`), pass
+  `network_security_group_id` / `networkSecurityGroupId`.
+
+## Reusing the identity elsewhere
+
+If you run the collector on AKS instead of the bundled VM, take the
+`collector_identity_client_id` output and wire it through workload identity —
+see the Helm chart (`deploy/helm/arq-signals/`) and its `azure_entra` /
+AKS-workload-identity snippet (#114).

--- a/deploy/azure/bicep/main.bicep
+++ b/deploy/azure/bicep/main.bicep
@@ -1,0 +1,166 @@
+// Azure passwordless onboarding for Elevarq Signals (#112).
+//
+// Provisions a user-assigned managed identity for the collector and runs the
+// collector on a Linux VM pre-wired for auth_method: azure_entra over
+// verify-full TLS. The credential is a short-lived Entra OAuth2 token minted
+// from the managed identity at connect time — no password is stored anywhere
+// (INV001/INV002).
+//
+// The DB-side mapping (pgaadauth_create_principal + GRANT pg_monitor) is a
+// one-time SQL step run as an Entra administrator; the PG principal name MUST
+// equal the managed identity display name. See ../README.md.
+//
+// Deploy at resource-group scope:
+//   az deployment group create -g <rg> -f main.bicep -p main.bicepparam
+
+targetScope = 'resourceGroup'
+
+@description('Azure region for the collector resources. Defaults to the resource group location.')
+param location string = resourceGroup().location
+
+@description('Prefix for created resource names. The managed identity name (= prefix + "-collector") MUST equal the PG principal created with pgaadauth_create_principal.')
+param namePrefix string = 'arq-signals'
+
+@description('Flexible Server endpoint hostname (e.g. myserver.postgres.database.azure.com).')
+param dbHost string
+
+@description('PostgreSQL port.')
+param dbPort int = 5432
+
+@description('Database name to connect to.')
+param dbName string
+
+@description('Resource ID of an existing subnet for the collector NIC (must route to the Flexible Server).')
+param subnetId string
+
+@description('Optional NSG resource ID to associate with the collector NIC (must allow egress to the DB on dbPort). Leave empty to rely on the subnet NSG.')
+param networkSecurityGroupId string = ''
+
+@description('VM size for the collector.')
+param vmSize string = 'Standard_B1s'
+
+@description('Admin user for the collector VM (SSH key auth only; password auth is disabled).')
+param adminUsername string = 'azureuser'
+
+@description('SSH public key for the collector VM admin user. A public key is not a secret (INV001/INV002).')
+param adminSshPublicKey string
+
+@description('Elevarq Signals container image (pinned tag).')
+param imageUri string = 'ghcr.io/elevarq/arq-signals:0.10.0-beta.5'
+
+@description('URL of the CA bundle for sslmode=verify-full. Default is the DigiCert Global Root G2 that Azure Database for PostgreSQL Flexible Server chains to.')
+param dbCaCertUrl string = 'https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem'
+
+@description('Signals environment (prod enforces verify-full TLS).')
+param arqEnv string = 'prod'
+
+@description('Collection interval.')
+param pollInterval string = '5m'
+
+@description('Extra tags applied to created resources.')
+param tags object = {}
+
+// The managed identity display name == the PG principal name (azure_entra
+// requires user == Entra principal display name).
+var identityName = '${namePrefix}-collector'
+
+var commonTags = union({ 'app.kubernetes.io/name': 'arq-signals', 'managed-by': 'bicep' }, tags)
+
+resource collectorIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: identityName
+  location: location
+  tags: commonTags
+}
+
+// cloud-init for the collector VM. Bicep multi-line strings do not interpolate,
+// so this is a single interpolated string with \n line breaks.
+var cloudInit ='#!/bin/bash\nset -euo pipefail\napt-get update -y\napt-get install -y docker.io curl\nsystemctl enable --now docker\nmkdir -p /etc/arq\n# Azure Flexible Server CA bundle for sslmode=verify-full.\ncurl -fsSL ${dbCaCertUrl} -o /etc/arq/azure-ca.pem\ncat > /etc/arq/signals.yaml <<\'YAML\'\nenv: ${arqEnv}\nsignals:\n  poll_interval: ${pollInterval}\ndatabase:\n  path: /data/arq-signals.db\n  wal: true\napi:\n  listen_addr: "127.0.0.1:8081"\ntargets:\n  - name: ${dbName}-azure\n    host: ${dbHost}\n    port: ${dbPort}\n    dbname: ${dbName}\n    user: ${identityName}\n    auth_method: azure_entra\n    azure_client_id: ${collectorIdentity.properties.clientId}\n    sslmode: verify-full\n    sslrootcert_file: /etc/arq/azure-ca.pem\nYAML\ndocker run -d --name arq-signals --restart=always -e AZURE_CLIENT_ID=${collectorIdentity.properties.clientId} -v /etc/arq:/etc/arq:ro -v arq-data:/data -p 127.0.0.1:8081:8081 ${imageUri} --config /etc/arq/signals.yaml\n'
+
+resource nic 'Microsoft.Network/networkInterfaces@2023-09-01' = {
+  name: '${namePrefix}-collector-nic'
+  location: location
+  tags: commonTags
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'internal'
+        properties: {
+          subnet: {
+            id: subnetId
+          }
+          privateIPAllocationMethod: 'Dynamic'
+        }
+      }
+    ]
+    networkSecurityGroup: empty(networkSecurityGroupId) ? null : {
+      id: networkSecurityGroupId
+    }
+  }
+}
+
+resource vm 'Microsoft.Compute/virtualMachines@2024-03-01' = {
+  name: '${namePrefix}-collector'
+  location: location
+  tags: commonTags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${collectorIdentity.id}': {}
+    }
+  }
+  properties: {
+    hardwareProfile: {
+      vmSize: vmSize
+    }
+    osProfile: {
+      computerName: '${namePrefix}-collector'
+      adminUsername: adminUsername
+      customData: base64(cloudInit)
+      linuxConfiguration: {
+        disablePasswordAuthentication: true
+        ssh: {
+          publicKeys: [
+            {
+              path: '/home/${adminUsername}/.ssh/authorized_keys'
+              keyData: adminSshPublicKey
+            }
+          ]
+        }
+      }
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: 'Canonical'
+        offer: 'ubuntu-24_04-lts'
+        sku: 'server'
+        version: 'latest'
+      }
+      osDisk: {
+        createOption: 'FromImage'
+        caching: 'ReadWrite'
+        managedDisk: {
+          storageAccountType: 'Standard_LRS'
+        }
+      }
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: nic.id
+        }
+      ]
+    }
+  }
+}
+
+@description('Managed identity display name — create the PG principal with this exact name (pgaadauth_create_principal).')
+output collectorIdentityName string = collectorIdentity.name
+
+@description('Managed identity client ID — the azure_client_id the collector uses to select this identity.')
+output collectorIdentityClientId string = collectorIdentity.properties.clientId
+
+@description('Managed identity principal (object) ID.')
+output collectorIdentityPrincipalId string = collectorIdentity.properties.principalId
+
+@description('Collector VM resource ID.')
+output vmId string = vm.id

--- a/deploy/azure/bicep/main.bicepparam
+++ b/deploy/azure/bicep/main.bicepparam
@@ -1,0 +1,9 @@
+// Example parameters for the Azure passwordless onboarding (#112).
+// No secrets here — adminSshPublicKey is a public key, not a secret.
+// Copy and edit, then: az deployment group create -g <rg> -f main.bicep -p main.bicepparam
+using './main.bicep'
+
+param dbHost = 'myserver.postgres.database.azure.com'
+param dbName = 'appdb'
+param subnetId = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/collector'
+param adminSshPublicKey = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... you@example.com'

--- a/deploy/azure/terraform/.gitignore
+++ b/deploy/azure/terraform/.gitignore
@@ -1,0 +1,9 @@
+# Terraform working files — never commit state or the provider cache.
+.terraform/
+*.tfstate
+*.tfstate.*
+.terraform.tfstate.lock.info
+crash.log
+*.tfvars
+# .terraform.lock.hcl IS committed (pins provider versions).
+!.terraform.lock.hcl

--- a/deploy/azure/terraform/.terraform.lock.hcl
+++ b/deploy/azure/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.117.1"
+  constraints = "~> 3.110"
+  hashes = [
+    "h1:j6wnjpHfBcQC4xd3ZYquaIPIIR46xJQs7rxwPdSOZos=",
+    "zh:0c513676836e3c50d004ece7d2624a8aff6faac14b833b96feeac2e4bc2c1c12",
+    "zh:50ea01ada95bae2f187db9e926e463f45d860767a85ebc59160414e00e76c35d",
+    "zh:52c2a9edacc06b3f72153f5ef6daca0761c6292158815961fe37f60bc576a3d7",
+    "zh:618eed2a06b19b1a025b45b05891846d570a6a1cca4d23f4942f5a99e1f747ae",
+    "zh:61cde5d3165d7e5ec311d5d89486819cd605c1b2d54611b5c97bd4e97dba2762",
+    "zh:6a873358d5031fc222f5e05f029d1237f3dce8345c767665f393283dfa2627f6",
+    "zh:afdd80064b2a04da311856feb4ed45f77ff4df6c356e8c2b10afb51fe7e61c70",
+    "zh:b09113df7e0e8c8959539bd22bae6c39faeb269ba3c4cd948e742f5cf58c35fb",
+    "zh:d340db7973109761cfc27d52aa02560363337c908b2c99b3628adc5a70a99d5b",
+    "zh:d5a577226ebc8c65e8f19384878a86acc4b51ede4b4a82d37c3b331b0efcd4a7",
+    "zh:e2962b147f9e71732df8dbc74940c10d20906f3c003cbfaa1eb9fabbf601a9f0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/deploy/azure/terraform/main.tf
+++ b/deploy/azure/terraform/main.tf
@@ -1,0 +1,129 @@
+# Azure passwordless onboarding for Elevarq Signals (#112).
+#
+# Provisions a user-assigned managed identity for the collector and runs the
+# collector on a Linux VM pre-wired for auth_method: azure_entra over
+# verify-full TLS. The credential is a short-lived Entra OAuth2 token minted
+# from the managed identity at connect time — no password is stored anywhere
+# (INV001/INV002).
+#
+# The DB-side mapping (pgaadauth_create_principal + GRANT pg_monitor) is a
+# one-time SQL step run as an Entra administrator; the PG principal name MUST
+# equal the managed identity display name. See ../README.md.
+
+data "azurerm_resource_group" "rg" {
+  name = var.resource_group_name
+}
+
+locals {
+  tags = merge({ "app.kubernetes.io/name" = "arq-signals", "managed-by" = "terraform" }, var.tags)
+
+  # The managed identity display name == the PG principal name (azure_entra
+  # requires user == Entra principal display name).
+  identity_name = "${var.name_prefix}-collector"
+
+  user_data = <<-EOT
+    #!/bin/bash
+    set -euo pipefail
+    apt-get update -y
+    apt-get install -y docker.io curl
+    systemctl enable --now docker
+    mkdir -p /etc/arq
+    # Azure Flexible Server CA bundle for sslmode=verify-full.
+    curl -fsSL ${var.db_ca_cert_url} -o /etc/arq/azure-ca.pem
+    cat > /etc/arq/signals.yaml <<'YAML'
+    env: ${var.arq_env}
+    signals:
+      poll_interval: ${var.poll_interval}
+    database:
+      path: /data/arq-signals.db
+      wal: true
+    api:
+      listen_addr: "127.0.0.1:8081"
+    targets:
+      - name: ${var.db_name}-azure
+        host: ${var.db_host}
+        port: ${var.db_port}
+        dbname: ${var.db_name}
+        user: ${local.identity_name}
+        auth_method: azure_entra
+        azure_client_id: ${azurerm_user_assigned_identity.collector.client_id}
+        sslmode: verify-full
+        sslrootcert_file: /etc/arq/azure-ca.pem
+    YAML
+    docker run -d --name arq-signals --restart=always \
+      -e AZURE_CLIENT_ID=${azurerm_user_assigned_identity.collector.client_id} \
+      -v /etc/arq:/etc/arq:ro \
+      -v arq-data:/data \
+      -p 127.0.0.1:8081:8081 \
+      ${var.image_uri} --config /etc/arq/signals.yaml
+  EOT
+}
+
+# --- Managed identity: the passwordless enabler -----------------------------
+
+resource "azurerm_user_assigned_identity" "collector" {
+  name                = local.identity_name
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = var.location
+  tags                = local.tags
+}
+
+# --- Collector compute ------------------------------------------------------
+
+resource "azurerm_network_interface" "collector" {
+  name                = "${var.name_prefix}-collector-nic"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = var.location
+  tags                = local.tags
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = var.subnet_id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "collector" {
+  count                     = var.network_security_group_id == "" ? 0 : 1
+  network_interface_id      = azurerm_network_interface.collector.id
+  network_security_group_id = var.network_security_group_id
+}
+
+resource "azurerm_linux_virtual_machine" "collector" {
+  name                = "${var.name_prefix}-collector"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = var.location
+  size                = var.vm_size
+  admin_username      = var.admin_username
+  network_interface_ids = [
+    azurerm_network_interface.collector.id,
+  ]
+  custom_data = base64encode(local.user_data)
+
+  admin_ssh_key {
+    username   = var.admin_username
+    public_key = var.admin_ssh_public_key
+  }
+
+  # No password auth — SSH key only.
+  disable_password_authentication = true
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.collector.id]
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
+    version   = "latest"
+  }
+
+  tags = local.tags
+}

--- a/deploy/azure/terraform/outputs.tf
+++ b/deploy/azure/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "collector_identity_name" {
+  description = "Managed identity display name — create the PG principal with this exact name (pgaadauth_create_principal)."
+  value       = azurerm_user_assigned_identity.collector.name
+}
+
+output "collector_identity_client_id" {
+  description = "Managed identity client ID — the azure_client_id the collector uses to select this identity."
+  value       = azurerm_user_assigned_identity.collector.client_id
+}
+
+output "collector_identity_principal_id" {
+  description = "Managed identity principal (object) ID."
+  value       = azurerm_user_assigned_identity.collector.principal_id
+}
+
+output "vm_id" {
+  description = "Collector VM resource ID."
+  value       = azurerm_linux_virtual_machine.collector.id
+}

--- a/deploy/azure/terraform/variables.tf
+++ b/deploy/azure/terraform/variables.tf
@@ -1,0 +1,94 @@
+# Inputs for the Azure passwordless (Entra ID) onboarding module (#112).
+# No secrets here — azure_entra mints a short-lived Entra OAuth2 token from
+# the collector VM's user-assigned managed identity (INV001/INV002). The SSH
+# public key is a public credential, not a secret.
+
+variable "resource_group_name" {
+  type        = string
+  description = "Existing resource group to create the collector resources in."
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the collector resources (e.g. westeurope)."
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for created resource names. The managed identity's name (= this prefix + '-collector') MUST equal the PG principal created with pgaadauth_create_principal."
+  default     = "arq-signals"
+}
+
+variable "db_host" {
+  type        = string
+  description = "Flexible Server endpoint hostname (e.g. myserver.postgres.database.azure.com)."
+}
+
+variable "db_port" {
+  type        = number
+  description = "PostgreSQL port."
+  default     = 5432
+}
+
+variable "db_name" {
+  type        = string
+  description = "Database name to connect to."
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "Resource ID of an existing subnet for the collector NIC (must route to the Flexible Server)."
+}
+
+variable "network_security_group_id" {
+  type        = string
+  description = "Optional NSG to associate with the collector NIC (must allow egress to the DB on db_port). Leave empty to rely on the subnet's NSG."
+  default     = ""
+}
+
+variable "vm_size" {
+  type        = string
+  description = "VM size for the collector."
+  default     = "Standard_B1s"
+}
+
+variable "admin_username" {
+  type        = string
+  description = "Admin user for the collector VM (SSH key auth only; password auth is disabled)."
+  default     = "azureuser"
+}
+
+variable "admin_ssh_public_key" {
+  type        = string
+  description = "SSH public key for the collector VM admin user. A public key is not a secret (INV001/INV002)."
+}
+
+variable "image_uri" {
+  type        = string
+  description = "Elevarq Signals container image (pinned tag)."
+  default     = "ghcr.io/elevarq/arq-signals:0.10.0-beta.5"
+}
+
+variable "db_ca_cert_url" {
+  type        = string
+  description = "URL of the CA bundle for sslmode=verify-full. Default is the DigiCert Global Root G2 that Azure Database for PostgreSQL Flexible Server chains to."
+  default     = "https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem"
+}
+
+variable "arq_env" {
+  type        = string
+  description = "Signals environment (prod enforces verify-full TLS)."
+  default     = "prod"
+}
+
+variable "poll_interval" {
+  type        = string
+  description = "Collection interval."
+  default     = "5m"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags applied to created resources."
+  default     = {}
+}

--- a/deploy/azure/terraform/versions.tf
+++ b/deploy/azure/terraform/versions.tf
@@ -1,0 +1,14 @@
+# Pinned provider + Terraform versions (#112). Bump deliberately.
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.110"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}


### PR DESCRIPTION
## Summary

Onboarding IaC for a **passwordless** Signals collector against Azure Database for PostgreSQL Flexible Server using `auth_method: azure_entra`. Mirrors the AWS template (#111) under `deploy/azure/`. Part of #100; consumes `features/arq-signals/credential-providers.md` (#93) and the `azure_entra` provider (#95).

Two equivalent implementations:
- `deploy/azure/terraform/` — `terraform apply`
- `deploy/azure/bicep/main.bicep` — `az deployment group create`

Both provision a **user-assigned managed identity**, a NIC on an existing subnet, and a Linux VM running the collector pre-wired for `azure_entra` over `verify-full` TLS. The credential is a short-lived Entra OAuth2 token minted from the managed identity at connect time — no password is stored anywhere. The DB-side mapping (`pgaadauth_create_principal` + `GRANT pg_monitor`) is a documented one-time SQL step; the PG principal name equals the managed identity display name.

## Acceptance (#112)

- [x] Parameterised, versions pinned (Terraform >= 1.5, `azurerm ~> 3.110` with committed lock file; pinned ARM API versions; pinned image tag)
- [x] **No secrets in inputs** (INV001/INV002) — the SSH public key is a public credential; the VM disables password auth
- [x] Static validation: `bicep build` + `build-params` clean, `terraform validate` + `fmt -check` pass
- [x] Documented, env-gated **live** procedure in `deploy/azure/README.md` (operator-run, mirrors #95)

## Security notes

- No secrets in any input or on disk; token minted from the managed identity at connect time and never persisted.
- VM uses SSH key auth only (`disablePasswordAuthentication: true`); API listener binds `127.0.0.1`.
- TLS `verify-full` against the Azure CA bundle (overridable via `db_ca_cert_url`).
- `gitleaks` clean. `trivy config` reports one MEDIUM (AZU-0068, NIC has no NSG): **by design** — network egress is governed by the operator's **subnet** NSG (the idiomatic Azure placement), with an optional `network_security_group_id` to pin a NIC-level NSG. The static scanner cannot see the subnet NSG or the conditional association.

resolves #112