### PR TITLE
Docs: encryption-at-rest design statement (#177)

### DIFF
--- a/docs/install/kubernetes-production.md
+++ b/docs/install/kubernetes-production.md
@@ -100,6 +100,37 @@ Per-component summary for the platform team's review:
 | API auth | Bearer token via Secret; `subtle.ConstantTimeCompare`; strong-token validation |
 | Outbound network | None except Postgres + DNS (NetworkPolicy enforces) |
 | Volumes | PVC for SQLite store; emptyDir for `/tmp` (read-only root) |
+| Encryption at rest | Provide an **encrypted `StorageClass`** for the PVC (see below); Signals stores diagnostic data only — never credentials |
+
+## Encryption at rest
+
+The SQLite store holds collected diagnostic data and snapshot state — **never
+credentials** (they are read at connect time and never written to disk). The
+store is plaintext at the application layer; at-rest encryption is provided by
+the volume, the standard KMS-backed control:
+
+- Back the PVC with an **encrypted `StorageClass`**. With the AWS EBS CSI
+  driver, for example:
+
+  ```yaml
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: ssd-encrypted-retain
+  provisioner: ebs.csi.aws.com
+  parameters:
+    type: gp3
+    encrypted: "true"          # KMS-encrypted volume
+    # kmsKeyId: <arn>          # optional: a customer-managed key
+  reclaimPolicy: Retain
+  ```
+
+  then set `persistence.storageClass: ssd-encrypted-retain` in your Helm
+  values. Other providers expose an equivalent encrypted-class option.
+
+See [runtime-safety-model.md → Data at Rest](../runtime-safety-model.md#data-at-rest)
+for the rationale (it keeps the airgapped, dependency-free binary intact while
+satisfying encryption-at-rest requirements at the infrastructure layer).
 
 ## Deployment topologies
 

--- a/docs/runtime-safety-model.md
+++ b/docs/runtime-safety-model.md
@@ -42,6 +42,32 @@ Conservative timeouts are applied via `SET LOCAL` inside the collection transact
 - Never included in snapshot exports or API responses
 - Error messages containing credential information are redacted
 
+## Data at Rest
+The local store (`modernc.org/sqlite`, pure-Go, `CGO_ENABLED=0`) holds
+**collected diagnostic data and snapshot state only**. Per *Credential
+Handling* above, **credentials are never written to it** — the most sensitive
+material never reaches disk.
+
+By design the store is **plaintext at the application layer**: the pure-Go
+SQLite engine has no built-in encryption, and Signals intentionally does not
+add one, because doing so would require a CGO build (e.g. SQLCipher + a C
+crypto library) and forfeit the static, dependency-free, auditable binary that
+is a core property of the project.
+
+**At-rest encryption is provided by the deployment environment** — the
+standard, KMS-backed control for this class of data:
+
+- **Kubernetes:** back the SQLite PVC with an encrypted `StorageClass`
+  (e.g. an EBS CSI class with `encrypted: "true"`, or any provider equivalent).
+- **EC2 / VM:** use an encrypted EBS volume / encrypted host disk for the data
+  directory.
+- **Bare metal:** host full-disk encryption (LUKS or equivalent).
+
+This keeps the airgapped, no-egress design intact while satisfying
+encryption-at-rest requirements (including the AWS FTR control) at the
+infrastructure layer. See the encrypted-`StorageClass` guidance in
+[install/kubernetes-production.md](install/kubernetes-production.md).
+
 ## Unsafe Override
 An explicit override is available for lab/dev environments only:
 ```


### PR DESCRIPTION
## Summary

Documents the encryption-at-rest design: the local SQLite store holds diagnostic data only (never credentials) and is plaintext at the application layer by design — SQLCipher would force a CGO build and forfeit the static, auditable binary. At-rest encryption is provided at the infrastructure layer (encrypted EBS / PVC `StorageClass` / host FDE) — the standard KMS-backed control that keeps the airgapped design intact and satisfies the AWS FTR control.

Adds a **Data at Rest** section to `docs/runtime-safety-model.md` and an **encrypted-StorageClass** guide (with an EBS CSI example) to `docs/install/kubernetes-production.md`.

Closes the encryption-at-rest gap from FTR-readiness umbrella #174.

closes #177
