### PR TITLE
Remove residual current-voice "Arq" branding after #137 (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Arq Signals will be documented in this file.
+All notable changes to Elevarq Signals will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 

--- a/examples/timescaledb-demo/README.md
+++ b/examples/timescaledb-demo/README.md
@@ -7,7 +7,7 @@ Issue: [#76](https://github.com/Elevarq/Arq-Signals/issues/76).
 
 Collector contract: `specifications/collectors/timescaledb_family_v1.md`.
 Analyzer rule mapping: `docs/timescaledb-analyzer-roadmap.md`
-(TS-R001..TS-R009, [Elevarq/Arq#1204](https://github.com/Elevarq/Elevarq/issues/1204)).
+(TS-R001..TS-R009, [Elevarq/Arq#1204](https://github.com/Elevarq/Arq/issues/1204)).
 
 ## Run it
 

--- a/internal/guidedconnect/detect.go
+++ b/internal/guidedconnect/detect.go
@@ -1,5 +1,5 @@
 // Package guidedconnect implements the orchestration behind
-// `arqctl connect --auto` (#99): it auto-detects the cloud platform and
+// `signalsctl connect --auto` (#99): it auto-detects the cloud platform and
 // ambient identity, proposes an auth_method, resolves the credential,
 // runs the existing connection diagnostic, validates the role is
 // read-only, and renders either a ready-to-use (secret-free) target


### PR DESCRIPTION
## Summary

Follow-up to the #137 rebrand. Removes the two **current-voice** "Arq" residues found during the documentation audit (alongside #161), and fixes one tangential broken link.

## Changes

- `CHANGELOG.md:3` — standing header "Arq Signals" → "Elevarq Signals". Historical release entries (e.g. the v0.1.0 "Initial open-source release of Arq Signals", past `ARQ_SIGNALS_*` env vars) are **left as factual records**.
- `internal/guidedconnect/detect.go:2` — package comment named the deprecated binary `arqctl connect --auto` → `signalsctl connect --auto`.
- `examples/timescaledb-demo/README.md:10` — link URL `github.com/Elevarq/Elevarq/...` → `github.com/Elevarq/Arq/issues/1204` (matches the `Elevarq/Arq#1204` link text).

## Deliberately untouched

The `arqctl` deprecated-binary **alias** — `cmd/signalsctl/main.go` warning shim + the `arqctl` symlink in `Dockerfile`/`Makefile` — is retained until one release after launch per #137. Verified still intact.

## Verification

gofmt clean, `go vet` + `go build ./...` pass. No current-voice "Arq Signals" / `arqctl` remains in non-archive docs; no live `ARQ_*` env vars in deploy/CI/helm.

closes #163