### PR TITLE
ci: make the aws_rds_iam live smoke reliable (readiness probe + SSM poll)

### DIFF
--- a/.github/workflows/aws-rds-iam-live-smoke.yml
+++ b/.github/workflows/aws-rds-iam-live-smoke.yml
@@ -144,9 +144,9 @@ jobs:
           {
             "commands": [
               "set -euo pipefail",
-              "TOKEN=$(cat /root/signals-api-token)",
-              "for i in $(seq 1 60); do [ \"$(docker inspect -f '{{.State.Health.Status}}' signals 2>/dev/null)\" = healthy ] && docker exec -e SIGNALS_API_TOKEN=\"$TOKEN\" signals signalsctl status >/dev/null 2>&1 && break; echo \"waiting for collector API ($i/60)\"; sleep 5; done",
+              "for i in $(seq 1 90); do [ \"$(docker inspect -f '{{.State.Health.Status}}' signals 2>/dev/null)\" = healthy ] && break; echo \"waiting for container healthy ($i/90)\"; sleep 5; done",
               "docker logs signals 2>&1 | grep -iE 'collector|snapshot|connected' | tail -5 || true",
+              "TOKEN=$(cat /root/signals-api-token)",
               "docker exec -e SIGNALS_API_TOKEN=\"$TOKEN\" signals signalsctl collect now --force",
               "sleep 20",
               "docker exec -e SIGNALS_API_TOKEN=\"$TOKEN\" signals signalsctl status",

--- a/.github/workflows/aws-rds-iam-live-smoke.yml
+++ b/.github/workflows/aws-rds-iam-live-smoke.yml
@@ -164,7 +164,7 @@ jobs:
           # 'aws ssm wait command-executed' waiter gives up (~100s) before the
           # on-instance readiness wait + collection finish on a cold instance.
           STATUS=Pending
-          for i in $(seq 1 50); do
+          for _ in $(seq 1 50); do
             STATUS="$(aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query Status --output text 2>/dev/null || echo Pending)"
             case "$STATUS" in Success|Failed|Cancelled|TimedOut) break;; esac
             sleep 15

--- a/.github/workflows/aws-rds-iam-live-smoke.yml
+++ b/.github/workflows/aws-rds-iam-live-smoke.yml
@@ -144,9 +144,9 @@ jobs:
           {
             "commands": [
               "set -euo pipefail",
-              "for i in $(seq 1 30); do [ \"$(docker inspect -f '{{.State.Running}}' signals 2>/dev/null)\" = true ] && break; sleep 10; done",
-              "docker logs signals 2>&1 | grep -iE 'collector|snapshot|connected' | tail -5 || true",
               "TOKEN=$(cat /root/signals-api-token)",
+              "for i in $(seq 1 60); do [ \"$(docker inspect -f '{{.State.Health.Status}}' signals 2>/dev/null)\" = healthy ] && docker exec -e SIGNALS_API_TOKEN=\"$TOKEN\" signals signalsctl status >/dev/null 2>&1 && break; echo \"waiting for collector API ($i/60)\"; sleep 5; done",
+              "docker logs signals 2>&1 | grep -iE 'collector|snapshot|connected' | tail -5 || true",
               "docker exec -e SIGNALS_API_TOKEN=\"$TOKEN\" signals signalsctl collect now --force",
               "sleep 20",
               "docker exec -e SIGNALS_API_TOKEN=\"$TOKEN\" signals signalsctl status",

--- a/.github/workflows/aws-rds-iam-live-smoke.yml
+++ b/.github/workflows/aws-rds-iam-live-smoke.yml
@@ -144,7 +144,7 @@ jobs:
           {
             "commands": [
               "set -euo pipefail",
-              "for i in $(seq 1 90); do [ \"$(docker inspect -f '{{.State.Health.Status}}' signals 2>/dev/null)\" = healthy ] && break; echo \"waiting for container healthy ($i/90)\"; sleep 5; done",
+              "for i in $(seq 1 90); do curl -fsS -o /dev/null http://127.0.0.1:8081/health && break; echo \"waiting for collector API ($i/90)\"; sleep 3; done",
               "docker logs signals 2>&1 | grep -iE 'collector|snapshot|connected' | tail -5 || true",
               "TOKEN=$(cat /root/signals-api-token)",
               "docker exec -e SIGNALS_API_TOKEN=\"$TOKEN\" signals signalsctl collect now --force",
@@ -160,8 +160,15 @@ jobs:
             --comment 'signals aws_rds_iam live smoke' \
             --parameters file:///tmp/ssm-params.json \
             --query 'Command.CommandId' --output text)"
-          aws ssm wait command-executed --command-id "$CMD_ID" --instance-id "$IID" || true
-          STATUS="$(aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query Status --output text)"
+          # Poll for a terminal SSM status ourselves: the built-in
+          # 'aws ssm wait command-executed' waiter gives up (~100s) before the
+          # on-instance readiness wait + collection finish on a cold instance.
+          STATUS=Pending
+          for i in $(seq 1 50); do
+            STATUS="$(aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query Status --output text 2>/dev/null || echo Pending)"
+            case "$STATUS" in Success|Failed|Cancelled|TimedOut) break;; esac
+            sleep 15
+          done
           echo "----- instance stdout -----"
           aws ssm get-command-invocation --command-id "$CMD_ID" --instance-id "$IID" --query StandardOutputContent --output text
           echo "----- instance stderr -----"


### PR DESCRIPTION
Three timing races in the live-smoke verify step, all harness (not product) — the published rc.1 image was independently verified to start clean (healthy in ~8s, /health 200, 0 restarts):

1. Called the API the instant the container was `Running` (before the daemon's listener was up).
2. Read the token file before cloud-init wrote it (SSM comes online before cloud-init finishes) -> `set -e` instant exit.
3. The runner-side `aws ssm wait command-executed` waiter (~100s default) gave up before a cold instance finished pulling the image + collecting.

Fixes: probe readiness with a fast, token-free `curl /health` on the published host port; read the token only after readiness; replace the built-in waiter with a manual status-poll (12-min budget).

## Proof
Run [28200873310](https://github.com/Elevarq/Signals/actions/runs/28200873310) — **green** against `ghcr.io/elevarq/signals:0.10.0-rc.1`: passwordless snapshot, `status=success collectors_failed=0 collectors_skipped=19` (the #200 owner-only degrade, live). actionlint clean.

Refs #201