### PR TITLE
rebrand: stage active repo-URL rewrites to Elevarq/signals (#133)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Estimation guide
-    url: https://github.com/Elevarq/Arq-Signals/blob/main/docs/ESTIMATION.md
+    url: https://github.com/Elevarq/signals/blob/main/docs/ESTIMATION.md
     about: How we use Effort, Estimated Hours, and Actual Hours.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
             org.opencontainers.image.description=Open-source PostgreSQL diagnostic signal collector — local-first, no data egress.
             org.opencontainers.image.licenses=BSD-3-Clause
             org.opencontainers.image.vendor=Elevarq
-            org.opencontainers.image.documentation=https://github.com/Elevarq/Arq-Signals/blob/main/README.md
+            org.opencontainers.image.documentation=https://github.com/Elevarq/signals/blob/main/README.md
 
       - name: Build and push (multi-arch + SBOM + SLSA provenance)
         id: push
@@ -527,7 +527,7 @@ jobs:
           Same command works against \`${{ env.DOCKERHUB_IMAGE }}:${VERSION}\` — the certificate identity is bound to the workflow, not the registry.
 
           Full verification checklist (manifest, SBOM, provenance, Trivy):
-          [docs/release-verification.md](https://github.com/Elevarq/Arq-Signals/blob/main/docs/release-verification.md)
+          [docs/release-verification.md](https://github.com/Elevarq/signals/blob/main/docs/release-verification.md)
           EOF
 
       - name: Create GitHub release

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ type: software
 authors:
   - name: Elevarq
     website: https://elevarq.com
-repository-code: https://github.com/elevarq/arq-signals
-url: https://github.com/elevarq/arq-signals
+repository-code: https://github.com/elevarq/signals
+url: https://github.com/elevarq/signals
 abstract: >-
   Read-only PostgreSQL diagnostic collector. Extracts
   operational signals from PostgreSQL system views and

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ exposes.
 
 From [Elevarq](https://elevarq.com) — PostgreSQL tools for engineering teams.
 
-[![CI](https://github.com/elevarq/arq-signals/actions/workflows/ci.yml/badge.svg)](https://github.com/elevarq/arq-signals/actions/workflows/ci.yml)
+[![CI](https://github.com/elevarq/signals/actions/workflows/ci.yml/badge.svg)](https://github.com/elevarq/signals/actions/workflows/ci.yml)
 [![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/elevarq/arq-signals)](https://goreportcard.com/report/github.com/elevarq/arq-signals)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13020/badge)](https://www.bestpractices.dev/projects/13020)
@@ -33,8 +33,8 @@ From [Elevarq](https://elevarq.com) — PostgreSQL tools for engineering teams.
 ## Try it in 2 minutes
 
 ```bash
-git clone https://github.com/elevarq/arq-signals.git
-cd arq-signals
+git clone https://github.com/elevarq/signals.git
+cd signals
 docker compose -f examples/docker-compose.yml up -d
 ```
 
@@ -281,8 +281,8 @@ Full operator checklist (provenance, Trivy re-scan, OCI labels, etc.):
 ### Docker Compose (recommended for trying)
 
 ```bash
-git clone https://github.com/elevarq/arq-signals.git
-cd arq-signals
+git clone https://github.com/elevarq/signals.git
+cd signals
 docker compose -f examples/docker-compose.yml up -d
 ```
 
@@ -305,8 +305,8 @@ docker run -d --name signals \
 ### Build from source
 
 ```bash
-git clone https://github.com/elevarq/arq-signals.git
-cd arq-signals
+git clone https://github.com/elevarq/signals.git
+cd signals
 make build    # produces bin/signals and bin/signalsctl
 ./bin/signals --config signals.yaml
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ If you find a vulnerability in Elevarq Signals, please report it privately.
 Do **not** open a public GitHub issue.
 
 **Preferred channel — GitHub Private Vulnerability Reporting:**
-[github.com/Elevarq/Arq-Signals/security/advisories/new](https://github.com/Elevarq/Arq-Signals/security/advisories/new).
+[github.com/Elevarq/signals/security/advisories/new](https://github.com/Elevarq/signals/security/advisories/new).
 The thread is end-to-end encrypted to the project maintainers, and we
 can collaborate on a fix and a coordinated disclosure inside the
 advisory.

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -13,6 +13,6 @@ keywords:
   - diagnostics
   - database
   - observability
-home: https://github.com/elevarq/arq-signals
+home: https://github.com/elevarq/signals
 sources:
-  - https://github.com/elevarq/arq-signals
+  - https://github.com/elevarq/signals

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -59,7 +59,7 @@ Any other output means the image is **not** trustworthy — do not deploy.
 Locate the GitHub Actions run for the version you're verifying:
 
 ```
-https://github.com/Elevarq/Arq-Signals/actions/workflows/release.yml
+https://github.com/Elevarq/signals/actions/workflows/release.yml
 ```
 
 Confirm:
@@ -157,13 +157,13 @@ embedded SPDX document has:
 pulling the image at all:
 
 ```bash
-gh release download v<VERSION> --repo Elevarq/Arq-Signals \
+gh release download v<VERSION> --repo Elevarq/signals \
   --pattern 'sbom.spdx.json' \
   --pattern 'SHA256SUMS'
 
 # or via curl:
 curl -L \
-  https://github.com/Elevarq/Arq-Signals/releases/download/v<VERSION>/sbom.spdx.json \
+  https://github.com/Elevarq/signals/releases/download/v<VERSION>/sbom.spdx.json \
   -o sbom.spdx.json
 ```
 


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE until the GitHub repo `Elevarq/Arq-Signals` has been renamed to `Elevarq/signals`.**
> The new URLs 404 before the rename; the old URLs redirect after it. Merging early only breaks the CI badge, clone instructions, and links. This PR is staged so the cutover is a single click the moment the rename lands.

closes #133
Part of #62.

## What
Rewrites the **active, user/consumer-facing** repo-URL references from `Elevarq/Arq-Signals` → `Elevarq/signals`. URL-only; no behavioural change.

| File | Reference |
|------|-----------|
| `README.md` | CI badge, 3× `git clone` URL + matching `cd` (clone of `signals.git` makes a `signals/` dir) |
| `CITATION.cff` | `repository-code`, `url` |
| `SECURITY.md` | private advisory link |
| `.github/ISSUE_TEMPLATE/config.yml` | estimation-guide link |
| `.github/workflows/release.yml` | OCI `image.documentation` label, release-notes verification link |
| `deploy/helm/signals/Chart.yaml` | `home`, `sources` |
| `docs/release-verification.md` | Actions link, `gh release --repo` flag, SBOM release-asset URL |

## Deliberately NOT changed
- **Go module path** (`go.mod`, imports, ldflags) + **goreportcard** badge — stays `github.com/elevarq/arq-signals` (Phase 2; module path is not part of this rename).
- **Cosign `--certificate-identity-regexp`** — already matches both old and new names (#131).
- **Frozen history** — `docs/archive/**`, release notes, and `CLAUDE.md` (internal dev-doc tied to the local sibling-dir convention, which stays `arq-signals`).
- **Issue / milestone cross-reference links** in `specifications/**` and `features/**` — they redirect cleanly; a trivial follow-up sweep, kept out to keep this diff reviewable.

## Validation
- `actionlint` clean
- `helm lint deploy/helm/signals` — 0 failed
- YAML parse OK (`config.yml`, `Chart.yaml`, `CITATION.cff`)
- No Go touched

## Cutover checklist (when the rename happens)
1. Rename the repo on GitHub (`Arq-Signals` → `signals`).
2. Mark this PR ready for review and merge.
3. Verify the CI badge renders and `git clone https://github.com/elevarq/signals.git` works.