### PR TITLE
release: make cosign verify identity forward-compatible with the signals rename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -520,7 +520,7 @@ jobs:
           Quick signature verification (GHCR):
           \`\`\`bash
           cosign verify ${{ env.IMAGE_NAME }}:${VERSION} \
-            --certificate-identity-regexp='github.com/Elevarq/Arq-Signals/.github/workflows/release.yml@' \
+            --certificate-identity-regexp='github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@' \
             --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
           \`\`\`
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Quick signature verification:
 
 ```bash
 cosign verify ghcr.io/elevarq/signals:<VERSION> \
-  --certificate-identity-regexp='github.com/Elevarq/Arq-Signals/.github/workflows/release.yml@' \
+  --certificate-identity-regexp='github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -189,11 +189,11 @@ version):
 
 ```bash
 cosign verify ghcr.io/elevarq/signals:<VERSION> \
-  --certificate-identity-regexp='https://github.com/Elevarq/Arq-Signals/.github/workflows/release.yml@' \
+  --certificate-identity-regexp='https://github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 
 cosign verify ghcr.io/elevarq/charts/signals:<VERSION> \
-  --certificate-identity-regexp='https://github.com/Elevarq/Arq-Signals/.github/workflows/release.yml@' \
+  --certificate-identity-regexp='https://github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 ```
 

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -38,13 +38,13 @@ syft version              # >= 0.90
 ```bash
 # Image signature.
 cosign verify ghcr.io/elevarq/signals:<VERSION> \
-  --certificate-identity-regexp='github.com/Elevarq/Arq-Signals/.github/workflows/release.yml@' \
+  --certificate-identity-regexp='github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 
 # SBOM attestation (#165).
 cosign verify-attestation \
   --type spdxjson \
-  --certificate-identity-regexp='github.com/Elevarq/Arq-Signals/.github/workflows/release.yml@' \
+  --certificate-identity-regexp='github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
   ghcr.io/elevarq/signals:<VERSION>
 ```
@@ -92,7 +92,7 @@ investigate.
 
 ```bash
 cosign verify ghcr.io/elevarq/signals:<VERSION> \
-  --certificate-identity-regexp='github.com/Elevarq/Arq-Signals/.github/workflows/release.yml@' \
+  --certificate-identity-regexp='github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
   | jq .
 ```
@@ -197,7 +197,7 @@ Verify with:
 ```bash
 cosign verify-attestation \
   --type spdxjson \
-  --certificate-identity-regexp='github.com/Elevarq/Arq-Signals/.github/workflows/release.yml@' \
+  --certificate-identity-regexp='github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
   ghcr.io/elevarq/signals:<VERSION>
 ```

--- a/examples/helm/README.md
+++ b/examples/helm/README.md
@@ -23,7 +23,7 @@ trust root as the container image. Verify before install:
 
 ```bash
 cosign verify ghcr.io/elevarq/charts/signals:0.10.0-beta.5 \
-  --certificate-identity-regexp='github.com/Elevarq/Arq-Signals/.github/workflows/release.yml@' \
+  --certificate-identity-regexp='github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 ```
 


### PR DESCRIPTION
Part of #62. Makes the documented `cosign verify --certificate-identity-regexp` match **both** the old (`Arq-Signals`) and new (`signals`) workflow identity, so release-artifact verification survives the repo rename regardless of when it happens.

After the rename, releases signed by the new repo carry the OIDC identity `github.com/Elevarq/signals/.github/workflows/release.yml@…`; artifacts signed before keep `…/Arq-Signals/…`. The regexp previously pinned only the old name and would fail to verify the first post-rename release.

## Change
All nine documented sites widened to:

```
github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@
```

Files: `README.md`, `SECURITY.md` (image + chart), `.github/workflows/release.yml` (release-notes snippet), `docs/release-verification.md` (×4), `examples/helm/README.md`.

## Safety / scope
- Documentation + release-notes template only. The cosign **signing** step is unchanged (identity is derived from the workflow at sign time) and the Go module path is untouched.
- Safe to merge before the rename — the old name still matches, only the alternation is added.

## Verification
- `actionlint` clean on `release.yml`; YAML parses; `gitleaks` clean.
- Both URL forms (with/without `https://`) updated; no bare old-form identity remains.

closes #131