### PR TITLE
release: prepare 0.10.0-rc.1 (CHANGELOG cut + image-tag sweep)

### DIFF
--- a/.github/workflows/aws-rds-iam-live-smoke.yml
+++ b/.github/workflows/aws-rds-iam-live-smoke.yml
@@ -53,7 +53,7 @@ on:
       image_uri:
         description: Signals container image (pinned tag)
         required: false
-        default: ghcr.io/elevarq/signals:0.10.0-beta.7
+        default: ghcr.io/elevarq/signals:0.10.0-rc.1
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0-rc.1] - 2026-06-25
+
+> **Release candidate.** Closes the launch-readiness items found in the
+> deploy/onboarding review: the AWS/Azure/GCP passwordless onboarding
+> templates are runnable as documented, image tags are unified, the
+> extended-statistics-data collectors degrade cleanly under a
+> least-privilege role, the Terraform modules are validated in CI, and the
+> AWS `aws_rds_iam` path is live-validated against an IAM-auth RDS.
+
 ### Added
 
 - **CI: `terraform validate` for the cloud onboarding modules (#202).** A new

--- a/deploy/aws/LIVE-SMOKE.md
+++ b/deploy/aws/LIVE-SMOKE.md
@@ -79,7 +79,7 @@ fill the inputs:
 | `security_group_ids` | `["sg-0123…"]` | **JSON array** string |
 | `db_user` | `signals` | role granted `rds_iam` + `pg_monitor` |
 | `name_prefix` | `signals-livesmoke` | prefixes the throwaway resources |
-| `image_uri` | `ghcr.io/elevarq/signals:0.10.0-beta.7` | pinned tag |
+| `image_uri` | `ghcr.io/elevarq/signals:0.10.0-rc.1` | pinned tag |
 
 A green run means: the collector minted an RDS IAM token from its instance
 role, connected `verify-full` with **no password on disk**, and produced

--- a/deploy/aws/cloudformation/signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/signals-rds-iam.yaml
@@ -38,7 +38,7 @@ Parameters:
     Default: t3.small
   ImageUri:
     Type: String
-    Default: ghcr.io/elevarq/signals:0.10.0-beta.7
+    Default: ghcr.io/elevarq/signals:0.10.0-rc.1
     Description: Elevarq Signals container image (pinned tag).
   Env:
     Type: String

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "instance_type" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:0.10.0-beta.7"
+  default     = "ghcr.io/elevarq/signals:0.10.0-rc.1"
 }
 
 variable "env" {

--- a/deploy/azure/bicep/main.bicep
+++ b/deploy/azure/bicep/main.bicep
@@ -46,7 +46,7 @@ param adminUsername string = 'azureuser'
 param adminSshPublicKey string
 
 @description('Elevarq Signals container image (pinned tag).')
-param imageUri string = 'ghcr.io/elevarq/signals:0.10.0-beta.7'
+param imageUri string = 'ghcr.io/elevarq/signals:0.10.0-rc.1'
 
 @description('URL of the CA bundle for sslmode=verify-full. Default is the DigiCert Global Root G2 that Azure Database for PostgreSQL Flexible Server chains to.')
 param dbCaCertUrl string = 'https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem'

--- a/deploy/azure/terraform/variables.tf
+++ b/deploy/azure/terraform/variables.tf
@@ -66,7 +66,7 @@ variable "admin_ssh_public_key" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:0.10.0-beta.7"
+  default     = "ghcr.io/elevarq/signals:0.10.0-rc.1"
 }
 
 variable "db_ca_cert_url" {

--- a/deploy/gcp/terraform/variables.tf
+++ b/deploy/gcp/terraform/variables.tf
@@ -82,7 +82,7 @@ variable "image" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:0.10.0-beta.7"
+  default     = "ghcr.io/elevarq/signals:0.10.0-rc.1"
 }
 
 variable "env" {

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 0.10.0-beta.7
-appVersion: "0.10.0-beta.7"
+version: 0.10.0-rc.1
+appVersion: "0.10.0-rc.1"
 keywords:
   - postgresql
   - monitoring

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "0.10.0-beta.7"
+  tag: "0.10.0-rc.1"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration. Rendered into the mounted


### PR DESCRIPTION
Prep for the first RC, consolidating the merged launch-readiness work (#198/#199/#205/#200/#202/#201).

## What
- **CHANGELOG**: cut `[Unreleased]` into `## [0.10.0-rc.1] - 2026-06-25`. The release workflow's `validate` gate greps `## [0.10.0-rc.1]` and STOPs without it.
- **Image-tag sweep** `0.10.0-beta.7` → `0.10.0-rc.1`: Helm `values.yaml image.tag` + `Chart.yaml version`/`appVersion`, AWS/Azure/GCP Terraform `image_uri`, Azure Bicep, AWS CloudFormation `ImageUri`, the live-smoke default, and the runbook example.

## Why the values.yaml sweep is load-bearing
The Helm deployment template renders `{{ .Values.image.repository }}:{{ .Values.image.tag }}` **directly** — no `.Chart.AppVersion` fallback — and `helm package` only stamps `version`/`appVersion`, not `values.yaml`. Without bumping `image.tag`, the published rc.1 chart would deploy the **beta.7** image.

## Verification
helm lint OK · terraform fmt -check clean (aws/azure/gcp) · actionlint clean · no `beta.7` left in deploy/workflow refs.

## Next (separate, operator-gated — NOT in this PR)
After merge, push `v0.10.0-rc.1` to trigger `release.yml` (build + push + cosign + SBOM + chart + GitHub pre-release), then live-smoke the published rc image + trivy scan before declaring GO. I'll confirm with the maintainer before pushing the tag.

closes #213