### PR TITLE
Docs: document the 14 missing collectors + completeness guard (#166)

### DIFF
--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -54,6 +54,7 @@ Operational health, security, and planner diagnostics.
 | `connection_utilization_v1` | `pg_stat_activity` | 5m | Connection counts vs max_connections |
 | `planner_stats_staleness_v1` | `pg_stat_user_tables` + `pg_class` | 1h | Estimate drift and modifications since analyze |
 | `pgss_reset_check_v1` | `pg_stat_statements_info` | 1h | Statistics reset timestamp (requires extension, PG 14+) |
+| `pgss_capacity_v1` | `pg_stat_statements_info` + `pg_stat_statements` | 1h | `pg_stat_statements` capacity pressure: dealloc counter and tracked-statement count (requires extension) |
 
 ## Server Survival Pack
 
@@ -154,6 +155,19 @@ excluded.
 | `pg_stats_v1` | `pg_stats` | 24h | Column-level planner stats (`n_distinct`, `correlation`); MCV / histogram payloads deliberately excluded |
 | `pg_stats_extended_v1` | `pg_statistic_ext` | 24h | Multi-column extended statistics |
 | `pg_vector_columns_v1` | `pg_attribute` + `pg_type` | 24h | `vector` columns inventory (requires `vector` extension, PG 14+) |
+| `pg_types_v1` | `pg_type` + `pg_namespace` (+ `pg_enum`) | 24h | User-defined types and domains (enums, composites, domains) |
+| `pg_aggregates_v1` | `pg_aggregate` + `pg_proc` | 24h | User-defined aggregate inventory (non-extension-owned) |
+| `pg_operators_v1` | `pg_operator` + `pg_proc` | 24h | User-defined operator inventory (non-extension-owned) |
+| `pg_casts_v1` | `pg_cast` + `pg_type` + `pg_proc` | 24h | User-defined cast inventory (non-extension-owned) |
+| `pg_collations_v1` | `pg_collation` + `pg_namespace` | 24h | User-defined collation inventory (non-extension-owned) |
+| `pg_text_search_v1` | `pg_ts_config` + `pg_ts_parser` | 24h | User-defined text-search configuration inventory (non-extension-owned) |
+| `pg_identity_columns_v1` | `pg_attribute` + `pg_class` + `pg_depend` | 24h | Identity / `SERIAL` column metadata for user-schema tables |
+| `pg_statistic_ext_v1` | `pg_statistic_ext` + `pg_class` | 24h | Extended-statistics object metadata (names, kinds, attnums) |
+| `pg_statistic_ext_data_v1` | `pg_statistic_ext_data` + `pg_statistic_ext` | 24h | Sampled extended-statistics data (kinds d/f/e; excludes MCV) |
+| `pg_statistic_ext_data_mcv_v1` | `pg_statistic_ext_data` + `pg_statistic_ext` | 24h | Sampled extended-statistics MCV data (kind m); high-sensitivity, off by default |
+| `pg_stats_array_range_v1` | `pg_stats` | 24h | Per-element / per-range planner stats (array/range MCV & histograms); high-sensitivity, opt-in (`CollectArrayRangeHistograms`) |
+| `pg_policies_v1` | `pg_policies` + `pg_class` | 24h | Row-level security (RLS) policy inventory with table RLS flags; high-sensitivity, off by default |
+| `pg_rules_v1` | `pg_rules` | 24h | Rewrite-rule (`CREATE RULE`) inventory; high-sensitivity, off by default |
 
 ## DDL definitions
 

--- a/tests/signals_collectors_doc_completeness_test.go
+++ b/tests/signals_collectors_doc_completeness_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/elevarq/signals/internal/pgqueries"
+)
+
+// Anti-drift guard for #166. Every collector registered in pgqueries.All()
+// must be documented in docs/collectors.md. The README guard pins the
+// collector *count* (99); this pins table *completeness*, so a collector
+// cannot be added to the registry without an inventory row — which is exactly
+// how docs/collectors.md fell 14 behind the registry.
+func TestCollectorsDoc_EveryRegistryIDDocumented(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "collectors.md"))
+	if err != nil {
+		t.Fatalf("read docs/collectors.md: %v", err)
+	}
+	body := string(data)
+
+	var missing []string
+	for _, q := range pgqueries.All() {
+		if !strings.Contains(body, q.ID) {
+			missing = append(missing, q.ID)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("docs/collectors.md is missing %d registered collector(s) from its inventory: %s",
+			len(missing), strings.Join(missing, ", "))
+	}
+}


### PR DESCRIPTION
## Summary

`docs/collectors.md` documented only **85 of 99** registered collectors. This adds the **14 missing** inventory rows — 13 under *Schema model* (`pg_types`, `pg_aggregates`, `pg_operators`, `pg_casts`, `pg_collations`, `pg_text_search`, `pg_identity_columns`, the extended-statistics trio, `pg_stats_array_range`, `pg_policies`, `pg_rules`) and `pgss_capacity` next to its `pg_stat_statements` sibling — each with PostgreSQL source + cadence, with high-sensitivity collectors flagged.

**Anti-drift guard:** `tests/signals_collectors_doc_completeness_test.go` asserts every `pgqueries.All()` ID appears in `docs/collectors.md` — so a new collector cannot enter the registry without an inventory row (which is exactly how the doc fell 14 behind). Passing at 99/99.

Closes #166.
