### PR TITLE
docs: fix doctor --config path pointing at non-existent /etc/signals-signals/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,20 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Corrected the documented `signalsctl doctor` config path that pointed
+  at a non-existent `/etc/signals-signals/` directory (#153).** The Helm
+  chart mounts the ConfigMap at `/etc/signals` and the daemon's default
+  config is `/etc/signals/signals.yaml`, but
+  `docs/install/kubernetes-production.md` told operators to run
+  `signalsctl doctor --config /etc/signals-signals/signals.yaml`, which
+  fails on copy-paste — the path does not exist in the pod. The
+  `specifications/doctor.md` example output had the same doubled directory
+  (plus the wrong filename `config.yaml`). Both now reference
+  `/etc/signals/signals.yaml`. The `signals-signals` *resource* names in
+  the same doc are correct (Helm renders `{release}-signals` and the docs
+  install with release name `signals`) and are unchanged. Documentation
+  only.
+
 - **Example DB monitoring roles renamed to the single `signals` role
   (#141).** #137's claim that the examples use a single `signals` role
   was incomplete — the role-creation SQL and the snapshot fixture were

--- a/docs/install/kubernetes-production.md
+++ b/docs/install/kubernetes-production.md
@@ -216,7 +216,7 @@ kubectl -n observability get pods -l app.kubernetes.io/name=signals
 
 # Run the operator preflight from inside the pod
 kubectl -n observability exec deploy/signals-signals -- \
-  signalsctl doctor --config /etc/signals-signals/signals.yaml --json
+  signalsctl doctor --config /etc/signals/signals.yaml --json
 
 # Confirm the API token Secret is wired (no token in the rendered manifest):
 helm template signals deploy/helm/signals --values production.yaml | \

--- a/specifications/doctor.md
+++ b/specifications/doctor.md
@@ -53,7 +53,7 @@ summarises pass/fail counts.
 Example:
 
 ```
-OK   C1 config_valid              loaded /etc/signals-signals/config.yaml
+OK   C1 config_valid              loaded /etc/signals/signals.yaml
 OK   C2 store_writable            /var/lib/signals
 FAIL C3 target_reachable prod-db  dial tcp 10.0.0.7:5432: connect: connection refused
 OK   C3 target_reachable staging  reached staging.example.com:5432 in 14ms


### PR DESCRIPTION
The Helm chart mounts the ConfigMap at `/etc/signals` (`deploy/helm/signals/templates/deployment.yaml:96`) and the daemon's default config is `/etc/signals/signals.yaml` (`internal/config/config.go:410`, `cmd/signalsctl/doctor.go:96`), but two doc lines applied the chart's `{release}-signals` **resource-naming** pattern to a **filesystem path**:

- `docs/install/kubernetes-production.md:219` told operators to run `signalsctl doctor --config /etc/signals-signals/signals.yaml` — that directory does not exist in the pod, so the documented post-install validation command **fails on copy-paste**.
- `specifications/doctor.md:56` example output had the same doubled directory plus the wrong filename (`config.yaml` vs `signals.yaml`).

Both now reference `/etc/signals/signals.yaml`.

## Left unchanged (correct as-is)

The `signals-signals` **resource** names elsewhere in the install doc (`delete pvc signals-signals-data` at :192, `exec deploy/signals-signals` at :218) are correct: Helm renders `{{ .Release.Name }}-signals` and the docs install with release name `signals` (`helm install signals deploy/helm/signals/`).

## Verification

`git grep -n "/etc/signals-signals" -- docs/ specifications/` returns nothing; the resource names at :192/:218 are unchanged.

closes #153