### PR TITLE
ci: operator-gated aws_rds_iam live-smoke workflow + runbook (#201)

### DIFF
--- a/.github/workflows/aws-rds-iam-live-smoke.yml
+++ b/.github/workflows/aws-rds-iam-live-smoke.yml
@@ -1,0 +1,174 @@
+name: AWS RDS IAM Live Smoke
+
+# Operator-gated end-to-end live smoke for the AWS passwordless onboarding
+# path (deploy/aws/terraform, auth_method: aws_rds_iam). Mirrors the
+# provider live smokes (#94/#95/#96): NOT part of default CI — it
+# provisions real infrastructure and is triggered manually. Tracks
+# Elevarq/Signals#201.
+#
+# It: terraform apply -> (transiently grant the collector role SSM so the
+# loopback-only API can be reached) -> force a collection -> assert a
+# passwordless snapshot was produced -> terraform destroy (always).
+#
+# Prerequisites (see deploy/aws/LIVE-SMOKE.md):
+#   - An RDS/Aurora PostgreSQL instance with IAM DB auth ENABLED, and the
+#     one-time DB grant applied (CREATE ROLE signals / GRANT rds_iam /
+#     GRANT pg_monitor).
+#   - A repo variable AWS_LIVE_SMOKE_ROLE_ARN — an AWS IAM role that trusts
+#     this repo's GitHub OIDC identity and can apply the module + manage SSM.
+#
+# This workflow has no default-CI trigger on purpose. Nothing runs, and no
+# cloud cost is incurred, until an operator dispatches it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      region:
+        description: AWS region of the RDS instance (e.g. us-east-1)
+        required: true
+      db_host:
+        description: RDS/Aurora endpoint hostname
+        required: true
+      db_name:
+        description: Database name to connect to
+        required: true
+      db_resource_id:
+        description: RDS DbiResourceId (db-ABCDEFGH...), scopes rds-db:connect
+        required: true
+      subnet_id:
+        description: Subnet id for the collector (must route to the DB)
+        required: true
+      security_group_ids:
+        description: 'Security group ids as a JSON array, e.g. ["sg-0123"]'
+        required: true
+      db_user:
+        description: PostgreSQL role granted rds_iam + pg_monitor
+        required: false
+        default: signals
+      name_prefix:
+        description: Name prefix for the throwaway smoke resources
+        required: false
+        default: signals-livesmoke
+      image_uri:
+        description: Signals container image (pinned tag)
+        required: false
+        default: ghcr.io/elevarq/signals:0.10.0-beta.7
+
+permissions:
+  contents: read
+  id-token: write  # GitHub -> AWS OIDC role assumption (no long-lived keys)
+
+# Never run two live smokes against the same infra concurrently.
+concurrency:
+  group: aws-rds-iam-live-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: deploy/aws/terraform
+    env:
+      TF_IN_AUTOMATION: "1"
+      TF_INPUT: "0"
+      SSM_POLICY_ARN: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      TF_VAR_region: ${{ inputs.region }}
+      TF_VAR_db_host: ${{ inputs.db_host }}
+      TF_VAR_db_name: ${{ inputs.db_name }}
+      TF_VAR_db_resource_id: ${{ inputs.db_resource_id }}
+      TF_VAR_db_user: ${{ inputs.db_user }}
+      TF_VAR_subnet_id: ${{ inputs.subnet_id }}
+      TF_VAR_security_group_ids: ${{ inputs.security_group_ids }}
+      TF_VAR_name_prefix: ${{ inputs.name_prefix }}
+      TF_VAR_image_uri: ${{ inputs.image_uri }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@5579c002bb4778aa43395ef1df492868a9a1c83f  # v4.0.2
+        with:
+          role-to-assume: ${{ vars.AWS_LIVE_SMOKE_ROLE_ARN }}
+          aws-region: ${{ inputs.region }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3.1.2
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
+      - name: Terraform init
+        run: terraform init -input=false -no-color
+
+      - name: Terraform apply
+        run: terraform apply -auto-approve -input=false -no-color
+
+      - name: Grant collector role SSM (transient, for verification)
+        run: |
+          set -euo pipefail
+          ROLE_ARN="$(terraform output -raw collector_role_arn)"
+          ROLE_NAME="${ROLE_ARN##*/}"
+          echo "ROLE_NAME=$ROLE_NAME" >> "$GITHUB_ENV"
+          aws iam attach-role-policy --role-name "$ROLE_NAME" --policy-arn "$SSM_POLICY_ARN"
+
+      - name: Wait for the instance to register with SSM
+        run: |
+          set -euo pipefail
+          IID="$(terraform output -raw instance_id)"
+          echo "IID=$IID" >> "$GITHUB_ENV"
+          for i in $(seq 1 40); do
+            ONLINE="$(aws ssm describe-instance-information \
+              --filters "Key=InstanceIds,Values=$IID" \
+              --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null || true)"
+            if [ "$ONLINE" = "Online" ]; then echo "instance online in SSM"; exit 0; fi
+            echo "waiting for SSM ($i/40)…"; sleep 15
+          done
+          echo "instance never came online in SSM" >&2; exit 1
+
+      - name: Verify passwordless collection on the instance
+        run: |
+          set -euo pipefail
+          # The command strings below run ON THE INSTANCE via SSM. The quoted
+          # heredoc passes $(...)/$TOKEN through literally — they are NOT
+          # expanded in the runner. JSON \" becomes a literal " on the instance.
+          cat > /tmp/ssm-params.json <<'JSON'
+          {
+            "commands": [
+              "set -euo pipefail",
+              "for i in $(seq 1 30); do [ \"$(docker inspect -f '{{.State.Running}}' signals 2>/dev/null)\" = true ] && break; sleep 10; done",
+              "docker logs signals 2>&1 | grep -iE 'collector|snapshot|connected' | tail -5 || true",
+              "TOKEN=$(cat /root/signals-api-token)",
+              "docker exec -e SIGNALS_API_TOKEN=\"$TOKEN\" signals signalsctl collect now --force",
+              "sleep 20",
+              "docker exec -e SIGNALS_API_TOKEN=\"$TOKEN\" signals signalsctl status",
+              "docker exec -e SIGNALS_API_TOKEN=\"$TOKEN\" signals signalsctl export --output /data/snapshot.zip",
+              "docker exec signals sh -c 'test -s /data/snapshot.zip' && echo SNAPSHOT_OK"
+            ]
+          }
+          JSON
+          CMD_ID="$(aws ssm send-command --instance-ids "$IID" \
+            --document-name AWS-RunShellScript \
+            --comment 'signals aws_rds_iam live smoke' \
+            --parameters file:///tmp/ssm-params.json \
+            --query 'Command.CommandId' --output text)"
+          aws ssm wait command-executed --command-id "$CMD_ID" --instance-id "$IID" || true
+          STATUS="$(aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query Status --output text)"
+          echo "----- instance stdout -----"
+          aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query StandardOutputContent --output text
+          echo "----- instance stderr -----"
+          aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query StandardErrorContent --output text || true
+          OUT="$(aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query StandardOutputContent --output text)"
+          if [ "$STATUS" != "Success" ] || ! printf '%s' "$OUT" | grep -q SNAPSHOT_OK; then
+            echo "live smoke FAILED (status=$STATUS)" >&2; exit 1
+          fi
+          echo "live smoke PASSED — passwordless snapshot produced"
+
+      - name: Teardown (always)
+        if: always()
+        run: |
+          set +e
+          if [ -n "${ROLE_NAME:-}" ]; then
+            aws iam detach-role-policy --role-name "$ROLE_NAME" --policy-arn "$SSM_POLICY_ARN"
+          fi
+          terraform destroy -auto-approve -input=false -no-color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   and nothing is provisioned. All three modules validate clean; the earlier
   failure was an environment-specific provider-plugin issue, not a template
   defect.
+- **Operator-gated AWS `aws_rds_iam` live-smoke workflow + runbook (#201).**
+  A `workflow_dispatch`-only `AWS RDS IAM Live Smoke` workflow does
+  `terraform apply` against an IAM-auth RDS instance, transiently grants the
+  collector role SSM to reach the loopback-only API, forces a collection,
+  asserts a passwordless snapshot, then always `terraform destroy`s. It is
+  **not** part of default CI — nothing runs and no cloud cost is incurred
+  until an operator dispatches it with an `AWS_LIVE_SMOKE_ROLE_ARN` (GitHub→AWS
+  OIDC, no long-lived keys). See `deploy/aws/LIVE-SMOKE.md`. Azure/GCP variants
+  follow the same shape (follow-up).
 
 ### Changed
 

--- a/deploy/aws/LIVE-SMOKE.md
+++ b/deploy/aws/LIVE-SMOKE.md
@@ -1,0 +1,107 @@
+# AWS `aws_rds_iam` live smoke — operator runbook
+
+End-to-end validation of the passwordless AWS onboarding path
+([`deploy/aws/terraform`](terraform/), `auth_method: aws_rds_iam`). It is
+**operator-gated** — it provisions real infrastructure and is **not** part
+of default CI (mirrors the provider live smokes #94/#95/#96). Tracks
+[Elevarq/Signals#201](https://github.com/Elevarq/Signals/issues/201).
+
+The workflow ([`.github/workflows/aws-rds-iam-live-smoke.yml`](../../.github/workflows/aws-rds-iam-live-smoke.yml))
+does, in one job:
+
+1. `terraform apply` the module against your IAM-auth RDS instance.
+2. Transiently attach `AmazonSSMManagedInstanceCore` to the collector's
+   IAM role so the **loopback-only** API can be reached via SSM (the
+   production template grants no SSM access — this is added only for the
+   smoke and detached at teardown).
+3. SSM-exec on the instance: force a collection, then
+   `signalsctl status` / `export`, and assert a passwordless snapshot
+   (`SNAPSHOT_OK`).
+4. **Always** detach the transient policy and `terraform destroy`.
+
+This is the deploy-level smoke. The connection-level smoke (token mint +
+`verify-full` connect against an already-running RDS) is the
+`integration`-tagged Go test `internal/collector/credprovider_live_test.go`
+(`SIGNALS_INTEGRATION_LIVE=1`).
+
+## Prerequisites (one-time)
+
+1. **An IAM-auth-enabled RDS / Aurora PostgreSQL instance.** Enable
+   *IAM database authentication* on the instance (Elevarq's shared
+   instances have it **disabled** — use a throwaway test instance).
+2. **The one-time DB grant**, run once as a privileged role (see
+   [`README.md`](README.md) Step 1):
+   ```sql
+   CREATE ROLE signals LOGIN;
+   GRANT rds_iam TO signals;
+   GRANT pg_monitor TO signals;
+   ```
+3. **Network**: a subnet that routes to the instance, and a security
+   group that allows egress to the DB port. The collector needs outbound
+   HTTPS to pull the image (`ghcr.io`) and the RDS CA bundle, and SSM
+   endpoints reachable (NAT or SSM VPC endpoints).
+4. **A GitHub→AWS OIDC role**, exposed as the repo variable
+   **`AWS_LIVE_SMOKE_ROLE_ARN`** (Settings → Secrets and variables →
+   Actions → Variables). The role must:
+   - Trust this repo's GitHub OIDC identity
+     (`token.actions.githubusercontent.com`, `sub` scoped to
+     `repo:Elevarq/Signals:*` — tighten to `ref`/`environment` if you
+     prefer).
+   - Be allowed to apply/destroy the module:
+     `iam:CreateRole`, `iam:DeleteRole`, `iam:PutRolePolicy`,
+     `iam:DeleteRolePolicy`, `iam:GetRole*`,
+     `iam:CreateInstanceProfile`, `iam:DeleteInstanceProfile`,
+     `iam:AddRoleToInstanceProfile`, `iam:RemoveRoleFromInstanceProfile`,
+     `iam:PassRole`, `iam:TagRole`,
+     `ec2:RunInstances`, `ec2:TerminateInstances`,
+     `ec2:Describe*`, `ec2:CreateTags`, `ssm:GetParameters`.
+   - Be allowed to drive the verification:
+     `iam:AttachRolePolicy`, `iam:DetachRolePolicy` (scoped to the
+     collector role / the `AmazonSSMManagedInstanceCore` ARN),
+     `ssm:SendCommand`, `ssm:GetCommandInvocation`,
+     `ssm:DescribeInstanceInformation`.
+
+   Keep this role least-privilege and dedicated to the smoke. No
+   long-lived AWS keys are used — auth is GitHub OIDC.
+
+## Running it
+
+GitHub → **Actions** → **AWS RDS IAM Live Smoke** → **Run workflow**, then
+fill the inputs:
+
+| Input | Example | Notes |
+|-------|---------|-------|
+| `region` | `us-east-1` | region of the RDS instance |
+| `db_host` | `mydb.abc123.us-east-1.rds.amazonaws.com` | RDS endpoint |
+| `db_name` | `appdb` | database to connect to |
+| `db_resource_id` | `db-ABCDEFGH00000000000000` | the **DbiResourceId**, not the DB id |
+| `subnet_id` | `subnet-0123…` | must route to the DB |
+| `security_group_ids` | `["sg-0123…"]` | **JSON array** string |
+| `db_user` | `signals` | role granted `rds_iam` + `pg_monitor` |
+| `name_prefix` | `signals-livesmoke` | prefixes the throwaway resources |
+| `image_uri` | `ghcr.io/elevarq/signals:0.10.0-beta.7` | pinned tag |
+
+A green run means: the collector minted an RDS IAM token from its instance
+role, connected `verify-full` with **no password on disk**, and produced
+at least one snapshot — then everything was destroyed.
+
+## Cleanup / failure modes
+
+- The teardown step runs with `if: always()`, so a normal failure still
+  detaches the transient SSM policy and destroys the stack.
+- **If you cancel the job** between apply and teardown, resources can
+  leak. Recover by re-running with the same inputs (Terraform will
+  reconcile) or manually: detach `AmazonSSMManagedInstanceCore` from the
+  `<name_prefix>-collector` role, then terminate the instance and delete
+  the role / instance-profile (all tagged
+  `app.kubernetes.io/name=signals`, `managed-by=terraform`).
+- Cost: one `t3.small` + a 20 GiB encrypted EBS volume for the run's
+  duration only.
+
+## Azure / GCP variants
+
+The Azure (`azure_entra`) and GCP (`gcp_cloudsql_iam`) deploy paths follow
+the same shape and are tracked alongside #201. They are **not yet
+automated** — porting this workflow (swap the cloud auth action and the
+verify path) is the remaining follow-up for full multi-cloud live
+coverage.


### PR DESCRIPTION
## What

Adds the **operator-gated end-to-end live smoke** for the AWS passwordless onboarding path, plus its runbook:

- `.github/workflows/aws-rds-iam-live-smoke.yml` — `workflow_dispatch`-only. One job: `terraform apply` against an IAM-auth RDS → transiently attach `AmazonSSMManagedInstanceCore` to the collector role (the production template grants no SSM; this reaches the loopback-only API for verification) → force a collection → assert a passwordless snapshot (`SNAPSHOT_OK`) → **always** detach + `terraform destroy`.
- `deploy/aws/LIVE-SMOKE.md` — prerequisites (IAM-auth RDS + the DB grant, the GitHub→AWS OIDC role and its permissions), how to trigger, cleanup/failure modes, cost note, and the Azure/GCP follow-up.

## Design notes

- **No long-lived keys** — GitHub→AWS OIDC via `configure-aws-credentials` with a repo variable `AWS_LIVE_SMOKE_ROLE_ARN`.
- **Not in default CI** — no trigger but `workflow_dispatch`, with a `concurrency` guard. Nothing runs and **no cloud cost** is incurred until an operator dispatches it.
- Inputs are passed as `TF_VAR_*` env (no shell injection); the instance-side verification script is sent via a quoted-heredoc `file://` payload. `actionlint` clean.
- This is the **deploy-level** smoke; the connection-level one is the existing `integration`-tagged `internal/collector/credprovider_live_test.go`.

## Does NOT close #201

`Refs #201` — deliberately **not** `closes`. This lands the *harness*; #201's acceptance criteria require an actual live run with captured evidence. Closing is the operator's step: set `AWS_LIVE_SMOKE_ROLE_ARN`, stand up an IAM-auth RDS, dispatch the workflow, and attach the green run to #201. Azure/GCP variants remain a follow-up.

Refs #201