### PR TITLE
De-arq leftovers in deploy/ IaC templates (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,24 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   Service identifiers were already named `signals`; this is prose and
   example-path only, with no product behaviour impact.
 
+- **Cleared residual `arq` names from the `deploy/` IaC templates
+  (#145).** #137 renamed the config directory, store path, and Docker
+  volume and its changelog already claimed `/etc/arq/` -> `/etc/signals/`,
+  `/data/arq-signals.db` -> `/data/signals.db`, and `arq-data` ->
+  `signals-data`, but the cloud provisioning templates under `deploy/`
+  were outside its scope and still carried the old names, leaving the
+  docs ahead of reality. The Azure Bicep cloud-init now writes config to
+  `/etc/signals/`, stores the database at `/data/signals.db`, and mounts
+  the `signals-data` volume (`deploy/azure/bicep/main.bicep`). The
+  deployment-environment input variable `arq_env` / `ArqEnv` / `arqEnv`
+  is renamed to `env` / `Env` across the AWS CloudFormation template,
+  the AWS/Azure/GCP Terraform modules, and the Azure Bicep template
+  (`deploy/aws/cloudformation/signals-rds-iam.yaml`,
+  `deploy/{aws,azure,gcp}/terraform/`, `deploy/azure/bicep/main.bicep`).
+  Provisioning-template only; the generated collector config and runtime
+  behaviour are unchanged. Operators who set `arq_env` / `ArqEnv` in
+  their tfvars or stack parameters must rename it to `env` / `Env`.
+
 ## [0.10.0-beta.6] - 2026-06-17
 
 ### Added

--- a/deploy/aws/cloudformation/signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/signals-rds-iam.yaml
@@ -40,7 +40,7 @@ Parameters:
     Type: String
     Default: ghcr.io/elevarq/signals:0.10.0-beta.6
     Description: Elevarq Signals container image (pinned tag).
-  ArqEnv:
+  Env:
     Type: String
     Default: prod
     AllowedValues: [prod, lab, dev]
@@ -114,7 +114,7 @@ Resources:
           curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
             -o /etc/signals/rds-ca.pem
           cat > /etc/signals/signals.yaml <<'YAML'
-          env: ${ArqEnv}
+          env: ${Env}
           signals:
             poll_interval: ${PollInterval}
           database:

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -32,7 +32,7 @@ locals {
     curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
       -o /etc/signals/rds-ca.pem
     cat > /etc/signals/signals.yaml <<'YAML'
-    env: ${var.arq_env}
+    env: ${var.env}
     signals:
       poll_interval: ${var.poll_interval}
     database:

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -67,7 +67,7 @@ variable "image_uri" {
   default     = "ghcr.io/elevarq/signals:0.10.0-beta.5"
 }
 
-variable "arq_env" {
+variable "env" {
   type        = string
   description = "Signals environment (prod enforces verify-full TLS)."
   default     = "prod"

--- a/deploy/azure/bicep/main.bicep
+++ b/deploy/azure/bicep/main.bicep
@@ -52,7 +52,7 @@ param imageUri string = 'ghcr.io/elevarq/signals:0.10.0-beta.5'
 param dbCaCertUrl string = 'https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem'
 
 @description('Signals environment (prod enforces verify-full TLS).')
-param arqEnv string = 'prod'
+param env string = 'prod'
 
 @description('Collection interval.')
 param pollInterval string = '5m'
@@ -74,7 +74,7 @@ resource collectorIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@202
 
 // cloud-init for the collector VM. Bicep multi-line strings do not interpolate,
 // so this is a single interpolated string with \n line breaks.
-var cloudInit ='#!/bin/bash\nset -euo pipefail\napt-get update -y\napt-get install -y docker.io curl\nsystemctl enable --now docker\nmkdir -p /etc/arq\n# Azure Flexible Server CA bundle for sslmode=verify-full.\ncurl -fsSL ${dbCaCertUrl} -o /etc/arq/azure-ca.pem\ncat > /etc/arq/signals.yaml <<\'YAML\'\nenv: ${arqEnv}\nsignals:\n  poll_interval: ${pollInterval}\ndatabase:\n  path: /data/arq-signals.db\n  wal: true\napi:\n  listen_addr: "127.0.0.1:8081"\ntargets:\n  - name: ${dbName}-azure\n    host: ${dbHost}\n    port: ${dbPort}\n    dbname: ${dbName}\n    user: ${identityName}\n    auth_method: azure_entra\n    azure_client_id: ${collectorIdentity.properties.clientId}\n    sslmode: verify-full\n    sslrootcert_file: /etc/arq/azure-ca.pem\nYAML\ndocker run -d --name signals --restart=always -e AZURE_CLIENT_ID=${collectorIdentity.properties.clientId} -v /etc/arq:/etc/arq:ro -v arq-data:/data -p 127.0.0.1:8081:8081 ${imageUri} --config /etc/arq/signals.yaml\n'
+var cloudInit ='#!/bin/bash\nset -euo pipefail\napt-get update -y\napt-get install -y docker.io curl\nsystemctl enable --now docker\nmkdir -p /etc/signals\n# Azure Flexible Server CA bundle for sslmode=verify-full.\ncurl -fsSL ${dbCaCertUrl} -o /etc/signals/azure-ca.pem\ncat > /etc/signals/signals.yaml <<\'YAML\'\nenv: ${env}\nsignals:\n  poll_interval: ${pollInterval}\ndatabase:\n  path: /data/signals.db\n  wal: true\napi:\n  listen_addr: "127.0.0.1:8081"\ntargets:\n  - name: ${dbName}-azure\n    host: ${dbHost}\n    port: ${dbPort}\n    dbname: ${dbName}\n    user: ${identityName}\n    auth_method: azure_entra\n    azure_client_id: ${collectorIdentity.properties.clientId}\n    sslmode: verify-full\n    sslrootcert_file: /etc/signals/azure-ca.pem\nYAML\ndocker run -d --name signals --restart=always -e AZURE_CLIENT_ID=${collectorIdentity.properties.clientId} -v /etc/signals:/etc/signals:ro -v signals-data:/data -p 127.0.0.1:8081:8081 ${imageUri} --config /etc/signals/signals.yaml\n'
 
 resource nic 'Microsoft.Network/networkInterfaces@2023-09-01' = {
   name: '${namePrefix}-collector-nic'

--- a/deploy/azure/terraform/main.tf
+++ b/deploy/azure/terraform/main.tf
@@ -31,7 +31,7 @@ locals {
     # Azure Flexible Server CA bundle for sslmode=verify-full.
     curl -fsSL ${var.db_ca_cert_url} -o /etc/signals/azure-ca.pem
     cat > /etc/signals/signals.yaml <<'YAML'
-    env: ${var.arq_env}
+    env: ${var.env}
     signals:
       poll_interval: ${var.poll_interval}
     database:

--- a/deploy/azure/terraform/variables.tf
+++ b/deploy/azure/terraform/variables.tf
@@ -75,7 +75,7 @@ variable "db_ca_cert_url" {
   default     = "https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem"
 }
 
-variable "arq_env" {
+variable "env" {
   type        = string
   description = "Signals environment (prod enforces verify-full TLS)."
   default     = "prod"

--- a/deploy/gcp/terraform/main.tf
+++ b/deploy/gcp/terraform/main.tf
@@ -31,7 +31,7 @@ locals {
     ${var.db_server_ca_cert}
     PEM
     cat > /etc/signals/signals.yaml <<'YAML'
-    env: ${var.arq_env}
+    env: ${var.env}
     signals:
       poll_interval: ${var.poll_interval}
     database:

--- a/deploy/gcp/terraform/variables.tf
+++ b/deploy/gcp/terraform/variables.tf
@@ -85,7 +85,7 @@ variable "image_uri" {
   default     = "ghcr.io/elevarq/signals:0.10.0-beta.5"
 }
 
-variable "arq_env" {
+variable "env" {
   type        = string
   description = "Signals environment (prod enforces verify-full TLS)."
   default     = "prod"


### PR DESCRIPTION
## Summary

Clears the residual `arq` names from the `deploy/` IaC templates — the cluster surfaced after `examples/` was finished (#143). #137 renamed the config directory, store path, and Docker volume and its changelog already claimed the deploy-side renames, but the cloud provisioning templates under `deploy/` were outside #137's scope and still carried the old names, leaving the docs ahead of reality.

## Changes

- **Azure Bicep cloud-init** (`deploy/azure/bicep/main.bicep`): `/etc/arq` -> `/etc/signals`, `/data/arq-signals.db` -> `/data/signals.db`, `arq-data` volume -> `signals-data`.
- **Deployment-environment input variable** `arq_env` / `ArqEnv` / `arqEnv` -> `env` / `Env` across:
  - `deploy/aws/cloudformation/signals-rds-iam.yaml`
  - `deploy/{aws,azure,gcp}/terraform/` (variables.tf + main.tf)
  - `deploy/azure/bicep/main.bicep`

Provisioning-template only — the generated collector config and runtime behaviour are unchanged.

## Verification

- `terraform validate` passes for all three modules (aws/azure/gcp); `terraform fmt -check -recursive` clean.
- `git grep -Iin "arq" -- deploy/` returns only the keep-list gated on the repo rename (#62): module path, ghcr image refs, `deploy/helm/arq-signals`. No `arq_env`/`ArqEnv`/`arqEnv`, `/etc/arq`, `arq-signals.db`, or `arq-data` remain.
- No new yamllint findings (the 5 line-length/document-start warnings on the CloudFormation template pre-exist on `main`).
- No bicep CLI locally; verified every `${...}` token in the cloud-init references a declared param/var (`${env}` now resolves to `param env`).

## Breaking change for operators

Anyone who set `arq_env` (Terraform tfvars) or `ArqEnv` (CloudFormation stack parameter) must rename it to `env` / `Env`. CHANGELOG updated.

closes #145