### PR TITLE
Add GCP passwordless onboarding template (Terraform)

### DIFF
--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,0 +1,110 @@
+# GCP onboarding — passwordless Elevarq Signals on Cloud SQL
+
+Stands up a least-privilege, **passwordless** Signals collector against Cloud
+SQL for PostgreSQL using `auth_method: gcp_cloudsql_iam`. The collector VM's
+attached **service account** mints a short-lived Google OAuth2 token at connect
+time — **no password is stored anywhere** (INV001/INV002), and the connection
+is `verify-full` over the direct libpq path (INV003).
+
+- [`terraform/`](terraform/) — `terraform apply`
+
+Provisions a dedicated service account with `roles/cloudsql.instanceUser`,
+optionally the IAM DB user, and a GCE VM (no public IP) running the collector
+pre-wired for `gcp_cloudsql_iam`. See
+[`docs/database-connections.md`](../../docs/database-connections.md) for the
+full `auth_method` reference.
+
+## Prerequisites
+
+- A Cloud SQL for PostgreSQL instance with **IAM database authentication**
+  enabled (`cloudsql.iam_authentication = on`).
+- A VPC network + subnetwork that routes to the instance's **private IP** (the
+  direct libpq path needs private connectivity).
+- The instance's **server CA certificate** (public, not a secret):
+
+  ```bash
+  gcloud sql instances describe <instance> \
+    --format='value(serverCaCert.cert)' > server-ca.pem
+  ```
+
+## Step 1 — IAM DB user + grant (one-time)
+
+The module creates the service account and grants
+`roles/cloudsql.instanceUser`. The IAM DB user can be created by the module
+(set `instance_name`) or out-of-band:
+
+```bash
+# SA email without the .gserviceaccount.com suffix is the PG role name
+gcloud sql users create arq-signals-collector@<project>.iam.gserviceaccount.com \
+  --instance=<instance> --type=cloud_iam_service_account
+```
+
+Then grant least-privilege monitoring, **as a privileged role** on the target
+database (the role name is the SA email **without** `.gserviceaccount.com`):
+
+```sql
+GRANT pg_monitor TO "arq-signals-collector@<project>.iam";
+```
+
+`terraform output collector_db_user` prints the exact role name. See
+[`docs/postgres-role.md`](../../docs/postgres-role.md) for the role rationale.
+
+## Step 2 — Terraform
+
+```bash
+cd terraform
+terraform init
+terraform apply \
+  -var project_id=my-project \
+  -var region=europe-west1 \
+  -var zone=europe-west1-b \
+  -var db_host=10.0.0.5 \
+  -var db_name=appdb \
+  -var instance_name=my-instance \
+  -var network=projects/my-project/global/networks/my-vpc \
+  -var subnetwork=projects/my-project/regions/europe-west1/subnetworks/collector \
+  -var "db_server_ca_cert=$(cat server-ca.pem)"
+```
+
+To impersonate another service account, set
+`-var gcp_impersonate_service_account=collector@my-proj.iam.gserviceaccount.com`
+— the VM SA must hold **Service Account Token Creator** on it.
+
+## Verify (live)
+
+Live verification provisions real infrastructure and is operator-gated — it is
+not part of default CI (mirrors the provider live smokes, #96). After apply,
+SSH to the collector VM:
+
+```bash
+# the collector container should be running and collecting
+docker logs arq-signals 2>&1 | grep -iE "collector|snapshot|connected"
+# trigger an export to confirm a successful passwordless connection
+docker exec arq-signals arqctl export --output /data/snapshot.zip
+```
+
+A healthy run connects with **no password in config**, mints a token from the
+attached service account, and collects at least one snapshot. If the
+connection is rejected, re-check Step 1 (IAM DB user exists, `pg_monitor`
+granted to the truncated SA name) and that the VM's subnet routes to the
+instance private IP.
+
+## Security notes
+
+- **No secrets** in any input or on disk — the token is minted from the
+  attached service account at connect time and never persisted. The server CA
+  certificate is public information.
+- The service account is **dedicated** to the collector and granted only
+  `roles/cloudsql.instanceUser`. Add `roles/cloudsql.client` only if you front
+  the instance with the Cloud SQL connector.
+- The VM has **no public IP**, runs **Shielded VM** (secure boot + vTPM +
+  integrity monitoring), and the API listener binds to `127.0.0.1` only.
+- TLS is **`verify-full`** against the instance server CA (written to
+  `/etc/arq/cloudsql-ca.pem`).
+
+## Reusing the identity elsewhere
+
+If you run the collector on GKE instead of the bundled VM, take the
+`collector_service_account_email` output and bind it through Workload Identity
+— see the Helm chart (`deploy/helm/arq-signals/`) and its `gcp_cloudsql_iam` /
+GKE-workload-identity snippet (#114).

--- a/deploy/gcp/terraform/.gitignore
+++ b/deploy/gcp/terraform/.gitignore
@@ -1,0 +1,9 @@
+# Terraform working files — never commit state or the provider cache.
+.terraform/
+*.tfstate
+*.tfstate.*
+.terraform.tfstate.lock.info
+crash.log
+*.tfvars
+# .terraform.lock.hcl IS committed (pins provider versions).
+!.terraform.lock.hcl

--- a/deploy/gcp/terraform/.terraform.lock.hcl
+++ b/deploy/gcp/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.40"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/deploy/gcp/terraform/main.tf
+++ b/deploy/gcp/terraform/main.tf
@@ -1,0 +1,121 @@
+# GCP passwordless onboarding for Elevarq Signals (#113).
+#
+# Provisions a dedicated service account for the collector with
+# roles/cloudsql.instanceUser, optionally creates the IAM DB user, and runs
+# the collector on a GCE VM (with the SA attached) pre-wired for
+# auth_method: gcp_cloudsql_iam over verify-full TLS on the direct libpq path.
+# The credential is a short-lived Google OAuth2 token minted from the attached
+# service account at connect time — no password is stored anywhere
+# (INV001/INV002).
+#
+# The GRANT pg_monitor to the IAM user is a one-time SQL step; see ../README.md.
+
+locals {
+  labels = merge({ "app_kubernetes_io_name" = "arq-signals", "managed-by" = "terraform" }, var.labels)
+
+  # IAM DB user / PG role name = SA email without the .gserviceaccount.com
+  # suffix (Google's documented truncation).
+  pg_user = trimsuffix(google_service_account.collector.email, ".gserviceaccount.com")
+
+  impersonate_yaml = var.gcp_impersonate_service_account == "" ? "" : "\n        gcp_impersonate_service_account: ${var.gcp_impersonate_service_account}"
+
+  startup_script = <<-EOT
+    #!/bin/bash
+    set -euo pipefail
+    apt-get update -y
+    apt-get install -y docker.io
+    systemctl enable --now docker
+    mkdir -p /etc/arq
+    # Cloud SQL instance server CA for sslmode=verify-full (public certificate).
+    cat > /etc/arq/cloudsql-ca.pem <<'PEM'
+    ${var.db_server_ca_cert}
+    PEM
+    cat > /etc/arq/signals.yaml <<'YAML'
+    env: ${var.arq_env}
+    signals:
+      poll_interval: ${var.poll_interval}
+    database:
+      path: /data/arq-signals.db
+      wal: true
+    api:
+      listen_addr: "127.0.0.1:8081"
+    targets:
+      - name: ${var.db_name}-cloudsql
+        host: ${var.db_host}
+        port: ${var.db_port}
+        dbname: ${var.db_name}
+        user: "${local.pg_user}"
+        auth_method: gcp_cloudsql_iam${local.impersonate_yaml}
+        sslmode: verify-full
+        sslrootcert_file: /etc/arq/cloudsql-ca.pem
+    YAML
+    docker run -d --name arq-signals --restart=always \
+      -v /etc/arq:/etc/arq:ro \
+      -v arq-data:/data \
+      -p 127.0.0.1:8081:8081 \
+      ${var.image_uri} --config /etc/arq/signals.yaml
+  EOT
+}
+
+# --- Service account: the passwordless enabler ------------------------------
+
+resource "google_service_account" "collector" {
+  project      = var.project_id
+  account_id   = "${var.name_prefix}-collector"
+  display_name = "Elevarq Signals collector (passwordless Cloud SQL IAM)"
+}
+
+# Minimal role to authenticate to Cloud SQL as an IAM user.
+resource "google_project_iam_member" "instance_user" {
+  project = var.project_id
+  role    = "roles/cloudsql.instanceUser"
+  member  = "serviceAccount:${google_service_account.collector.email}"
+}
+
+# Optional: create the IAM DB user declaratively when the instance is known.
+resource "google_sql_user" "collector" {
+  count    = var.instance_name == "" ? 0 : 1
+  project  = var.project_id
+  name     = local.pg_user
+  instance = var.instance_name
+  type     = "CLOUD_IAM_SERVICE_ACCOUNT"
+}
+
+# --- Collector compute ------------------------------------------------------
+
+resource "google_compute_instance" "collector" {
+  project      = var.project_id
+  name         = "${var.name_prefix}-collector"
+  machine_type = var.machine_type
+  zone         = var.zone
+  labels       = local.labels
+
+  boot_disk {
+    initialize_params {
+      image = var.image
+    }
+  }
+
+  network_interface {
+    network    = var.network
+    subnetwork = var.subnetwork
+    # No access_config block => no public IP; reach Cloud SQL over private IP.
+  }
+
+  service_account {
+    email  = google_service_account.collector.email
+    scopes = ["cloud-platform"]
+  }
+
+  metadata = {
+    startup-script         = local.startup_script
+    enable-oslogin         = "TRUE"
+    block-project-ssh-keys = "TRUE"
+  }
+
+  shielded_instance_config {
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
+  }
+}

--- a/deploy/gcp/terraform/outputs.tf
+++ b/deploy/gcp/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "collector_service_account_email" {
+  description = "Service account the collector runs under (attach elsewhere / grant Cloud SQL access)."
+  value       = google_service_account.collector.email
+}
+
+output "collector_db_user" {
+  description = "IAM DB user / PG role name — GRANT pg_monitor to this (SA email without .gserviceaccount.com)."
+  value       = local.pg_user
+}
+
+output "instance_id" {
+  description = "Collector GCE instance id."
+  value       = google_compute_instance.collector.instance_id
+}

--- a/deploy/gcp/terraform/variables.tf
+++ b/deploy/gcp/terraform/variables.tf
@@ -1,0 +1,104 @@
+# Inputs for the GCP passwordless (Cloud SQL IAM) onboarding module (#113).
+# No secrets here — gcp_cloudsql_iam mints a short-lived Google OAuth2 token
+# from the collector VM's attached service account (INV001/INV002). The
+# server CA certificate is public, not a secret.
+
+variable "project_id" {
+  type        = string
+  description = "GCP project ID for the collector resources."
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region (e.g. europe-west1)."
+}
+
+variable "zone" {
+  type        = string
+  description = "GCP zone for the collector VM (e.g. europe-west1-b)."
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for created resource names."
+  default     = "arq-signals"
+}
+
+variable "db_host" {
+  type        = string
+  description = "Cloud SQL endpoint — private IP, or the Cloud SQL proxy endpoint."
+}
+
+variable "db_port" {
+  type        = number
+  description = "PostgreSQL port."
+  default     = 5432
+}
+
+variable "db_name" {
+  type        = string
+  description = "Database name to connect to."
+}
+
+variable "instance_name" {
+  type        = string
+  description = "Cloud SQL instance name. When set, the module creates the IAM DB user declaratively; leave empty to create it out-of-band (see README)."
+  default     = ""
+}
+
+variable "db_server_ca_cert" {
+  type        = string
+  description = "The Cloud SQL instance server-ca.pem contents (PEM), used for sslmode=verify-full. This is a public certificate, not a secret. Get it from the Cloud SQL console or: gcloud sql instances describe <instance> --format='value(serverCaCert.cert)'."
+}
+
+variable "network" {
+  type        = string
+  description = "VPC network self_link or name for the collector VM (must route to the Cloud SQL private IP)."
+}
+
+variable "subnetwork" {
+  type        = string
+  description = "Subnetwork self_link or name for the collector VM."
+}
+
+variable "gcp_impersonate_service_account" {
+  type        = string
+  description = "Optional service account email for the collector to impersonate (the VM SA must hold roles/iam.serviceAccountTokenCreator on it). Empty disables impersonation."
+  default     = ""
+}
+
+variable "machine_type" {
+  type        = string
+  description = "GCE machine type for the collector."
+  default     = "e2-small"
+}
+
+variable "image" {
+  type        = string
+  description = "Boot image for the collector VM."
+  default     = "projects/debian-cloud/global/images/family/debian-12"
+}
+
+variable "image_uri" {
+  type        = string
+  description = "Elevarq Signals container image (pinned tag)."
+  default     = "ghcr.io/elevarq/arq-signals:0.10.0-beta.5"
+}
+
+variable "arq_env" {
+  type        = string
+  description = "Signals environment (prod enforces verify-full TLS)."
+  default     = "prod"
+}
+
+variable "poll_interval" {
+  type        = string
+  description = "Collection interval."
+  default     = "5m"
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Extra labels applied to created resources."
+  default     = {}
+}

--- a/deploy/gcp/terraform/versions.tf
+++ b/deploy/gcp/terraform/versions.tf
@@ -1,0 +1,15 @@
+# Pinned provider + Terraform versions (#113). Bump deliberately.
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.40"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}


### PR DESCRIPTION
## Summary

Onboarding IaC for a **passwordless** Signals collector against Cloud SQL for PostgreSQL using `auth_method: gcp_cloudsql_iam`. Mirrors the AWS template (#111) under `deploy/gcp/`. Part of #100; consumes `features/arq-signals/credential-providers.md` (#93) and the `gcp_cloudsql_iam` provider (#96).

- `deploy/gcp/terraform/` — `terraform apply`

Provisions a dedicated service account with `roles/cloudsql.instanceUser`, optionally the IAM DB user (`google_sql_user`, gated on `instance_name`), and a GCE VM (no public IP, Shielded VM) running the collector pre-wired for `gcp_cloudsql_iam` over `verify-full` on the direct libpq path. The credential is a short-lived Google OAuth2 token minted from the attached service account at connect time — no password is stored anywhere.

The `GRANT pg_monitor` to the IAM DB user (role name = SA email without `.gserviceaccount.com`) is a documented one-time SQL step. Optional `gcp_impersonate_service_account` wires impersonation.

## Acceptance (#113)

- [x] Parameterised, versions pinned (Terraform >= 1.5, `google ~> 5.40` with committed lock file; pinned image tag)
- [x] **No secrets in inputs** (INV001/INV002) — the Cloud SQL server CA is a public certificate
- [x] Static validation: `terraform validate` + `fmt -check` pass
- [x] Documented, env-gated **live** procedure in `deploy/gcp/README.md` (operator-run, mirrors #96)

## Security notes

- No secrets in any input or on disk; token minted from the attached SA at connect time.
- SA dedicated to the collector, granted only `roles/cloudsql.instanceUser`.
- VM has no public IP, runs Shielded VM, OS Login enabled, project SSH keys blocked; API listener binds `127.0.0.1`.
- TLS `verify-full` against the instance server CA.
- `gitleaks` clean. `trivy config` clean of MEDIUM+; one accepted LOW (GCP-0033, Google-managed disk encryption rather than CMEK — CMEK would require operator KMS infra).

resolves #113