### PR TITLE
docs: correct pre-#137 arq references in docs and example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,24 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   plus the cosmetic internal variable `arqControlPlaneTokenFn` ->
   `signalsControlPlaneTokenFn` in `cmd/signals/main.go`.
 
+- **Corrected docs/examples that still described the pre-#137 `arq`
+  behaviour (#149).** #137 changed the shipped code but left several
+  docs and one example describing the old names, so they actively
+  misled operators. The collector identifies as
+  `application_name = signals` (constant `collector.AppName`, used by
+  the `pg_stat_statements_v1` self-filter), but `docs/faq.md`,
+  `docs/postgres-role.md`, and `docs/collectors.md` still said
+  `arq-signals` — an operator building their own self-filter from those
+  docs would have matched the wrong value. The
+  `examples/local-superuser-override/signals.yaml.example` comment told
+  operators to set `ARQ_SIGNALS_ALLOW_UNSAFE_ROLE`, but the daemon reads
+  `SIGNALS_ALLOW_UNSAFE_ROLE` (`internal/config/config.go`), so the
+  override silently did nothing. Also corrected the stale identity/store
+  paths `/var/lib/arq-signals` and `/var/lib/arq` -> `/var/lib/signals`
+  in `specifications/doctor.md` and
+  `docs/observability/operational-readiness.md`. Documentation/example
+  only; the code already behaved correctly.
+
 ## [0.10.0-beta.6] - 2026-06-17
 
 ### Added

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -255,7 +255,7 @@ permissions: [`postgres-role.md`](postgres-role.md).
   (sourced from the `collector.AppName` constant) so the filter
   works from the very first statement on every session. If a
   non-Signals application sets its own `application_name` to
-  `arq-signals`, its rows are suppressed — that is operator
+  `signals`, its rows are suppressed — that is operator
   misconfiguration, not a Signals defect.
 
 ### Self-filter limits (operator note)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,9 +65,9 @@ No. The collector self-filters so that customer workload analysis
 is not polluted by Signals' own probe queries:
 
 - Every PostgreSQL connection opened by Signals sets
-  `application_name = arq-signals` in its startup parameters.
+  `application_name = signals` in its startup parameters.
 - The `pg_stat_statements_v1` SQL excludes rows attributable to
-  any session whose `application_name` is `arq-signals`,
+  any session whose `application_name` is `signals`,
   matched on `(userid, dbid)`.
 - The same SQL scopes rows to the connected database
   (`pg_database.datname = current_database()`), so cross-database
@@ -75,5 +75,5 @@ is not polluted by Signals' own probe queries:
   collected.
 
 If you operate another application that also sets its
-`application_name` to `arq-signals`, its rows will be suppressed
+`application_name` to `signals`, its rows will be suppressed
 too. Pick a distinct name for non-Signals tooling.

--- a/docs/observability/operational-readiness.md
+++ b/docs/observability/operational-readiness.md
@@ -125,7 +125,7 @@ The recommended package:
 - Raw daemon logs without timestamp bounding — they often span
   multiple targets and surface concurrent activity the issue at
   hand is irrelevant to.
-- Files under `/var/lib/arq` (the identity directory) —
+- Files under `/var/lib/signals` (the identity directory) —
   `install_secret` is private to the process. Send the
   fingerprint from the daemon's startup log instead.
 - Copies of `config.yaml` carrying inline credentials — redact

--- a/docs/postgres-role.md
+++ b/docs/postgres-role.md
@@ -69,7 +69,7 @@ runtime on every connection:
 - `SET LOCAL default_transaction_read_only = on`
 - `SET LOCAL statement_timeout`, `lock_timeout`,
   `idle_in_transaction_session_timeout` — short, configurable.
-- Every connection sets `application_name = arq-signals` in its
+- Every connection sets `application_name = signals` in its
   startup parameters (R106). The value is used by the
   `pg_stat_statements_v1` collector to filter out Signals' own
   probe queries so customer workload analysis is not polluted by

--- a/examples/local-superuser-override/signals.yaml.example
+++ b/examples/local-superuser-override/signals.yaml.example
@@ -1,6 +1,6 @@
 # Elevarq Signals — superuser override example (LOCAL/DEV ONLY)
 #
-# Uses the postgres superuser. Requires ARQ_SIGNALS_ALLOW_UNSAFE_ROLE=true.
+# Uses the postgres superuser. Requires SIGNALS_ALLOW_UNSAFE_ROLE=true.
 # Do NOT use this configuration in production.
 
 env: dev

--- a/specifications/doctor.md
+++ b/specifications/doctor.md
@@ -54,7 +54,7 @@ Example:
 
 ```
 OK   C1 config_valid              loaded /etc/signals-signals/config.yaml
-OK   C2 store_writable            /var/lib/arq-signals
+OK   C2 store_writable            /var/lib/signals
 FAIL C3 target_reachable prod-db  dial tcp 10.0.0.7:5432: connect: connection refused
 OK   C3 target_reachable staging  reached staging.example.com:5432 in 14ms
 WARN C4 role_safe       prod-db   skipped (target_reachable failed)


### PR DESCRIPTION
#137 renamed the shipped behaviour but left several docs and one example describing the old `arq` names, so they actively misled operators.

## What was wrong

- **`docs/faq.md`, `docs/postgres-role.md`, `docs/collectors.md`** said the collector sets `application_name = arq-signals`. The code sets `signals` (`collector.AppName`, used by the `pg_stat_statements_v1` self-filter). An operator building their own self-filter from the docs would have matched the wrong value.
- **`examples/local-superuser-override/signals.yaml.example`** told operators to set `ARQ_SIGNALS_ALLOW_UNSAFE_ROLE`; the daemon reads `SIGNALS_ALLOW_UNSAFE_ROLE` (`internal/config/config.go`), so the override silently did nothing.
- **`specifications/doctor.md`, `docs/observability/operational-readiness.md`** carried stale store/identity paths `/var/lib/arq-signals` and `/var/lib/arq` -> `/var/lib/signals`.

## Scope

Documentation/example only; the code already behaved correctly. Verified against shipped code (`collector.AppName = "signals"`, `pgqueries` filter `application_name = 'signals'`, config reads `SIGNALS_ALLOW_UNSAFE_ROLE`).

Out of scope (intentional keep-list / separate follow-ups): spec IDs (`ARQ-SIGNALS-R*`), the `features/arq-signals/` module-path directory (gated on repo rename #62), and developer-facing identifiers `ARQ_TEST_*` / `user=arq` samples (tracked in #150).

closes #149