### PR TITLE
Release hygiene: finalize CHANGELOG for 0.10.0-beta.7 (Gate F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0-beta.7] - 2026-06-19
+
+> **Highlights.** Adds the AWS Systems Manager Parameter Store `secret_store`
+> backend, completes the de-`arq` rename to Elevarq Signals, and closes a
+> credential-redaction gap found during beta testing.
+>
+> **Breaking — first-party importers must update import paths.** The Go
+> module path changed `github.com/elevarq/arq-signals` ->
+> `github.com/elevarq/signals`, and the repository was renamed
+> `Elevarq/Arq-Signals` -> `Elevarq/Signals` (old URLs redirect). The
+> deprecated `arqctl` / `arq-signals` binary aliases were removed — use
+> `signals` / `signalsctl`.
+>
+> **Security.** `pg_stat_statements` query text is now redacted of structured
+> credential literals (role/user `PASSWORD`, libpq conninfo `password=`)
+> before persistence and export (#188).
+>
+> **Upgrade notes.** No config changes required beyond the import-path /
+> binary-name renames above. The committed `Chart.yaml` version is stamped
+> from the release tag at package time, so it may lag the tag.
+
 ### Added
 
 - **`secret_store`: AWS Systems Manager Parameter Store backend (#157).**


### PR DESCRIPTION
## Summary

Finalizes the CHANGELOG for the next beta so **Release-Protocol Gate F** is green. Rolls `[Unreleased]` -> `[0.10.0-beta.7] - 2026-06-19`, which is what the `release.yml` validate step greps for (it STOPs without a `## [<version>]` entry).

Adds a highlights / **breaking** (de-arq module-path + repo rename — importers update import paths; binary aliases removed) / **security** (#188 credential redaction) / upgrade-notes lead. Fresh empty `[Unreleased]` for future entries.

**No version-file bumps** — `Chart.yaml` / image versions are stamped from the git tag at release time by design (#3), so the committed file intentionally lags.

closes #191
