### PR TITLE
Security: redact structured credential secrets in statement text (#188)

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1133,6 +1133,14 @@ func (c *Collector) collectTarget(ctx context.Context, tgt config.TargetConfig, 
 		// Spec: specifications/collectors/fdw_*_v1.md REDACT-R001..R004.
 		redactFDWRowsIfNeeded(q.ID, rows)
 
+		// Statement-text post-processing: redact structured credential
+		// literals (PASSWORD '…', conninfo password=) in collectors that
+		// carry raw SQL text (pg_stat_statements_v1.query) BEFORE encoding,
+		// so cleartext never reaches disk or the export. No-op otherwise.
+		// Spec: specifications/collectors/pg_stat_statements_v1.md
+		// REDACT-R001..R003 (#188 / INV-SIGNALS-07).
+		redactStatementSecretsIfNeeded(q.ID, rows)
+
 		// R075 (revised, issue #6): when the operator has opted out of
 		// high-sensitivity collection, NULL the collector's declared
 		// SensitiveColumns in each row so the sensitive payload never

--- a/internal/collector/statement_postprocess.go
+++ b/internal/collector/statement_postprocess.go
@@ -1,0 +1,44 @@
+// Statement-text secret post-processor.
+//
+// Some collectors expose raw SQL statement text that can contain
+// structured credential literals (e.g. pg_stat_statements_v1's `query`
+// column carries un-normalized CREATE/ALTER ROLE … PASSWORD '…'). This
+// post-processor runs after queryToMaps and BEFORE the rows are encoded
+// into NDJSON, so cleartext credentials never reach the snapshot writer
+// or the daemon's persisted store (REDACT-R001..R003, #188 /
+// INV-SIGNALS-07).
+//
+// The redaction logic lives in internal/pgqueries/statement_redact.go
+// (RedactStatementSecrets). This file is the wiring: which collector ID
+// owns which statement-text column.
+
+package collector
+
+import (
+	"github.com/elevarq/signals/internal/pgqueries"
+)
+
+// statementTextColumnByID maps a collector ID to the row column whose
+// value is raw SQL statement text needing structured-credential
+// redaction. Only pg_stat_statements_v1 exposes such text today; the map
+// keeps the wiring explicit and a no-op for every other collector.
+var statementTextColumnByID = map[string]string{
+	"pg_stat_statements_v1": "query",
+}
+
+// redactStatementSecretsIfNeeded mutates rows in place when queryID names
+// a collector with a statement-text column, masking structured credential
+// literals before the rows are persisted/exported. Unconditional — it does
+// not consult the high-sensitivity gate, because a credential must never
+// be exportable (INV-SIGNALS-07). No-op for every other collector.
+func redactStatementSecretsIfNeeded(queryID string, rows []map[string]any) {
+	col, ok := statementTextColumnByID[queryID]
+	if !ok {
+		return
+	}
+	for _, row := range rows {
+		if s, ok := row[col].(string); ok {
+			row[col] = pgqueries.RedactStatementSecrets(s)
+		}
+	}
+}

--- a/internal/collector/statement_postprocess_test.go
+++ b/internal/collector/statement_postprocess_test.go
@@ -1,0 +1,33 @@
+package collector
+
+import "testing"
+
+// REDACT-R001 wiring (#188): redactStatementSecretsIfNeeded masks the
+// statement-text column for pg_stat_statements_v1 in place, and is a no-op
+// for every other collector.
+func TestRedactStatementSecretsIfNeeded(t *testing.T) {
+	t.Run("redacts pg_stat_statements query column", func(t *testing.T) {
+		rows := []map[string]any{
+			{"query": "CREATE ROLE signals WITH LOGIN PASSWORD 'monitor_pass'", "calls": int64(1)},
+			{"query": "SELECT * FROM t WHERE id = $1", "calls": int64(9)},
+		}
+		redactStatementSecretsIfNeeded("pg_stat_statements_v1", rows)
+		if got := rows[0]["query"]; got != "CREATE ROLE signals WITH LOGIN PASSWORD '<redacted>'" {
+			t.Errorf("password not redacted: %q", got)
+		}
+		if got := rows[1]["query"]; got != "SELECT * FROM t WHERE id = $1" {
+			t.Errorf("normal query must be unchanged: %q", got)
+		}
+		if rows[0]["calls"] != int64(1) {
+			t.Errorf("non-text columns must be untouched")
+		}
+	})
+
+	t.Run("no-op for other collectors", func(t *testing.T) {
+		rows := []map[string]any{{"query": "CREATE ROLE x PASSWORD 'leak'"}}
+		redactStatementSecretsIfNeeded("pg_stat_activity_v1", rows)
+		if got := rows[0]["query"]; got != "CREATE ROLE x PASSWORD 'leak'" {
+			t.Errorf("must not touch non-registered collectors; got %q", got)
+		}
+	})
+}

--- a/internal/pgqueries/statement_redact.go
+++ b/internal/pgqueries/statement_redact.go
@@ -1,0 +1,54 @@
+// Statement-text secret redaction.
+//
+// pg_stat_statements normalizes constants in ordinary DML to `$N`
+// placeholders, but utility statements (CREATE/ALTER ROLE …) are NOT
+// normalized, so a literal password survives in the view's `query`
+// column. RedactStatementSecrets masks the finite, well-defined set of
+// *structured credential syntaxes* in statement text, before the row is
+// persisted or exported (REDACT-R001..R003, #188 / INV-SIGNALS-07).
+//
+// Scope is deliberately limited to structured credential syntax. Secrets
+// hard-coded into free-form code (function bodies, arbitrary literals,
+// comments) are NOT detected — see #189 (bucket 2): that is undecidable
+// and a content scanner would either gut diagnostic value or give false
+// assurance.
+
+package pgqueries
+
+import "regexp"
+
+var (
+	// `[ENCRYPTED] PASSWORD '<literal>'` in CREATE/ALTER ROLE|USER|GROUP.
+	// The literal is a single-quoted SQL string ('' escapes an embedded
+	// quote). The keyword prefix is preserved; only the literal is masked.
+	passwordLiteralRe = regexp.MustCompile(`(?i)(\b(?:ENCRYPTED\s+)?PASSWORD\s+)'(?:[^']|'')*'`)
+
+	// libpq conninfo `password=<value>` inside dblink / postgres_fdw /
+	// CREATE SUBSCRIPTION … CONNECTION text. The value is an unquoted run
+	// terminated by whitespace or a closing quote.
+	conninfoPasswordRe = regexp.MustCompile(`(?i)(password\s*=\s*)([^\s']+)`)
+
+	// `$N` normalized placeholders — never redacted (avoids mangling DML
+	// such as `WHERE password = $1`).
+	placeholderRe = regexp.MustCompile(`^\$\d+$`)
+)
+
+// RedactStatementSecrets masks structured credential literals — role/user
+// PASSWORD literals and libpq conninfo `password=` values — in SQL
+// statement text, while leaving normalized DML and non-credential content
+// unchanged (REDACT-R002 / REDACT-R003). It does not attempt to find
+// secrets in free-form code (#189).
+func RedactStatementSecrets(s string) string {
+	if s == "" {
+		return s
+	}
+	s = passwordLiteralRe.ReplaceAllString(s, "$1'<redacted>'")
+	s = conninfoPasswordRe.ReplaceAllStringFunc(s, func(m string) string {
+		sub := conninfoPasswordRe.FindStringSubmatch(m)
+		if placeholderRe.MatchString(sub[2]) {
+			return m // a normalized placeholder, not a real secret
+		}
+		return sub[1] + "<redacted>"
+	})
+	return s
+}

--- a/internal/pgqueries/statement_redact_test.go
+++ b/internal/pgqueries/statement_redact_test.go
@@ -1,0 +1,66 @@
+package pgqueries
+
+import "testing"
+
+// REDACT-R002 / REDACT-R003 (pg_stat_statements_v1, #188): RedactStatementSecrets
+// masks structured credential literals in statement text while leaving everything
+// else untouched. Written failing before the implementation exists.
+func TestRedactStatementSecrets(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "create role password (the reported leak)",
+			in:   "CREATE ROLE signals WITH LOGIN PASSWORD 'monitor_pass'",
+			want: "CREATE ROLE signals WITH LOGIN PASSWORD '<redacted>'",
+		},
+		{
+			name: "alter user encrypted password",
+			in:   "ALTER USER bob ENCRYPTED PASSWORD 'sekret-123'",
+			want: "ALTER USER bob ENCRYPTED PASSWORD '<redacted>'",
+		},
+		{
+			name: "alter role password with special chars",
+			in:   "ALTER ROLE admin PASSWORD 'p@ss w0rd!$%'",
+			want: "ALTER ROLE admin PASSWORD '<redacted>'",
+		},
+		{
+			name: "conninfo password= in dblink",
+			in:   "SELECT dblink('host=db port=5432 password=topsecret dbname=app', 'select 1')",
+			want: "SELECT dblink('host=db port=5432 password=<redacted> dbname=app', 'select 1')",
+		},
+		{
+			name: "create subscription connection conninfo",
+			in:   "CREATE SUBSCRIPTION s CONNECTION 'host=h dbname=d user=u password=hunter2' PUBLICATION p",
+			want: "CREATE SUBSCRIPTION s CONNECTION 'host=h dbname=d user=u password=<redacted>' PUBLICATION p",
+		},
+		{
+			name: "parameterized DML is unchanged (no over-redaction)",
+			in:   "SELECT * FROM users WHERE id = $1 AND token = $2",
+			want: "SELECT * FROM users WHERE id = $1 AND token = $2",
+		},
+		{
+			name: "the word password without a value is unchanged",
+			in:   "SELECT count(*) FROM audit WHERE event = 'password_reset'",
+			want: "SELECT count(*) FROM audit WHERE event = 'password_reset'",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactStatementSecrets(tc.in)
+			if got != tc.want {
+				t.Errorf("RedactStatementSecrets(%q)\n  got:  %q\n  want: %q", tc.in, got, tc.want)
+			}
+			if tc.want != tc.in && got == tc.in {
+				t.Errorf("secret was NOT redacted: %q", got)
+			}
+		})
+	}
+}

--- a/specifications/collectors/pg_stat_statements_v1.md
+++ b/specifications/collectors/pg_stat_statements_v1.md
@@ -58,11 +58,33 @@ includes but is not limited to:
 
 ## Query text handling
 
-- Normalized text only: `pg_stat_statements` replaces constants
-  with `$N` placeholders for parameterized SQL. Unparameterized
-  SQL retains its literals — acceptable under the
-  deployment-boundary assumption (data remains on site). No
-  collection-time redaction.
+- Normalized text: `pg_stat_statements` replaces constants with `$N`
+  placeholders for parameterized SQL, so ordinary DML literals are not
+  retained. **Utility statements are not normalized**, so a literal
+  secret in `CREATE`/`ALTER ROLE … PASSWORD '…'` — or a libpq conninfo
+  `password=` inside `dblink` / `postgres_fdw` / `CREATE SUBSCRIPTION …
+  CONNECTION` — is retained verbatim by the view (#188).
+- **REDACT-R001 (structured credential redaction):** the `query`
+  column MUST be passed through the statement-secret redactor before
+  the row is persisted or exported (the same pre-NDJSON seam as the FDW
+  option redactor), so cleartext never reaches the local store or the
+  snapshot. This is **unconditional** — independent of the
+  high-sensitivity gate (SIGNALS-R075); a credential must never be
+  exportable. Reaffirms **INV-SIGNALS-07**.
+- **REDACT-R002 (patterns):** the redactor masks the secret literal
+  while preserving the surrounding statement shape:
+  - `[ENCRYPTED] PASSWORD '<lit>'` in `CREATE`/`ALTER`
+    `ROLE`/`USER`/`GROUP` → `PASSWORD '<redacted>'`.
+  - libpq conninfo `password=<val>` / `password '<val>'` (in `dblink`,
+    `postgres_fdw`, `CREATE SUBSCRIPTION … CONNECTION`, and user-mapping
+    option text) → `password=<redacted>`.
+- **REDACT-R003 (no over-redaction):** statements with no credential
+  syntax — the overwhelming majority, since DML literals are already
+  `$N`-normalized — pass through unchanged, preserving diagnostic value.
+- **Out of scope (bucket 2, #189):** secrets hard-coded into free-form
+  code (function/procedure bodies, arbitrary non-credential literals,
+  comments) are NOT detected or redacted. This collector guarantees
+  redaction only of the structured credential syntax above.
 
 ## Invariants
 
@@ -102,9 +124,12 @@ includes but is not limited to:
 
 ## Sensitivity
 
-Low-to-medium. Query text may embed literals on unparameterized SQL;
-by deployment-boundary assumption the snapshot remains within the
-customer site.
+Low-to-medium. Structured credential syntax in the `query` text
+(`PASSWORD '…'`, conninfo `password=`) is redacted before persistence
+(REDACT-R001..R003, INV-SIGNALS-07). Non-credential literals on
+unparameterized SQL may still appear and, like secrets hard-coded into
+free-form code (bucket 2, #189), are not redacted; the snapshot remains
+within the customer site by the deployment-boundary assumption.
 
 ## Analyzer requirements unblocked
 


### PR DESCRIPTION
## Summary

Fixes the P0 credential leak found by the local beta smoke: `pg_stat_statements_v1` exported plaintext passwords from un-normalized utility statements (`CREATE`/`ALTER ROLE … PASSWORD '…'`, libpq conninfo `password=`).

**Fix:** a statement-text redactor (`RedactStatementSecrets`) wired at the pre-NDJSON seam (alongside the FDW redactor), so the secret never reaches the local SQLite store *or* the export. **Unconditional** — not gated by high-sensitivity (INV-SIGNALS-07).

**Scope = bucket 1** (structured credential syntax): `[ENCRYPTED] PASSWORD '…'` in role/user/group DDL; conninfo `password=` in dblink / postgres_fdw / `CREATE SUBSCRIPTION … CONNECTION`. Catalog user-mapping/FDW options were already redacted (REDACT-R003). Free-form-code secrets are out of scope (bucket 2, #189).

## STDD

- **Spec:** `specifications/collectors/pg_stat_statements_v1.md` REDACT-R001..R003 (+ Sensitivity), reaffirms INV-SIGNALS-07.
- **Tests:** unit (patterns + `WHERE id = $1` / `event = 'password_reset'` passthrough to pin no-over-redaction) + collector wiring.

## Verified in the real artifact

Re-ran the docker smoke: export now shows `CREATE ROLE … PASSWORD '<redacted>'` and `grep` for the password returns nothing. gofmt/vet/`go test ./...`/golangci-lint/gitleaks/govulncheck/semgrep/osv/kube-lint all green.

closes #188
