### PR TITLE
Clear remaining hyphenated arq-signals refs from examples (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   names already wired in those demos' Compose files. Example-only
   change; no product behaviour is affected.
 
+- **Cleared remaining hyphenated `arq-signals` references from the
+  examples (#143).** Follow-up to #137/#127. Renamed the example SQLite
+  store paths `./arq-signals.db` / `./arq-signals-test.db` ->
+  `./signals.db` / `./signals-test.db`
+  (`examples/local-safe-role/signals.yaml.example`,
+  `examples/local-superuser-override/signals.yaml.example`) and the
+  residual prose use of "arq-signals" as the product name ->
+  "Elevarq Signals" in example comments and headers
+  (`examples/README.md`, `examples/docker-compose.yml`,
+  `examples/docker-compose.prod.yml`, `examples/signals.yaml`,
+  `examples/init.sql`, `examples/timescaledb-demo/docker-compose.yml`).
+  Service identifiers were already named `signals`; this is prose and
+  example-path only, with no product behaviour impact.
+
 ## [0.10.0-beta.6] - 2026-06-17
 
 ### Added

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ Deployment templates and reference configurations.
 
 | Pattern | File | Use when |
 |---|---|---|
-| Dev quickstart | [`docker-compose.yml`](docker-compose.yml) | Trying arq-signals on a self-contained local PostgreSQL. Bootstraps PG 16 + monitoring role + sample data. |
+| Dev quickstart | [`docker-compose.yml`](docker-compose.yml) | Trying Elevarq Signals on a self-contained local PostgreSQL. Bootstraps PG 16 + monitoring role + sample data. |
 | Production | [`docker-compose.prod.yml`](docker-compose.prod.yml) | Connecting to your real PostgreSQL with a Docker secret for the password. No embedded DB. |
 | Kubernetes | [`helm/`](helm/) | Helm-based deployment on a K8s cluster. |
 

--- a/examples/docker-compose.prod.yml
+++ b/examples/docker-compose.prod.yml
@@ -1,4 +1,4 @@
-# Production-style arq-signals deployment.
+# Production-style Elevarq Signals deployment.
 #
 # Connects to an EXISTING PostgreSQL instance. The monitoring-role
 # password is delivered via a Docker secret — mounted at
@@ -75,7 +75,7 @@ services:
 
     volumes:
       # YAML config is the source of truth for multi-target / TLS-verify /
-      # non-trivial setups. arq-signals auto-discovers /etc/signals/signals.yaml.
+      # non-trivial setups. Elevarq Signals auto-discovers /etc/signals/signals.yaml.
       - ./signals.prod.yaml:/etc/signals/signals.yaml:ro
 
       # Persistent local SQLite for snapshot retention.

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,4 +1,4 @@
-# arq-signals quick start (LOCAL DEV ONLY)
+# Elevarq Signals quick start (LOCAL DEV ONLY)
 #
 # This compose file is for local development. SIGNALS_ENV=dev so the
 # weak-token rule (#135 / config.WeakAPITokenReason) emits a
@@ -8,7 +8,7 @@
 # via SIGNALS_API_TOKEN_FILE or a Kubernetes Secret — see
 # docs/security/access-control.md.
 #
-# Start arq-signals alongside a PostgreSQL 16 instance:
+# Start Elevarq Signals alongside a PostgreSQL 16 instance:
 #   docker compose -f examples/docker-compose.yml up -d
 #
 # Trigger a collection (dev-only token shown):
@@ -52,7 +52,7 @@ services:
   postgres:
     image: postgres:16-alpine
     # Preload pg_stat_statements so init.sql's CREATE EXTENSION works
-    # and the arq-signals pg_stat_statements_v1 / pgss_reset_check_v1
+    # and the Elevarq Signals pg_stat_statements_v1 / pgss_reset_check_v1
     # collectors can actually read the view.
     command: ["postgres", "-c", "shared_preload_libraries=pg_stat_statements"]
     environment:

--- a/examples/init.sql
+++ b/examples/init.sql
@@ -1,4 +1,4 @@
--- arq-signals monitoring role setup
+-- Elevarq Signals monitoring role setup
 -- This script runs automatically when PostgreSQL starts for the first time.
 
 -- Create the monitoring role with login but no superuser privileges

--- a/examples/local-safe-role/signals.yaml.example
+++ b/examples/local-safe-role/signals.yaml.example
@@ -25,7 +25,7 @@ targets:
     # password_env: PG_PASSWORD
 
 database:
-  path: ./arq-signals.db
+  path: ./signals.db
   wal: true
 
 api:

--- a/examples/local-superuser-override/signals.yaml.example
+++ b/examples/local-superuser-override/signals.yaml.example
@@ -22,7 +22,7 @@ targets:
     enabled: true
 
 database:
-  path: ./arq-signals-test.db
+  path: ./signals-test.db
   wal: true
 
 api:

--- a/examples/signals.yaml
+++ b/examples/signals.yaml
@@ -1,6 +1,6 @@
-# arq-signals configuration
+# Elevarq Signals configuration
 #
-# This file configures the arq-signals collector. All values shown are
+# This file configures the Elevarq Signals collector. All values shown are
 # defaults unless noted otherwise.
 #
 # Environment variables override file values. See README.md for the

--- a/examples/timescaledb-demo/docker-compose.yml
+++ b/examples/timescaledb-demo/docker-compose.yml
@@ -5,7 +5,7 @@
 # substrate for Tiger Data demo material and a reusable development
 # fixture. Issue: #76.
 #
-# Start TimescaleDB (PG 17) + arq-signals:
+# Start TimescaleDB (PG 17) + Elevarq Signals:
 #   docker compose -f examples/timescaledb-demo/docker-compose.yml up -d
 #
 # Optional PostgreSQL 18 variant (port 5435, DB only): add


### PR DESCRIPTION
## Summary

Follow-up to #137 (interfaces/paths) and #127 (prose name), surfaced by #141. Clears the last hyphenated `arq-signals` references from `examples/`, in two categories:

- **SQLite store paths (#137):** `./arq-signals.db` -> `./signals.db`, `./arq-signals-test.db` -> `./signals-test.db` in `local-safe-role/signals.yaml.example` and `local-superuser-override/signals.yaml.example` — matching the post-#137 default store path.
- **Prose product name (#127):** residual "arq-signals" used as the product name -> "Elevarq Signals" in example comments/headers (`README.md`, `docker-compose.yml`, `docker-compose.prod.yml`, `signals.yaml`, `init.sql`, `timescaledb-demo/docker-compose.yml`).

Service/binary identifiers were already named `signals`, so every remaining occurrence was prose or an example path — no identifier was touched.

## Acceptance

`git grep -n "arq-signals" -- examples/` now returns only the Go module path, the GHCR chart path, and the `deploy/helm/arq-signals/` chart dir — all gated on the repository rename (#62). Verified.

## Verification

- Example/docs/path only — no product behaviour, spec, or test impact (no spec/test/Go code references these strings)
- All six example YAML files validated as parseable
- pre-push preflight (`scripts/preflight.sh all`) passed

closes #143