### PR TITLE
Fix stale README collector count (73 -> 99) + anti-drift guard (#161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ audit the binary. You own the output.
 ## What Elevarq Signals does
 
 - Connects to one or more PostgreSQL instances (14+)
-- Runs 73 read-only diagnostic collectors covering:
+- Runs 99 read-only diagnostic collectors covering:
   - Server configuration, identity, and cluster fingerprint
   - Session activity and connection pressure
   - Table, index, and I/O statistics (incl. `pg_stat_io` /
@@ -468,7 +468,7 @@ inspect exactly what Elevarq Signals collects without running it.
 
 ## Collected signals
 
-Elevarq Signals includes 73 read-only collectors. Grouped by domain:
+Elevarq Signals includes 99 read-only collectors. Grouped by domain:
 
 - **Baseline & runtime** — server config, sessions, databases,
   tables, indexes, table / index I/O, query stats
@@ -917,7 +917,7 @@ analyzer).
 
 ## Project resources
 
-- [Collector inventory](docs/collectors.md) — all 73 collectors with sources and cadences
+- [Collector inventory](docs/collectors.md) — all 99 collectors with sources and cadences
 - [Database connections](docs/database-connections.md) — per-cloud `auth_method` recipes (RDS IAM, Entra, Cloud SQL IAM, secret stores) + grants
 - [Runtime safety model](docs/runtime-safety-model.md) — read-only enforcement details
 - [Adoption guide](docs/adoption-guide.md) — production deployment guidance

--- a/tests/signals_readme_collector_count_test.go
+++ b/tests/signals_readme_collector_count_test.go
@@ -1,0 +1,52 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/elevarq/arq-signals/internal/pgqueries"
+)
+
+// Anti-drift guard for #161. The collector count advertised in README.md
+// must equal the runtime registry (`len(pgqueries.All())`). The README
+// lagged at 73 while the registry already had 99; this test pins every
+// count claim on the public landing page to the single source of truth so
+// it cannot silently drift again.
+//
+// When README phrasing introduces a new count claim, add its pattern to
+// countPatterns below — that is the deliberate-change checkpoint.
+func TestREADME_CollectorCountMatchesRegistry(t *testing.T) {
+	want := len(pgqueries.All())
+
+	data, err := os.ReadFile(filepath.Join(repoRoot(t), "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	body := string(data)
+
+	countPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(\d+) read-only diagnostic collectors`),
+		regexp.MustCompile(`includes (\d+) read-only collectors`),
+		regexp.MustCompile(`all (\d+) collectors`),
+	}
+
+	for _, re := range countPatterns {
+		matches := re.FindAllStringSubmatch(body, -1)
+		if matches == nil {
+			t.Errorf("README.md: no match for %q — phrasing changed? update this guard (#161)", re)
+			continue
+		}
+		for _, m := range matches {
+			got, err := strconv.Atoi(m[1])
+			if err != nil {
+				t.Fatalf("parse count from %q: %v", m[0], err)
+			}
+			if got != want {
+				t.Errorf("README.md says %d collectors (%q) but len(pgqueries.All()) = %d — update README.md", got, m[0], want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The public `README.md` advertised **73** read-only collectors; the actual count is **99**. Corrects the three stale references and adds a CI guard so the headline number can't drift again.

## Evidence

`99` agrees across three independent sources: `len(pgqueries.All())`, the 99 specs in `specifications/collectors/`, and `docs/collectors.md` ("includes 99 read-only diagnostic collectors"). Only the README lagged — by 26 collectors, visible against the current `0.10.0-beta.6`.

## Changes

- `README.md`: three `73` -> `99` (L82, L471, L920).
- `tests/signals_readme_collector_count_test.go`: pins every collector-count claim in the README to `len(pgqueries.All())`. Follows the existing `TestMetricsDoc_*` doc-drift pattern; when README phrasing adds a new count claim, its regex is added to the guard (the deliberate-change checkpoint).

## Verification

`go test ./tests/ -run TestREADME_CollectorCountMatchesRegistry` passes; gofmt/vet clean.

closes #161