### PR TITLE
Docs: fix stale secret_store/auth_method schema in appendix-b (#165)

### DIFF
--- a/features/signals/appendix-b-configuration-schema.md
+++ b/features/signals/appendix-b-configuration-schema.md
@@ -73,7 +73,7 @@ targets:
     # short-lived token minted from the collector's ambient cloud identity.
     auth_method: <string>    # Optional. "password" (default) | "aws_rds_iam"
                              #   | "azure_entra" | "gcp_cloudsql_iam"
-                             #   | "secret_store".
+                             #   | "secret_store" | "mtls".
     region: <string>         # Optional. AWS region for aws_rds_iam; when
                              #   omitted, resolved from AWS_REGION /
                              #   AWS_DEFAULT_REGION / instance metadata (IMDS).
@@ -85,9 +85,10 @@ targets:
                              #   the ambient ADC identity is used directly.
     secret_ref: <string>     # Required for secret_store. Cloud vault reference;
                              #   its shape selects the backend (AWS Secrets
-                             #   Manager ARN | Azure Key Vault secret URI | GCP
-                             #   Secret Manager resource name). AWS region is
-                             #   taken from the ARN, never from AWS_REGION/IMDS.
+                             #   Manager ARN | AWS Parameter Store ARN | Azure
+                             #   Key Vault secret URI | GCP Secret Manager
+                             #   resource name). AWS region is taken from the
+                             #   ARN, never from AWS_REGION/IMDS.
     secret_json_key: <string> # Optional, secret_store only. When set, parse the
                              #   fetched secret as a JSON object and use this
                              #   key's string value; when omitted, the raw
@@ -289,13 +290,12 @@ fetching identity needs `ssm:GetParameter` (and `kms:Decrypt` on the CMK for
 a `SecureString`). Like Secrets Manager it supplies no TTL, so reuse is
 bounded by `max_cache_ttl`.
 
-**Backend availability in this release:** the **AWS Secrets Manager** and
-**AWS Systems Manager Parameter Store** paths are production-grade. Azure
-Key Vault and GCP Secret Manager references are accepted at startup (the
-shapes are recognised and validated) but their production fetchers are
-deferred — a target using one fails at connect time with a clear "backend
-is not available in this build" error and does not stop collection for
-other targets. Tracked as a follow-up.
+**Backend availability:** all four `secret_store` backends — **AWS Secrets
+Manager**, **AWS Systems Manager Parameter Store**, **Azure Key Vault**, and
+**GCP Secret Manager** — are production-wired (Azure Key Vault and GCP Secret
+Manager shipped in #108). A target using any of them fetches its secret from
+the inferred backend at connect time; for a given target only that backend's
+SDK is invoked (INV005).
 
 The fetched secret is cached per target. The reuse bound is
 `min(vault-supplied TTL if any, max_cache_ttl if set)`; AWS Secrets Manager

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -187,8 +187,9 @@ type TargetConfig struct {
 	GCPImpersonateServiceAccount string `yaml:"gcp_impersonate_service_account"`
 
 	// SecretRef is the cloud secret-store reference for the secret_store
-	// provider (SIGNALS-AUTH-SECRET-, #97): an AWS Secrets Manager ARN,
-	// an Azure Key Vault secret URI, or a GCP Secret Manager resource name.
+	// provider (SIGNALS-AUTH-SECRET-, #97): an AWS Secrets Manager ARN, an
+	// AWS Systems Manager Parameter Store ARN, an Azure Key Vault secret URI,
+	// or a GCP Secret Manager resource name.
 	// Its shape selects the backend (InferSecretBackend). Required when
 	// auth_method is secret_store (FC-SECRET-007). Not a secret: the
 	// reference names, but does not contain, the credential.


### PR DESCRIPTION
## Summary

Brings `features/signals/appendix-b-configuration-schema.md` back in line with the code:

- **Backend availability**: was "Azure Key Vault / GCP Secret Manager fetchers deferred / not available in this build" — they are production-wired (since #108). Now states all four `secret_store` backends are wired.
- **`auth_method` enum** comment: added the missing `mtls`.
- **`secret_ref` comment**: added the AWS Parameter Store ARN form.
- `internal/config/config.go` `SecretRef` field comment updated to list Parameter Store (comment-only).

Doc/comment-only, no behaviour change. Closes #165.
