### PR TITLE
release: prepare 1.0.0 (GA promotion of rc.1)

### DIFF
--- a/.github/workflows/aws-rds-iam-live-smoke.yml
+++ b/.github/workflows/aws-rds-iam-live-smoke.yml
@@ -53,7 +53,7 @@ on:
       image_uri:
         description: Signals container image (pinned tag)
         required: false
-        default: ghcr.io/elevarq/signals:0.10.0-rc.1
+        default: ghcr.io/elevarq/signals:1.0.0
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-30
+
+> **1.0 — first stable release.** Promotes `0.10.0-rc.1` to GA with **no
+> functional changes** — the same bits, validated across a wide range of AWS
+> tests, re-tagged `1.0.0`.
+>
+> **Highlights since the beta line.** AWS passwordless onboarding validated
+> end-to-end across **all four credential methods** — `password`,
+> `secret_store` (AWS Secrets Manager), `secret_store` (AWS SSM Parameter
+> Store), and `aws_rds_iam`; runnable AWS / Azure / GCP onboarding templates;
+> least-privilege owner-only collector degradation (`pg_statistic_ext_data`
+> collectors skip rather than fail under a `pg_monitor` role); CI-validated
+> Terraform modules; and a live-validated AWS `aws_rds_iam` deploy path
+> (operator-gated smoke).
+>
+> **Scope.** GA support is the **AWS** deploy paths. The Azure (`azure_entra`)
+> and GCP (`gcp_cloudsql_iam`) templates are runnable and unit/integration-
+> tested; end-to-end live validation is in progress and tracked for 1.1.
+>
+> **Upgrade.** No config or behavior changes from `0.10.0-rc.1`. Pin the
+> `1.0.0` image / chart.
+
 ## [0.10.0-rc.1] - 2026-06-25
 
 > **Release candidate.** Closes the launch-readiness items found in the

--- a/deploy/aws/LIVE-SMOKE.md
+++ b/deploy/aws/LIVE-SMOKE.md
@@ -79,7 +79,7 @@ fill the inputs:
 | `security_group_ids` | `["sg-0123…"]` | **JSON array** string |
 | `db_user` | `signals` | role granted `rds_iam` + `pg_monitor` |
 | `name_prefix` | `signals-livesmoke` | prefixes the throwaway resources |
-| `image_uri` | `ghcr.io/elevarq/signals:0.10.0-rc.1` | pinned tag |
+| `image_uri` | `ghcr.io/elevarq/signals:1.0.0` | pinned tag |
 
 A green run means: the collector minted an RDS IAM token from its instance
 role, connected `verify-full` with **no password on disk**, and produced

--- a/deploy/aws/cloudformation/signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/signals-rds-iam.yaml
@@ -38,7 +38,7 @@ Parameters:
     Default: t3.small
   ImageUri:
     Type: String
-    Default: ghcr.io/elevarq/signals:0.10.0-rc.1
+    Default: ghcr.io/elevarq/signals:1.0.0
     Description: Elevarq Signals container image (pinned tag).
   Env:
     Type: String

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "instance_type" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:0.10.0-rc.1"
+  default     = "ghcr.io/elevarq/signals:1.0.0"
 }
 
 variable "env" {

--- a/deploy/azure/bicep/main.bicep
+++ b/deploy/azure/bicep/main.bicep
@@ -46,7 +46,7 @@ param adminUsername string = 'azureuser'
 param adminSshPublicKey string
 
 @description('Elevarq Signals container image (pinned tag).')
-param imageUri string = 'ghcr.io/elevarq/signals:0.10.0-rc.1'
+param imageUri string = 'ghcr.io/elevarq/signals:1.0.0'
 
 @description('URL of the CA bundle for sslmode=verify-full. Default is the DigiCert Global Root G2 that Azure Database for PostgreSQL Flexible Server chains to.')
 param dbCaCertUrl string = 'https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem'

--- a/deploy/azure/terraform/variables.tf
+++ b/deploy/azure/terraform/variables.tf
@@ -66,7 +66,7 @@ variable "admin_ssh_public_key" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:0.10.0-rc.1"
+  default     = "ghcr.io/elevarq/signals:1.0.0"
 }
 
 variable "db_ca_cert_url" {

--- a/deploy/gcp/terraform/variables.tf
+++ b/deploy/gcp/terraform/variables.tf
@@ -82,7 +82,7 @@ variable "image" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:0.10.0-rc.1"
+  default     = "ghcr.io/elevarq/signals:1.0.0"
 }
 
 variable "env" {

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 0.10.0-rc.1
-appVersion: "0.10.0-rc.1"
+version: 1.0.0
+appVersion: "1.0.0"
 keywords:
   - postgresql
   - monitoring

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "0.10.0-rc.1"
+  tag: "1.0.0"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration. Rendered into the mounted


### PR DESCRIPTION
Prep to cut **1.0.0** — the first stable GA — promoting `0.10.0-rc.1` with **no functional changes**. RC1 was validated across a wide range of AWS tests (all four credential methods: password, Secrets Manager, SSM Parameter Store, `aws_rds_iam`).

## What
- **CHANGELOG**: add `## [1.0.0] - 2026-06-30` GA section (the `release.yml` validate gate requires `## [1.0.0]`).
- **Image-tag sweep** `0.10.0-rc.1` → `1.0.0`: Helm `values.yaml`/`Chart.yaml`, AWS/Azure/GCP Terraform, Azure Bicep, AWS CloudFormation, live-smoke default, runbook.

## Verification
helm lint OK · terraform fmt -check clean (aws/azure/gcp) · actionlint clean · smoke JSON valid · no `rc.1` refs left in deploy/workflow.

## ⚠️ Confirm before/at tag time
- **CHANGELOG date** is set to the **target** Tue 2026-06-30 — update it to the actual tag day if it slips.
- **Scope is AWS-GA.** Azure/GCP are runnable + unit/integration-tested; live validation is tracked for 1.1 (#212).

## Next (separate, operator-gated — NOT in this PR)
After merge + your explicit go, push `v1.0.0` → `release.yml` publishes a signed **non-prerelease** 1.0.0 image + chart + GitHub Release. I won't push the tag without confirmation, and I'll verify the merge commit is checked out before tagging (per the rc.1 lesson).

closes #216