### PR TITLE
ci: add terraform validate for cloud onboarding modules (#202)

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,50 @@
+name: Terraform Validate
+
+# Validates the cloud onboarding Terraform modules under deploy/*/terraform
+# without provisioning anything: format check + provider init (no backend) +
+# terraform validate. Backend-free, so no cloud credentials are required and
+# nothing is applied. Tracks Elevarq/Signals#202.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "deploy/**/terraform/**"
+      - ".github/workflows/terraform-validate.yml"
+  pull_request:
+    paths:
+      - "deploy/**/terraform/**"
+      - ".github/workflows/terraform-validate.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [aws, azure, gcp]
+    defaults:
+      run:
+        working-directory: deploy/${{ matrix.module }}/terraform
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3.1.2
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
+      - name: Format check
+        run: terraform fmt -check -diff
+
+      - name: Init (no backend, no apply)
+        run: terraform init -backend=false -input=false -no-color
+
+      - name: Validate
+        run: terraform validate -no-color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **CI: `terraform validate` for the cloud onboarding modules (#202).** A new
+  `Terraform Validate` workflow runs `fmt -check` + `init -backend=false` +
+  `terraform validate` across `deploy/{aws,azure,gcp}/terraform` on every PR
+  that touches those modules. Backend-free, so no cloud credentials are used
+  and nothing is provisioned. All three modules validate clean; the earlier
+  failure was an environment-specific provider-plugin issue, not a template
+  defect.
+
 ### Changed
 
 - **Swept all deploy assets to image tag `0.10.0-beta.7` (#199).** The Helm


### PR DESCRIPTION
## What

Adds a `Terraform Validate` GitHub Actions workflow that runs, as a matrix over `deploy/{aws,azure,gcp}/terraform`:

- `terraform fmt -check -diff`
- `terraform init -backend=false -input=false`
- `terraform validate`

Triggers on PRs (and pushes to `main`) that touch `deploy/**/terraform/**` or the workflow itself, plus `workflow_dispatch`. **Backend-free** — no cloud credentials, no state, nothing provisioned. `setup-terraform` pinned by SHA (v3.1.2) per supply-chain Gate D.

## Why

#202: the deploy Terraform modules had never been validated cleanly in CI (the earlier attempt hit an environment-specific provider-plugin failure). This gives a permanent gate so a malformed module is caught on the PR that introduces it.

## Verification

Ran locally with Terraform 1.5.7 — all three modules pass:

```
aws:   fmt OK · Success! The configuration is valid.
azure: fmt OK · Success! The configuration is valid.
gcp:   fmt OK · Success! The configuration is valid.
```

Confirms the earlier failure was environmental, not a template defect. `actionlint` clean on the new workflow.

## Scope

Terraform only (the issue's scope). Azure Bicep (`az bicep build`) validation can be a follow-up if wanted.

closes #202