### PR TITLE
Drop deprecated arqctl / arq-signals binary aliases (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,10 +94,18 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     `TestR083ControlPlaneTokenSetsArqActor`,
     `TestHelm_ConfigMapIsMountedAtEtcArq`).
 
-  Unchanged (intentional): the `arqctl` deprecated-binary alias (warns and
-  forwards to `signalsctl` until launch), internal `ARQ-SIGNALS-*`
-  requirement IDs, and the Go module path / `features/arq-signals/` tree
-  (gated on the repository rename #62).
+  Unchanged (intentional): internal `ARQ-SIGNALS-*` requirement IDs, and
+  the Go module path / `features/arq-signals/` tree (gated on the
+  repository rename #62).
+
+### Removed
+
+- **Deprecated binary aliases `arqctl` and `arq-signals` (#168).** The old
+  Arq-branded names introduced as a transitional courtesy in #62 are gone:
+  the daemon and CLI no longer respond to (or warn under) those names, and
+  the container image / `make build` no longer create the symlinks. Use
+  `signals` and `signalsctl`. Brought forward from the originally planned
+  post-launch removal ahead of the repository rename (#62).
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,6 @@ RUN apk add --no-cache tini ca-certificates \
 COPY --from=builder /out/signals /usr/local/bin/signals
 COPY --from=builder /out/signalsctl /usr/local/bin/signalsctl
 
-# Deprecation aliases (#62): the old Arq-branded names resolve to the same
-# binaries and emit a stderr deprecation warning on use. Removed one
-# release after launch.
-RUN ln -s signals /usr/local/bin/arq-signals \
-    && ln -s signalsctl /usr/local/bin/arqctl
-
 RUN mkdir -p /data && chown signals:signals /data
 VOLUME /data
 

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,6 @@ LDFLAGS  = -X github.com/elevarq/arq-signals/internal/safety.Version=$(VERSION) 
 build:
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/signals ./cmd/signals
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/signalsctl ./cmd/signalsctl
-	# Deprecation aliases (#62): the old Arq-branded names resolve to the
-	# same binaries and emit a stderr deprecation warning on use. Removed
-	# one release after launch.
-	ln -sf signals bin/arq-signals
-	ln -sf signalsctl bin/arqctl
 
 test:
 	go test -race -count=1 ./...

--- a/cmd/signals/main.go
+++ b/cmd/signals/main.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -43,19 +42,7 @@ func redactReloadErr(err error) string {
 	return msg
 }
 
-// warnIfDeprecatedAlias prints a one-line deprecation notice to stderr
-// when the daemon is invoked under its old Arq-branded name. The alias
-// binary (arq-signals) is built from this same package and is removed
-// one release after launch (#62).
-func warnIfDeprecatedAlias() {
-	if filepath.Base(os.Args[0]) == "arq-signals" {
-		fmt.Fprintln(os.Stderr, "warning: \"arq-signals\" is deprecated and will be removed after launch; use \"signals\" instead")
-	}
-}
-
 func main() {
-	warnIfDeprecatedAlias()
-
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "signals: %v\n", err)
 		os.Exit(1)

--- a/cmd/signalsctl/main.go
+++ b/cmd/signalsctl/main.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"time"
 
@@ -22,19 +21,7 @@ var (
 	apiToken string
 )
 
-// warnIfDeprecatedAlias prints a one-line deprecation notice to stderr
-// when the CLI is invoked under its old Arq-branded name. The alias
-// binary (arqctl) is built from this same package and is removed one
-// release after launch (#62).
-func warnIfDeprecatedAlias() {
-	if filepath.Base(os.Args[0]) == "arqctl" {
-		fmt.Fprintln(os.Stderr, "warning: \"arqctl\" is deprecated and will be removed after launch; use \"signalsctl\" instead")
-	}
-}
-
 func main() {
-	warnIfDeprecatedAlias()
-
 	root := &cobra.Command{
 		Use:   "signalsctl",
 		Short: "CLI for Elevarq Signals",


### PR DESCRIPTION
## Summary

Removes the transitional binary aliases from #62 — `arqctl` (→ `signalsctl`) and `arq-signals` (→ `signals`) — ahead of the repository rename (#62) and the de-Arq cleanup. Brought forward from the originally planned post-launch removal (#137).

## Changes

- `cmd/signalsctl/main.go` & `cmd/signals/main.go`: removed `warnIfDeprecatedAlias()` + its call; dropped the now-unused `path/filepath` import.
- `Dockerfile` & `Makefile`: removed the `arq-signals` / `arqctl` symlink blocks.
- `CHANGELOG.md [Unreleased]`: added a `### Removed` entry; dropped `arqctl` from the #137 "Unchanged (intentional)" note (the module-path / `features/arq-signals/` tree remains gated on the repo rename #62).

## Verification

gofmt / `go vet` / `go build ./...` / `go test ./...` all pass (no unused-import breakage). No tests or specs reference the aliases. Confirmed no `arqctl` / `arq-signals` *binary-alias* references remain (only the legitimate module path, spec paths, and `ARQ-SIGNALS-*` requirement IDs, which stay until the rename).

closes #168