### PR TITLE
release: prep v0.10.0-beta.6 (CHANGELOG + version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0-beta.6] - 2026-06-17
+
 ### Added
 
 - **Secret-store credential provider (`auth_method: secret_store`, #93,
@@ -17,12 +19,14 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   secret URI, or a GCP Secret Manager resource name; a reference matching
   none is a hard startup error naming the three accepted forms. **The AWS
   Secrets Manager path is production-grade** (region taken authoritatively
-  from the ARN, never `AWS_REGION` / the SDK default chain / IMDS); Azure
-  Key Vault and GCP Secret Manager references are validated at startup but
-  their production fetchers are deferred behind the same interface and fail
-  at connect time with a clear "backend not available in this build" error
-  (backend support scaffolded; production fetchers tracked separately in
-  #108) without stopping collection for other targets.
+  from the ARN, never `AWS_REGION` / the SDK default chain / IMDS). **Azure
+  Key Vault and GCP Secret Manager are now production-wired as well (#108):**
+  each `secret_ref` is routed to exactly its inferred backend's SDK - Azure
+  via the `DefaultAzureCredential` chain + `azsecrets.GetSecret`, GCP via
+  Application Default Credentials + `AccessSecretVersion` - and no other
+  backend's SDK is ever invoked (INV005). A backend the collector's ambient
+  identity cannot reach is a connect-time, target-scoped failure that does
+  not stop collection for other targets.
   An optional `secret_json_key` extracts a named key from a JSON secret
   (raw value otherwise); extraction failures never echo the raw secret. The
   fetched secret is cached per target with a reuse bound of `min(vault TTL,
@@ -110,6 +114,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   `application_name = 'arq-signals'` collector identity are intentionally
   unchanged in this phase (config and integration interfaces, not binary
   branding).
+- **Release signature verification is forward-compatible with the repo
+  rename (#131).** The `cosign verify` `--certificate-identity-regexp` in
+  the README, `SECURITY.md`, the release notes, and the release workflow
+  now matches both the current `Elevarq/Arq-Signals` and the future
+  `Elevarq/signals` workflow identity, so signature verification keeps
+  working across the planned GitHub repository rename (#62) without a
+  flag-day change.
 
 ## [0.10.0-beta.5] - 2026-06-11
 

--- a/deploy/aws/cloudformation/signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/signals-rds-iam.yaml
@@ -38,7 +38,7 @@ Parameters:
     Default: t3.small
   ImageUri:
     Type: String
-    Default: ghcr.io/elevarq/signals:0.10.0-beta.5
+    Default: ghcr.io/elevarq/signals:0.10.0-beta.6
     Description: Elevarq Signals container image (pinned tag).
   ArqEnv:
     Type: String

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 0.10.0-beta.5
-appVersion: "0.10.0-beta.5"
+version: 0.10.0-beta.6
+appVersion: "0.10.0-beta.6"
 keywords:
   - postgresql
   - monitoring

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "0.10.0-beta.5"
+  tag: "0.10.0-beta.6"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration. Rendered into the mounted

--- a/examples/helm/README.md
+++ b/examples/helm/README.md
@@ -11,7 +11,7 @@ matches the release version):
 
 ```bash
 helm install signals oci://ghcr.io/elevarq/charts/signals \
-  --version 0.10.0-beta.5 \
+  --version 0.10.0-beta.6 \
   --set target.host=db.example.com \
   --set target.user=arq_signals \
   --set target.dbname=postgres \
@@ -22,7 +22,7 @@ The published chart is cosign-signed (keyless, GitHub OIDC) — the same
 trust root as the container image. Verify before install:
 
 ```bash
-cosign verify ghcr.io/elevarq/charts/signals:0.10.0-beta.5 \
+cosign verify ghcr.io/elevarq/charts/signals:0.10.0-beta.6 \
   --certificate-identity-regexp='github.com/Elevarq/(Arq-Signals|signals)/.github/workflows/release.yml@' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 ```


### PR DESCRIPTION
Pre-tag hygiene for the next beta, cut for the demo environment. The release pipeline is tag-driven (`release.yml` on `v*`); this PR is everything that must land **before** the `v0.10.0-beta.6` tag is pushed.

## Changes
**CHANGELOG**
- Promote `[Unreleased]` → `[0.10.0-beta.6] - 2026-06-17`.
- Correct the `secret_store` entry — Azure Key Vault + GCP Secret Manager are now **production-wired** (#108 / #130); the prior "deferred / fail at connect time" wording was stale.
- Add the cosign verify-identity forward-compat note (#131 / #132).

**Version bump 0.10.0-beta.5 → 0.10.0-beta.6**
- `deploy/helm/signals/Chart.yaml` (`version` + `appVersion`)
- `deploy/helm/signals/values.yaml` (`image.tag`)
- `deploy/aws/cloudformation/signals-rds-iam.yaml` (default image tag)
- `examples/helm/README.md` (`--version` + `cosign verify` tag)

The `examples/snapshot-*/README.md` sample-output versions are intentionally left at beta.5 — they describe the version that produced that historical export.

## Validation
- `helm lint deploy/helm/signals` — 0 failed
- Chart.yaml / values.yaml YAML parse OK
- No Go / workflow / shell touched (Go gates + actionlint are no-ops)

closes #135

> Next step after merge: push the `v0.10.0-beta.6` tag to trigger the release (build, SBOM, SLSA provenance, cosign sign, Trivy gate, GH pre-release + `ghcr.io/elevarq/signals:0.10.0-beta.6`).