### PR TITLE
Docs: document 2 missing Prometheus metrics + completeness guard (#167)

### DIFF
--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -133,6 +133,8 @@ just samples the same counter values more often.
 | `signals_sqlite_persistence_failures_total` | counter | (none) | `InsertCollectionAtomic` rollbacks (R077). |
 | `signals_last_successful_collection_timestamp` | gauge | `target` | Unix seconds of the most recent successful collection per target. |
 | `signals_high_sensitivity_collectors_enabled` | gauge | (none) | `1` if the R075 gate is open, `0` otherwise. |
+| `signals_circuit_state` | gauge | `target`, `state` | Per-target circuit-breaker state (R097); one row per state (`closed` / `open` / `paused`), the active row has value `1`, the others `0`. |
+| `signals_eligible_collectors` | gauge | `target` | Collectors eligible to run for the target after the version (R081), extension, daemon-wide sensitivity (R075), and per-target profile (R098) gates. Alert on sudden drops. |
 
 ## Suggested alerts
 

--- a/tests/signals_prometheus_doc_completeness_test.go
+++ b/tests/signals_prometheus_doc_completeness_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Anti-drift guard for #167. Every Prometheus metric registered in
+// internal/metrics/metrics.go must be documented in docs/prometheus.md's
+// metric reference. docs/prometheus.md had fallen two metrics behind the
+// code (signals_circuit_state, signals_eligible_collectors); this keeps the
+// reference complete as metrics are added.
+func TestPrometheusDoc_EveryRegisteredMetricDocumented(t *testing.T) {
+	root := repoRoot(t)
+
+	src, err := os.ReadFile(filepath.Join(root, "internal", "metrics", "metrics.go"))
+	if err != nil {
+		t.Fatalf("read metrics.go: %v", err)
+	}
+	doc, err := os.ReadFile(filepath.Join(root, "docs", "prometheus.md"))
+	if err != nil {
+		t.Fatalf("read prometheus.md: %v", err)
+	}
+	docBody := string(doc)
+
+	re := regexp.MustCompile(`Name:\s*"(signals_[a-z0-9_]+)"`)
+	names := map[string]bool{}
+	for _, m := range re.FindAllStringSubmatch(string(src), -1) {
+		names[m[1]] = true
+	}
+	if len(names) == 0 {
+		t.Fatal("no signals_* metric names found in metrics.go — the guard regex needs updating")
+	}
+
+	var missing []string
+	for n := range names {
+		if !strings.Contains(docBody, n) {
+			missing = append(missing, n)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("docs/prometheus.md is missing %d registered metric(s) from its reference: %s",
+			len(missing), strings.Join(missing, ", "))
+	}
+}


### PR DESCRIPTION
## Summary

`docs/prometheus.md` documented 12 of the 14 registered metrics. Adds the two missing gauges to the reference: `signals_circuit_state` (per-target circuit-breaker state, R097) and `signals_eligible_collectors` (per-target eligible-collector count after the R081/R075/R098 gates).

**Anti-drift guard:** `tests/signals_prometheus_doc_completeness_test.go` asserts every `signals_*` metric registered in `internal/metrics/metrics.go` is documented in `docs/prometheus.md`. Passing.

Closes #167.
