### PR TITLE
chore(deploy): sweep Helm/Azure/GCP image tags to 0.10.0-beta.7 (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Swept all deploy assets to image tag `0.10.0-beta.7` (#199).** The Helm
+  chart (`Chart.yaml` `version`/`appVersion`, `values.yaml` `image.tag`) had
+  drifted to `beta.6` and the Azure/GCP Terraform + Azure Bicep to `beta.5`;
+  all now pin the smoke-tested `beta.7`. (AWS templates are bumped in #198.)
+
 ### Fixed
 
 - **AWS onboarding templates are now runnable as documented (#198).** The

--- a/deploy/azure/bicep/main.bicep
+++ b/deploy/azure/bicep/main.bicep
@@ -46,7 +46,7 @@ param adminUsername string = 'azureuser'
 param adminSshPublicKey string
 
 @description('Elevarq Signals container image (pinned tag).')
-param imageUri string = 'ghcr.io/elevarq/signals:0.10.0-beta.5'
+param imageUri string = 'ghcr.io/elevarq/signals:0.10.0-beta.7'
 
 @description('URL of the CA bundle for sslmode=verify-full. Default is the DigiCert Global Root G2 that Azure Database for PostgreSQL Flexible Server chains to.')
 param dbCaCertUrl string = 'https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem'

--- a/deploy/azure/terraform/variables.tf
+++ b/deploy/azure/terraform/variables.tf
@@ -66,7 +66,7 @@ variable "admin_ssh_public_key" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:0.10.0-beta.5"
+  default     = "ghcr.io/elevarq/signals:0.10.0-beta.7"
 }
 
 variable "db_ca_cert_url" {

--- a/deploy/gcp/terraform/variables.tf
+++ b/deploy/gcp/terraform/variables.tf
@@ -82,7 +82,7 @@ variable "image" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:0.10.0-beta.5"
+  default     = "ghcr.io/elevarq/signals:0.10.0-beta.7"
 }
 
 variable "env" {

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 0.10.0-beta.6
-appVersion: "0.10.0-beta.6"
+version: 0.10.0-beta.7
+appVersion: "0.10.0-beta.7"
 keywords:
   - postgresql
   - monitoring

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "0.10.0-beta.6"
+  tag: "0.10.0-beta.7"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration. Rendered into the mounted


### PR DESCRIPTION
## What

Sweeps every deploy asset to the smoke-tested image tag `0.10.0-beta.7`, eliminating cross-asset version drift:

| Asset | Was | Now |
|-------|-----|-----|
| `deploy/helm/signals/Chart.yaml` (`version`, `appVersion`) | beta.6 | beta.7 |
| `deploy/helm/signals/values.yaml` (`image.tag`) | beta.6 | beta.7 |
| `deploy/azure/terraform/variables.tf` (`image_uri`) | beta.5 | beta.7 |
| `deploy/azure/bicep/main.bicep` (`imageUri`) | beta.5 | beta.7 |
| `deploy/gcp/terraform/variables.tf` (`image_uri`) | beta.5 | beta.7 |

The Helm `version`/`appVersion`/`image.tag` are bumped together per the lockstep policy documented in `Chart.yaml`.

## Why

Three different tags across the deploy assets is poor launch hygiene — a single declared image tag everywhere. Aligned with the no-drift principle.

## Verification

- `grep -rn "0.10.0-beta.5\|0.10.0-beta.6" deploy/` returns only the two AWS files (handled in #198).
- `helm lint deploy/helm/signals` passes; `terraform fmt -check` clean for the Azure/GCP modules.

## Scope notes

- AWS template tags are bumped in #198 (PR #203); those files are untouched here to avoid a cross-PR conflict.
- This PR touches `CHANGELOG.md` `[Unreleased]`, which also moves in #198/PR #203 — whichever lands second gets a trivial rebase.

closes #199
