### PR TITLE
docs(changelog): remove stray merge-conflict marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-<<<<<<< HEAD
 ### Changed
 
 - **Swept all deploy assets to image tag `0.10.0-beta.7` (#199).** The Helm


### PR DESCRIPTION
A `<<<<<<< HEAD` conflict marker leaked into `CHANGELOG.md` `[Unreleased]` (line 9) during the #207 rebase conflict resolution — the opening marker was left above the resolved block, and `git rebase --continue` committed it. The required CI gates (`test`, `security-scan`) don't scan `CHANGELOG.md`, so it passed checks and merged into main.

This removes the single stray marker line. `git grep` confirms no other conflict markers remain in tracked files. No content change otherwise.

Trivial cleanup of my own rebase error (no separate issue per the issue-first trivial-fix carve-out).