### PR TITLE
fix(aws): make onboarding templates runnable as documented (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **AWS onboarding templates are now runnable as documented (#198).** The
+  CloudFormation and Terraform templates ran the image as
+  `${ImageUri} --config …`, which replaced the `signals` `CMD` so tini tried to
+  exec `--config`; they now pass the `signals` subcommand explicitly. User-data
+  mints a control-plane API token and passes it via `SIGNALS_API_TOKEN` (stored
+  root-only at `/root/signals-api-token`, outside the bind mount) so the
+  documented `signalsctl status` / `export` verification can authenticate, makes
+  the bind-mounted config world-readable for the non-root container, and pins the
+  AWS image-tag defaults to `0.10.0-beta.7`.
+
 ## [0.10.0-beta.7] - 2026-06-19
 
 > **Highlights.** Adds the AWS Systems Manager Parameter Store `secret_store`

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -81,8 +81,14 @@ apply/deploy, on the collector instance:
 ```bash
 # the collector container should be running and collecting
 docker logs signals 2>&1 | grep -iE "collector|snapshot|connected"
-# trigger an export to confirm a successful passwordless connection
-docker exec signals signalsctl export --output /data/snapshot.zip
+
+# the control-plane API requires a bearer token; user-data minted one and
+# stored it root-only on the instance, outside the bind-mounted config.
+TOKEN="$(sudo cat /root/signals-api-token)"
+
+# confirm collector status and trigger an export over the loopback API
+docker exec -e SIGNALS_API_TOKEN="$TOKEN" signals signalsctl status
+docker exec -e SIGNALS_API_TOKEN="$TOKEN" signals signalsctl export --output /data/snapshot.zip
 ```
 
 A healthy run connects with **no password in config**, mints a token from the
@@ -100,6 +106,11 @@ rejected for `rds_iam`, re-check Step 1 and that the EC2 role's
   `/etc/signals/rds-ca.pem`).
 - IMDSv2 is enforced (`http_tokens = required`); the root volume is encrypted;
   the API listener binds to `127.0.0.1` only.
+- The loopback **control-plane API token** is a separate credential class from
+  the (non-existent) DB password: user-data mints a random 32-byte token, passes
+  it to the container via the environment (`SIGNALS_API_TOKEN`, the same path the
+  Helm chart uses), and stores it root-only at `/root/signals-api-token` — outside
+  the bind-mounted config, so `signals.yaml` itself stays secret-free.
 
 ## Reusing the identity elsewhere
 

--- a/deploy/aws/cloudformation/signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/signals-rds-iam.yaml
@@ -38,7 +38,7 @@ Parameters:
     Default: t3.small
   ImageUri:
     Type: String
-    Default: ghcr.io/elevarq/signals:0.10.0-beta.6
+    Default: ghcr.io/elevarq/signals:0.10.0-beta.7
     Description: Elevarq Signals container image (pinned tag).
   Env:
     Type: String
@@ -133,11 +133,24 @@ Resources:
               sslmode: verify-full
               sslrootcert_file: /etc/signals/rds-ca.pem
           YAML
+          # The config carries no secret; make the bind-mounted files
+          # world-readable so the non-root container (uid 10001) can read them.
+          chmod 0644 /etc/signals/signals.yaml /etc/signals/rds-ca.pem
+          # Mint a strong control-plane API token. It is passed to the
+          # container via the environment (mirrors the Helm SIGNALS_API_TOKEN
+          # path) and stored root-only, outside the bind mount, so the operator
+          # can authenticate the verify step — it is never written into config.
+          SIGNALS_API_TOKEN="$(openssl rand -hex 32)"
+          umask 077
+          printf '%s\n' "$SIGNALS_API_TOKEN" > /root/signals-api-token
+          # ENTRYPOINT is `tini --` with CMD `signals`; the `signals` arg below
+          # is required, else the image args replace CMD and tini execs --config.
           docker run -d --name signals --restart=always \
+            -e SIGNALS_API_TOKEN="$SIGNALS_API_TOKEN" \
             -v /etc/signals:/etc/signals:ro \
             -v signals-data:/data \
             -p 127.0.0.1:8081:8081 \
-            ${ImageUri} --config /etc/signals/signals.yaml
+            ${ImageUri} signals --config /etc/signals/signals.yaml
 
 Outputs:
   CollectorRoleArn:

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -51,11 +51,23 @@ locals {
         sslmode: verify-full
         sslrootcert_file: /etc/signals/rds-ca.pem
     YAML
+    # The config carries no secret; make the bind-mounted files world-readable
+    # so the non-root container (uid 10001) can read them.
+    chmod 0644 /etc/signals/signals.yaml /etc/signals/rds-ca.pem
+    # Mint a strong control-plane API token, passed to the container via the
+    # environment (mirrors the Helm SIGNALS_API_TOKEN path) and stored root-only,
+    # outside the bind mount, so the operator can authenticate the verify step.
+    SIGNALS_API_TOKEN="$(openssl rand -hex 32)"
+    umask 077
+    printf '%s\n' "$SIGNALS_API_TOKEN" > /root/signals-api-token
+    # ENTRYPOINT is `tini --` with CMD `signals`; the `signals` arg below is
+    # required, else the image args replace CMD and tini execs --config.
     docker run -d --name signals --restart=always \
+      -e SIGNALS_API_TOKEN="$SIGNALS_API_TOKEN" \
       -v /etc/signals:/etc/signals:ro \
       -v signals-data:/data \
       -p 127.0.0.1:8081:8081 \
-      ${var.image_uri} --config /etc/signals/signals.yaml
+      ${var.image_uri} signals --config /etc/signals/signals.yaml
   EOT
 }
 

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "instance_type" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:0.10.0-beta.5"
+  default     = "ghcr.io/elevarq/signals:0.10.0-beta.7"
 }
 
 variable "env" {


### PR DESCRIPTION
## What

Makes the AWS passwordless onboarding templates (#111) runnable from the documented commands. Four defects found during the AWS smoke, all in `deploy/aws/`:

1. **Wrong container command.** Image ran as `${ImageUri} --config …`, replacing `CMD ["signals"]` so tini execs `--config`. Now passes the `signals` subcommand explicitly (`cloudformation/signals-rds-iam.yaml`, `terraform/main.tf`).
2. **No usable API token path.** Every endpoint except `/health` requires a Bearer token (`internal/api/server.go`); templates set none, so the auto-generated token is unreachable. User-data now mints a 32-byte token and passes it via `SIGNALS_API_TOKEN` (same path as the Helm chart), stored root-only at `/root/signals-api-token` — outside the bind mount, so `signals.yaml` stays secret-free.
3. **Config unreadable by the non-root container** (uid 10001): `chmod 0644` the bind-mounted config + CA bundle.
4. **Stale tag.** AWS template defaults pinned to `0.10.0-beta.7` (the smoke-tested tag).

`README.md` verify steps updated to read the token and use the corrected `docker exec` invocation, plus a Security-notes bullet explaining the control-plane token is a separate credential class from the (non-existent) DB password.

## Why

The templates and README drifted from the binary's actual contract (`ENTRYPOINT ["tini","--"]` + `CMD ["signals"]`, token-gated API, non-root user). Aligned with the no-drift principle: docs and IaC now match real behavior.

## Verification

- `terraform fmt -check` clean; `gitleaks`/secrets scan clean (token is minted at runtime, no literal secret committed).
- Live `terraform apply` / `cloudformation deploy` against an IAM-auth-enabled RDS instance is tracked in #201 (Elevarq RDS has IAM DB auth disabled).

## Scope notes

- Cross-cloud version sweep (Helm/Azure/GCP beta drift) is #199 — those files are deliberately untouched here to avoid a cross-PR conflict.

closes #198
