### PR TITLE
De-arq the documented control_plane_token_env example value (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,18 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   behaviour are unchanged. Operators who set `arq_env` / `ArqEnv` in
   their tfvars or stack parameters must rename it to `env` / `Env`.
 
+- **Updated the documented `control_plane_token_env` example value
+  `ARQ_CONTROL_PLANE_TOKEN` -> `SIGNALS_CONTROL_PLANE_TOKEN` (#146).**
+  This is the operator-chosen env-var name shown in the commented config
+  examples — Signals never hard-codes or reads `ARQ_CONTROL_PLANE_TOKEN`;
+  it reads whatever name the operator sets in `control_plane_token_env`,
+  so this is a documentation example only, **not** a behaviour change and
+  not a breaking change (the config key and the `SIGNALS_CONTROL_PLANE_TOKEN_ENV`
+  override were already de-arq'd in #137). Updated in `README.md`,
+  `docs/authentication.md`, and `features/arq-signals/specification.md`,
+  plus the cosmetic internal variable `arqControlPlaneTokenFn` ->
+  `signalsControlPlaneTokenFn` in `cmd/signals/main.go`.
+
 ## [0.10.0-beta.6] - 2026-06-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ signals:
   mode: managed
   control_plane_token_file: /etc/signals/control-plane.token
   # or:
-  # control_plane_token_env: ARQ_CONTROL_PLANE_TOKEN
+  # control_plane_token_env: SIGNALS_CONTROL_PLANE_TOKEN
 ```
 
 The file is re-read on every authentication attempt so rotation is

--- a/cmd/signals/main.go
+++ b/cmd/signals/main.go
@@ -237,7 +237,7 @@ func run() error {
 	// startup so cross-token rules (length floor, distinctness from
 	// api.token) are validated before serving any traffic. Per-
 	// request rotation is handled by ControlPlaneTokenFn below.
-	var arqControlPlaneTokenFn func() string
+	var signalsControlPlaneTokenFn func() string
 	controlPlaneTokenConfigured := false
 	if cfg.Signals.Mode == config.ModeManaged {
 		startupToken, err := config.ResolveControlPlaneToken(cfg.Signals)
@@ -248,7 +248,7 @@ func run() error {
 			return fmt.Errorf("R083 cross-token validation: %w", err)
 		}
 		controlPlaneTokenConfigured = true
-		arqControlPlaneTokenFn = func() string {
+		signalsControlPlaneTokenFn = func() string {
 			// Re-read the source on every authentication attempt so
 			// rotating the file's contents takes effect on the next
 			// request without restarting the daemon. A read error
@@ -290,7 +290,7 @@ func run() error {
 		Exporter:            exporter,
 		Targets:             cfg.Targets,
 		ConfigPath:          *configPath, // R100: needed for POST /reload + SIGHUP handler.
-		ControlPlaneTokenFn: arqControlPlaneTokenFn,
+		ControlPlaneTokenFn: signalsControlPlaneTokenFn,
 		TLSCertFile:         cfg.API.TLSCertFile, // R113: daemon-terminated TLS (both-or-neither, validated).
 		TLSKeyFile:          cfg.API.TLSKeyFile,
 	}

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -55,7 +55,7 @@ signals:
   # Alternative: env var indirection. Treat the env var as the
   # source of the token value. Same posture as the existing
   # SIGNALS_API_TOKEN_FILE / SIGNALS_API_TOKEN pattern.
-  # control_plane_token_env: ARQ_CONTROL_PLANE_TOKEN
+  # control_plane_token_env: SIGNALS_CONTROL_PLANE_TOKEN
 ```
 
 Equivalent environment-variable overrides:

--- a/features/arq-signals/specification.md
+++ b/features/arq-signals/specification.md
@@ -1106,7 +1106,7 @@ signals:
   # api.token (R011).
   control_plane_token_file: /etc/signals/control-plane.token
   # alternative:
-  # control_plane_token_env: ARQ_CONTROL_PLANE_TOKEN
+  # control_plane_token_env: SIGNALS_CONTROL_PLANE_TOKEN
 ```
 
 | Field | Type | Default | Validation |


### PR DESCRIPTION
## Summary

Final de-arq leftover after `examples/` (#143) and `deploy/` (#145): the documented `control_plane_token_env` example value `ARQ_CONTROL_PLANE_TOKEN` -> `SIGNALS_CONTROL_PLANE_TOKEN`.

## Investigation (the open question from the issue)

**Does the collector read `ARQ_CONTROL_PLANE_TOKEN` as a hard-coded default, or is it only the documented example value?**

Answer: **only the documented example value — case (a).** Signals never hard-codes or reads `ARQ_CONTROL_PLANE_TOKEN`. It reads whatever env-var name the operator puts in `control_plane_token_env` via `os.LookupEnv(s.ControlPlaneTokenEnv)` (`internal/config/config.go:1150-1153`). The override env vars that *set* the config (`SIGNALS_CONTROL_PLANE_TOKEN_FILE` / `SIGNALS_CONTROL_PLANE_TOKEN_ENV`) were already `SIGNALS_*` from #137. The literal `ARQ_CONTROL_PLANE_TOKEN` existed only as the suggested name in commented-out config snippets.

So this is **not** a behaviour change, **not** breaking, and needs **no deprecation alias** — it is a documentation example rename. No new behavioural test is required (no default behaviour exists to test; the existing managed-mode tests use generic env-var names and are unaffected).

## Changes

- Example value `ARQ_CONTROL_PLANE_TOKEN` -> `SIGNALS_CONTROL_PLANE_TOKEN` in `README.md`, `docs/authentication.md`, `features/arq-signals/specification.md` (config-schema appendix comment).
- Cosmetic internal variable `arqControlPlaneTokenFn` -> `signalsControlPlaneTokenFn` in `cmd/signals/main.go` (local var, not user-facing).
- CHANGELOG entry under `### Fixed`, explicitly noting this is doc/cosmetic, not a behaviour change.

## Verification

- `gofmt -l` clean, `go vet ./cmd/signals/...` clean, `go build ./...` OK.
- `go test ./cmd/... ./tests/` pass (incl. the managed-mode / R083 control-plane-token tests).
- `git grep "ARQ_CONTROL_PLANE_TOKEN\|arqControlPlaneTokenFn"` returns nothing repo-wide.
- Pre-push preflight (`scripts/preflight.sh all`) passed.

closes #146