### PR TITLE
feat: add umbrella field + cross-cutting-decision note to feature.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -19,6 +19,15 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: umbrella
+    attributes:
+      label: Umbrella / parent issue (if this is a child)
+      description: "If this is a child of an umbrella, link it and INHERIT its cross-cutting decisions — do not duplicate them here. State only what is specific to this child (its component, inputs, manifest paths). See 'Umbrella issues own cross-cutting decisions' in the root engineering standards (CLAUDE.md)."
+      placeholder: "Inherits decisions from #<umbrella> — read it; do not duplicate"
+    validations:
+      required: false
+
   - type: textarea
     id: acceptance
     attributes:
@@ -101,3 +110,8 @@ body:
         After creating this issue, apply the matching labels:
         `effort:XS` / `effort:S` / `effort:M` / `effort:L` / `effort:XL`
         `priority:P0` / `priority:P1` / `priority:P2` / `priority:P3`
+
+        Cross-cutting decisions (anything affecting more than one child)
+        live in the umbrella issue only — reference it, never copy its
+        decision prose into a child (it silently drifts). See "Umbrella
+        issues own cross-cutting decisions" in the root CLAUDE.md.


### PR DESCRIPTION
Rolls out the "umbrella issues own cross-cutting decisions" convention to Arq-Signals, mirroring the Arq change (Elevarq/Arq#1321 / PR #1325).

## What changed
- `.github/ISSUE_TEMPLATE/feature.yml` gains an optional `umbrella` input field (label "Umbrella / parent issue (if this is a child)", inherit-don't-duplicate description, placeholder "Inherits decisions from #<umbrella> — read it; do not duplicate", not required), placed after Scope.
- The trailing markdown note now states that cross-cutting decisions live in the umbrella only and must be referenced, never copied.

## Validation
- `feature.yml` parses as valid YAML (`python3 -c "import yaml; yaml.safe_load(...)"`).

## Audit (summarised on the issue)
Only 3 open issues exist in the repo; one umbrella/child relationship (#62 → #133) was reviewed. See the issue for the audit result.

closes #155