### PR TITLE
Prepare AWS Marketplace listing docs — verified API publish path (#220)

### DIFF
--- a/docs/marketplace/EULA-review-notes.md
+++ b/docs/marketplace/EULA-review-notes.md
@@ -1,0 +1,52 @@
+# EULA review notes — Elevarq Signals (AWS Marketplace)
+
+Internal notes on the AWS Marketplace EULA decision. **Not** part of the
+customer-facing contract — the upload-ready EULA is [`EULA.md`](EULA.md), which
+must contain clean customer-facing text only. This file holds the rationale and
+the open counsel gates.
+
+> This is not legal advice. The items under "Counsel gates" must be confirmed
+> with counsel before the listing is submitted. Signals is still pre-1.0
+> (latest tag `v0.10.0-rc.1`); the listing — and therefore this EULA — is
+> gated on the v1.0.0 release and legal sign-off.
+
+## Custom EULA vs Standard Contract (SCMP)
+
+AWS Marketplace container products may use either the **Standard Contract for
+AWS Marketplace (SCMP)** or a **custom EULA**. A custom EULA is attached to a
+free offer as a `CustomEula` legal-term document — a PDF in an accessible S3
+bucket that the Catalog API references by S3 URL — so the uploaded text must be
+a clean, customer-facing contract with no draft markers or internal notes.
+
+**Decision:** use the **custom EULA in [`EULA.md`](EULA.md)**, which grants use
+under the product's existing **BSD-3-Clause** license. Rationale: Signals is
+already distributed under that permissive license, and the SCMP's
+commercial-support / warranty framing is aimed at paid products. The SCMP
+remains a fallback if counsel prefers a standardized contract.
+
+When 1.0 ships, render `EULA.md` to PDF and host it at
+`https://elevarq-marketplace-public.s3.amazonaws.com/eula/elevarq-signals-eula-v1.pdf`;
+the free offer's legal term then references that S3 URL
+(`{Type: LegalTerm, Documents: [{Type: CustomEula, Url: <s3-pdf>}]}`).
+
+## Counsel gates (confirm before submit)
+
+1. **Legal entity / party name.** The EULA names **Scantr LLC, doing business
+   as Elevarq**. Confirm this is the correct contracting party and matches the
+   AWS Marketplace **seller registration** record.
+2. **LICENSE copyright alignment.** The repository `LICENSE` (BSD-3-Clause)
+   copyright line currently reads **"Elevarq"** (`Copyright (c) 2026,
+   Elevarq`). Decide whether it should read **"Scantr LLC dba Elevarq"** so the
+   seller entity, the EULA party, and the `LICENSE` copyright holder are
+   intentionally aligned. (If the line is changed, do it as its own change with
+   counsel sign-off.)
+3. **Free-listing framing.** Confirm the "no software fee" wording (Section 2)
+   and the absence of any support upsell satisfy AWS's container-product
+   policies for free products (no metadata redirecting buyers to offerings not
+   available on AWS Marketplace).
+
+## Customer-facing hygiene
+
+The uploaded [`EULA.md`](EULA.md) must not contain internal-only terms
+("Draft", "counsel", "recommended option", "TODO", etc.). Re-check before each
+submission.

--- a/docs/marketplace/EULA.md
+++ b/docs/marketplace/EULA.md
@@ -1,29 +1,4 @@
-# End User License Agreement — Elevarq Signals (AWS Marketplace)
-
-> **Draft — requires legal review before use on the listing.** This is the
-> proposed EULA text for the free AWS Marketplace listing. Confirm the legal
-> entity name and terms with counsel before submitting.
->
-> **For counsel — entity/license alignment:** this EULA names **Scantr LLC,
-> doing business as Elevarq**, while the repository `LICENSE` (BSD-3-Clause)
-> carries the copyright line **"Elevarq"**. Decide whether the `LICENSE`
-> copyright line should also read **"Scantr LLC dba Elevarq"** so the two are
-> consistent, and confirm the entity named in the Marketplace seller
-> registration matches.
-
-## Recommended option
-
-For a **free, open-source** product, the simplest path is a short EULA that
-grants use under the product's existing open-source license (BSD-3-Clause).
-The alternative is AWS's pre-built **Standard Contract for AWS Marketplace
-(SCMP)** — selectable in the listing instead of a custom EULA. We recommend
-the **custom EULA below (referencing BSD-3-Clause)** because Signals is
-already distributed under that permissive license and the SCMP's
-commercial-support/warranty framing fits paid products better.
-
----
-
-## Elevarq Signals — End User License Agreement
+# Elevarq Signals — End User License Agreement
 
 This End User License Agreement ("Agreement") governs your use of **Elevarq
 Signals** (the "Software"), made available by **Scantr LLC, doing business as
@@ -36,17 +11,26 @@ Elevarq** ("Elevarq"), through AWS Marketplace.
    license, which govern your rights to use, copy, modify, and redistribute
    the Software.
 
-2. **No fees.** The Software is provided at no charge through AWS Marketplace.
-   AWS Marketplace terms also apply to your subscription.
+2. **No software fee.** The Software is offered at no software charge through
+   AWS Marketplace. You remain responsible for the AWS infrastructure and
+   service charges you incur while running the Software (for example, Amazon
+   EKS, Amazon EC2, Amazon EBS storage, Amazon RDS or Aurora, and — where you
+   use them — AWS Secrets Manager, AWS Systems Manager Parameter Store, and AWS
+   KMS). The AWS Marketplace terms also apply to your subscription.
 
-3. **Data.** The Software is local-first: it sends **no telemetry and no
-   diagnostic data to Elevarq**. All data the Software collects remains within
-   your AWS account / infrastructure. The Software's only outbound network
-   calls are the optional cloud-authentication and TLS requests you configure
-   (e.g. RDS IAM, AWS Secrets Manager, AWS Systems Manager Parameter Store),
-   which are made to your own cloud's services and never to Elevarq. Elevarq
-   does not receive telemetry, usage data, or any data collected by the
-   Software.
+3. **Data.** The Software is local-first and read-only: as packaged, it sends
+   **no telemetry and no diagnostic data to Elevarq**. The diagnostic snapshots
+   it collects remain within your own AWS account and customer-controlled
+   infrastructure; the Software exports data only to the local destination you
+   explicitly choose. The Software's only outbound network calls are the
+   optional cloud-authentication and TLS requests you configure (for example,
+   Amazon RDS IAM authentication, AWS Secrets Manager, or AWS Systems Manager
+   Parameter Store), which are made to your own cloud's services and never to
+   Elevarq. Any data associated with your AWS Marketplace subscription, Amazon
+   ECR access, or AWS account (for example, subscription and entitlement
+   records) is handled by AWS under the applicable AWS Marketplace and AWS
+   service terms; it is not collected by the Software, which sends no telemetry
+   to Elevarq.
 
 4. **No warranty.** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
    KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
@@ -58,13 +42,13 @@ Elevarq** ("Elevarq"), through AWS Marketplace.
    arising from or in connection with the Software or its use, as set out in
    the BSD 3-Clause License.
 
-6. **Support.** Community support is provided as described at
-   https://github.com/Elevarq/Signals/blob/main/SUPPORT.md. Commercial or
-   enterprise support, if desired, is available separately from Elevarq and is
-   not part of this free offering.
+6. **Support.** Community support is provided through GitHub Issues at
+   https://github.com/Elevarq/Signals. Security vulnerabilities should be
+   reported as described in Section 7.
 
-7. **Security.** Vulnerability reporting and supported-version policy are
-   described at https://github.com/Elevarq/Signals/blob/main/SECURITY.md.
+7. **Security.** Vulnerability reporting and the supported-version policy are
+   described at https://github.com/Elevarq/Signals/blob/main/SECURITY.md
+   (security contact: security@elevarq.com).
 
 In the event of any conflict between this Agreement and the BSD 3-Clause
 License with respect to the license grant, warranty, and liability, the BSD

--- a/docs/marketplace/aws-listing.md
+++ b/docs/marketplace/aws-listing.md
@@ -1,35 +1,51 @@
 # AWS Marketplace listing — Elevarq Signals (free container product)
 
-Working package for listing **Elevarq Signals 1.0** on AWS Marketplace as a
+Working package for listing **Elevarq Signals** on AWS Marketplace as a
 **free container product** (Helm chart delivery). Tracks
 [Elevarq/Signals#218](https://github.com/Elevarq/Signals/issues/218).
 
-Requirements are summarized in the issue; this file is the content + steps we
-paste into the AWS Marketplace Management Portal (AMMP) / drive via the
-Catalog API.
+This file is the content + steps we drive via the AWS Marketplace Catalog API
+(`StartChangeSet`); no AMMP web UI is required. The verified publish sequence
+and per-call gotchas live in [`catalog-api/README.md`](catalog-api/README.md).
 
-> **Status:** draft. Fields marked _(confirm)_ depend on the open questions in
-> §6 (multi-arch in one delivery option, exact field limits). The EULA and
-> cosign questions are now decided — see §6.
+> **Status: GATED — docs prep only.** Signals is still pre-1.0 (latest tag
+> `v0.10.0-rc.1`). Two gates remain before anything is submitted: (1) the
+> **v1.0.0 release** must ship, and (2) **legal sign-off** on the EULA / entity
+> wording (§4). Do **not** run the publish / visibility change-sets until both
+> clear. The `SignatureVerificationKey` question is resolved (§6 — it is the
+> inert metering key, not an image-signing requirement).
 
 ## 0. Pre-publish gate
 
-- [x] Seller account is a **registered seller** — confirmed: the AMMP
-      products console (`.../marketplace/management/products/server`) loads and
-      reports the account ready. Free publishing needs no tax/bank, and is
-      independent of the paid Analyzer review.
-- [ ] **v1.0.0** is tagged and published (non-prerelease) — `release.yml`.
+- [x] Seller account is a registered seller (free publishing needs no
+      tax/bank; independent of the paid Analyzer review).
+- [ ] **v1.0.0** tagged and published (non-prerelease) — `release.yml`. Image +
+      signed multi-arch OCI Helm chart on ghcr, GitHub Release live.
+- [ ] Marketplace ECR repos created (`AddRepositories`): `elevarq-signals`
+      (image) and `elevarq-signals-chart` (chart).
+- [ ] 1.0.0 image + chart re-hosted into the Marketplace ECR (see
+      [`catalog-api/README.md`](catalog-api/README.md); chart repoints its
+      default image to the Marketplace ECR repo, no `ghcr.io`).
+- [ ] Product logo hosted in S3 — `LogoUrl` requires an S3 URL (§1).
+- [ ] EULA rendered to PDF and hosted in S3 for the offer's `CustomEula` term
+      (§4) — gated on legal sign-off.
 
 ## 1. Product metadata
+
+These are the `UpdateInformation` fields — captured in
+[`catalog-api/03-update-information.json`](catalog-api/03-update-information.json).
 
 | Field | Value |
 |-------|-------|
 | Product title | Elevarq Signals |
-| Short description | Local-first, read-only PostgreSQL diagnostic collector — no diagnostic-data egress to Elevarq. |
-| Long description | Elevarq Signals is an open-source (BSD-3-Clause) diagnostic collector for PostgreSQL. It runs next to your database, collects a structured, read-only diagnostic snapshot on a schedule, and keeps the data local: **no telemetry and no diagnostic-data egress to Elevarq** — the only outbound calls are the optional cloud-auth requests (RDS IAM / Secrets Manager / SSM / TLS), which stay within your own cloud's control plane. It onboards **passwordlessly** against managed Postgres (Amazon RDS / Aurora via `aws_rds_iam`, or a cloud secret store) over `verify-full` TLS, using a least-privilege `pg_monitor` role. Snapshots are exported as a portable archive for downstream analysis. |
-| Categories _(confirm)_ | Database / Monitoring & Observability |
+| Short description | Local-first, read-only PostgreSQL diagnostic collector. Passwordless onboarding to Amazon RDS and Aurora over verify-full TLS, with no diagnostic-data egress to Elevarq. |
+| Long description | Elevarq Signals is an open-source (BSD-3-Clause) diagnostic collector for PostgreSQL that runs entirely inside your own environment. It connects to a managed database, collects a structured, read-only diagnostic snapshot on a schedule, and keeps every byte local: no telemetry and no diagnostic-data egress to Elevarq. Read-only is enforced by three independent layers, and unsafe roles (superuser, replication) are blocked before collection begins. Onboarding is passwordless against Amazon RDS and Aurora using RDS IAM authentication (or a cloud secret store via AWS Secrets Manager / AWS Systems Manager Parameter Store) over verify-full TLS, with a least-privilege `pg_monitor` role. The collector ships as a signed, multi-architecture (linux/amd64 and linux/arm64) container with an SBOM, and a production Helm chart for Amazon EKS provides liveness/readiness probes, least-privilege security contexts, and a persistent volume for local snapshots. |
+| Highlights (≤3) | (1) Read-only by design: three independent enforcement layers, unsafe roles blocked before collection. (2) Passwordless onboarding to Amazon RDS / Aurora via RDS IAM (or a cloud secret store) over verify-full TLS with a least-privilege `pg_monitor` role. (3) Local-first: no telemetry and no diagnostic-data egress to Elevarq; signed multi-arch container + Helm chart for Amazon EKS. |
+| Category | Infrastructure Software (validated; AWS has **no "Database" category**) |
+| Logo | `https://elevarq-marketplace-public.s3.amazonaws.com/logos/elevarq-512.png` — must be an **S3 URL** (a non-S3 host fails `INVALID_MEDIA`). Reuses the **Elevarq company logo** for the whole portfolio (512×512 transparent PNG; spec: square 1:1, 120–640px, transparent PNG, <5MB). |
+| Search keywords (≤15, ≤250 combined chars) | PostgreSQL, Postgres, diagnostics, observability, monitoring, database, Amazon RDS, Aurora, pg_monitor, Kubernetes, Helm, EKS, read-only, snapshot |
 | Vendor | Elevarq (DBA of Scantr LLC) |
-| Pricing | Free |
+| Pricing | Free (no pricing term — `UpdatePricingTerms PricingModel:Free` is rejected) |
 | Source / homepage | https://github.com/Elevarq/Signals |
 | License | BSD-3-Clause |
 
@@ -37,11 +53,13 @@ Catalog API.
 
 - **Method:** Helm chart, installed via the Helm CLI (Amazon EKS, or
   self-managed EKS Anywhere / EC2 / on-prem).
-- **Chart + images:** copied into the AWS-Marketplace-owned ECR repos (see
-  `scripts/marketplace-ecr-push.sh`). The published listing references the
-  Marketplace ECR repo, **not** `ghcr.io`.
-- _(Optional second delivery option)_ a plain **Container image** option for
-  ECS / manual `docker pull` from the Marketplace registry.
+- **Chart + image:** re-hosted into the AWS-Marketplace-owned ECR repos. The
+  published chart's default image points at the Marketplace ECR image repo —
+  **not** `ghcr.io` (AWS rejects external chart images:
+  `INVALID_HELM_CHART_IMAGES`).
+- Catalog-API change-set: [`catalog-api/02-add-helm-delivery.json`](catalog-api/02-add-helm-delivery.json)
+  (`ReleaseName`/`Namespace` = `signals`). Runs only **after** the product is
+  Limited.
 
 ### Buyer usage instructions (rendered on the listing)
 
@@ -51,7 +69,7 @@ aws ecr get-login-password --region <region> \
   | helm registry login --username AWS --password-stdin <marketplace-ecr-registry>
 ```
 
-Configure in a values file (`signals-values.yaml`), then install with `-f`:
+Configure a values file, then install with `-f`:
 
 ```yaml
 # signals-values.yaml
@@ -59,71 +77,126 @@ target:
   host: <rds-endpoint>
   dbname: <db>
   user: signals
-  authMethod: aws_rds_iam
+  authMethod: aws_rds_iam      # passwordless RDS IAM
   sslmode: verify-full
 ```
 
 ```sh
-helm install signals oci://<marketplace-ecr-chart-repo>/signals \
-  --version 1.0.0 -f signals-values.yaml
+helm install signals \
+  oci://<marketplace-ecr-registry>/<seller-ns>/elevarq-signals-chart \
+  --version 1.0.0 -n signals --create-namespace -f signals-values.yaml
 ```
 
-Full passwordless onboarding (IAM role / DB grant / CA bundle) is documented
-in [`deploy/helm/signals/README.md`](../../deploy/helm/signals/README.md) and
-[`docs/database-connections.md`](../database-connections.md).
+Note the chart URI ends at the **granted repo** (`elevarq-signals-chart`), not
+a `…/signals` sub-path — the chart is renamed to land there. Resource names are
+unaffected: the chart keys off the Helm release name (`signals`), not the chart
+name, so no `nameOverride` is needed (see the chart-path gotcha in
+[`catalog-api/README.md`](catalog-api/README.md)). Full passwordless onboarding
+(IAM role / DB grant / CA bundle) is documented in
+[`install-from-aws-marketplace.md`](install-from-aws-marketplace.md), the Helm
+chart README, and [`docs/database-connections.md`](../database-connections.md).
+
+### Reach: additional delivery options (assessed)
+
+- **Container image (Amazon ECS / Fargate / `docker pull`)** — _optional, low
+  effort._ A second delivery option pointing at the **same** Marketplace ECR
+  image we already re-hosted; reaches ECS/non-Helm buyers with no new artifact.
+  Defer until after the first publish.
+- **CloudFormation / QuickLaunch (deploy-to-EKS)** — _optional, higher effort._
+  Defer.
+- **EKS-Anywhere** compatibility — requires a license-secret
+  `OverrideParameters` entry; out of scope for the free EKS listing.
 
 ## 3. Support & maintenance (free-product eligibility)
 
-- **Support process:** GitHub Issues at https://github.com/Elevarq/Signals +
-  `SUPPORT.md`; security reports via `SECURITY.md`.
+- **Support process:** community support via GitHub Issues at
+  https://github.com/Elevarq/Signals; security reports via `SECURITY.md`
+  (`security@elevarq.com`). No commercial-support upsell on the listing.
 - **Update cadence:** versioned releases via CI (`release.yml`) with
-  cosign-signed, SBOM-attached, Trivy-scanned multi-arch images; security
-  patches cut as needed. _(state the committed cadence on the listing.)_
+  cosign-signed, SBOM-attached, Trivy-scanned multi-arch images and a signed
+  OCI Helm chart; security patches cut as needed.
 
 ## 4. License terms
 
-- Draft EULA: [`EULA.md`](EULA.md) — a custom EULA referencing the
-  BSD-3-Clause license (recommended for a free OSS product over the Standard
-  Contract for AWS Marketplace / SCMP). **Needs legal review** before
-  submission.
+- Customer-facing EULA (upload-ready): [`EULA.md`](EULA.md) — a clean custom
+  EULA referencing the BSD-3-Clause license. Submitted to the free offer as a
+  `CustomEula` legal term, referenced as a **PDF in S3** (the offer takes no
+  pricing term). This artifact contains contract text only.
+- Decision rationale + counsel gates: [`EULA-review-notes.md`](EULA-review-notes.md)
+  — custom-EULA-vs-SCMP decision, the Scantr LLC dba Elevarq entity gate, and
+  the seller-entity / EULA-party / `LICENSE`-copyright alignment. **Legal
+  sign-off required** before submission.
 
 ## Related artifacts
 
-- **Buyer install guide:** [`install-from-aws-marketplace.md`](install-from-aws-marketplace.md)
-  (the source for the delivery option's usage instructions).
-- **Architecture diagram (upload asset):** [`assets/architecture-listing.png`](assets/architecture-listing.png)
-  (simplified/branded for the listing); the full engineering diagram is
-  [`assets/architecture.png`](assets/architecture.png) from [`docs/architecture.md`](../architecture.md).
-- **Catalog-API automation:** [`catalog-api/`](catalog-api/) + `scripts/marketplace-changeset.sh`.
+- **Buyer install guide:** [`install-from-aws-marketplace.md`](install-from-aws-marketplace.md).
+- **Architecture diagram (upload asset):** [`assets/architecture-listing.png`](assets/architecture-listing.png).
+- **Catalog-API automation:** [`catalog-api/`](catalog-api/) +
+  `scripts/marketplace-changeset.sh`.
 - **ECR re-host:** `scripts/marketplace-ecr-push.sh`.
 
-## 5. Submit checklist (ordered)
+## 5. Submit checklist (ordered — verified sequence)
 
 1. [ ] Confirm registered-seller status (§0).
 2. [ ] Publish `v1.0.0`.
-3. [ ] Create Marketplace ECR repos (`AddRepositories` in AMMP / Catalog API).
-4. [ ] `scripts/marketplace-ecr-push.sh` — copy the 1.0.0 image + Helm chart
-       into the Marketplace ECR repos; let AWS scan them.
-5. [ ] Create the container product + Helm delivery option; paste §1–§4.
-6. [ ] Submit → AWS review.
-7. [ ] Preview + approve the **limited listing URL**.
-8. [ ] Request **Limited → Public** (Update visibility) → live.
+3. [ ] **`CreateProduct` + `AddRepositories`**
+       ([`catalog-api/01-create-product-and-repos.json`](catalog-api/01-create-product-and-repos.json))
+       — Draft product + ECR repos. Capture the product Identifier.
+4. [ ] Re-host the 1.0.0 image + Helm chart into the Marketplace ECR repos
+       (`docker buildx imagetools create` + chart repackage; **not** skopeo).
+5. [ ] Host the product logo in S3 (`LogoUrl` requires S3 — non-S3 fails
+       `INVALID_MEDIA`).
+6. [ ] **`UpdateInformation`** ([`catalog-api/03-update-information.json`](catalog-api/03-update-information.json))
+       — title, descriptions, highlights, category, keywords, logo. Works on
+       the Draft.
+7. [ ] **Free `Offer@1.0`** — `CreateOffer` + offer `UpdateInformation` +
+       `UpdateLegalTerms` (`CustomEula` S3 PDF) + `UpdateSupportTerms`. **No
+       pricing term.** **Gated on EULA legal sign-off (§4).**
+8. [ ] **`ReleaseProduct` + `ReleaseOffer` (combined)** — Draft → **Limited**.
+9. [ ] **`AddDeliveryOptions`** ([`catalog-api/02-add-helm-delivery.json`](catalog-api/02-add-helm-delivery.json))
+       — add the Helm version (now allowed, product is Limited). Triggers AWS's
+       async image + chart scan (the long pole).
+10. [ ] **`UpdateVisibility: Public`** — own change-set; AWS Seller-Ops manual
+        review; needs a published public seller profile
+        (`MISSING_SELLER_PROFILE_INFORMATION` otherwise). Gated on the EULA +
+        explicit go.
+
+> The whole sequence is Catalog-API-driven — no AMMP web UI required. See
+> [`catalog-api/README.md`](catalog-api/README.md) for the verified per-step
+> detail and error catalog.
 
 ## 6. Decisions & open questions
 
+**Open (must clear before submit)**
+
+- **v1.0.0 release** — Signals is pre-1.0 (`v0.10.0-rc.1`); the listing is
+  gated on the stable release.
+- **EULA / entity wording** — counsel review (Scantr LLC dba Elevarq); see
+  [`EULA-review-notes.md`](EULA-review-notes.md).
+
 **Decided**
 
-- **Cosign signature does not carry over.** The `skopeo` copy moves only the
-  image (not the `.sig` tag); AWS re-scans and may re-sign on ingestion.
-  Marketplace artifacts are AWS-scanned, not verifiable with our GHCR `cosign
-  verify` commands. Accepted for 1.0; re-signing the Marketplace ECR artifacts
-  is a possible later enhancement.
-- **EULA:** custom EULA referencing BSD-3-Clause (see [`EULA.md`](EULA.md)),
-  not SCMP. Pending legal review.
-
-**Open (confirm during submission)**
-
-- **Multi-arch** (linux/amd64 + linux/arm64) as a single manifest-list
-  delivery option — supported? (We ship a multi-arch manifest.)
-- Exact **listing-content field limits**.
-- Does the **90-day paid-equivalent** rule bind a standalone free OSS product?
+- **First publish is fully Catalog-API-driven** (not portal-only). Verified on
+  the live pgAgroal launch — see [`catalog-api/README.md`](catalog-api/README.md).
+- **Free offer takes no pricing term.** `UpdatePricingTerms PricingModel:Free`
+  is rejected; the offer's terms are legal (`CustomEula`) + support only.
+- **`SignatureVerificationKey` is NOT an image-signing gate.** The active RSA
+  public key on the product is the **metering** signature-verification key for
+  the `RegisterUsage` flow: AWS auto-generates the keypair at product creation
+  and holds the private half; the seller never signs anything with it. Image
+  signing is not required to `AddDeliveryOptions` or publish, and free ECS/EKS
+  products are exempt from `RegisterUsage`. The real ingestion gate is AWS's
+  vulnerability/secret **scan** (`SCAN_ERROR`), which a Trivy-clean image
+  passes. No action needed on the key.
+- **Re-host uses `docker buildx imagetools create`** (multi-arch,
+  registry-to-registry) — skopeo is **not** required or installed.
+- **Cosign GHCR signatures do not carry into the Marketplace ECR.** The
+  multi-arch copy moves only the image; AWS re-scans (and may re-sign) on
+  ingestion. Re-signing the Marketplace ECR artifacts is a possible later
+  enhancement.
+- **Chart path.** The chart is published at the granted ECR repo
+  `<seller-ns>/elevarq-signals-chart` (chart renamed to match the repo's last
+  path segment, pushed to the parent namespace). Deployed resource names are
+  unaffected because the Signals chart keys off the Helm release name, not the
+  chart name — no `nameOverride` needed. Pushing the unrenamed chart to the
+  repo creates a non-existent hierarchical sub-repo → `403`.

--- a/docs/marketplace/catalog-api/03-update-information.json
+++ b/docs/marketplace/catalog-api/03-update-information.json
@@ -1,0 +1,53 @@
+{
+  "Catalog": "AWSMarketplace",
+  "ChangeSet": [
+    {
+      "ChangeType": "UpdateInformation",
+      "Entity": {
+        "Type": "ContainerProduct@1.0",
+        "Identifier": "${PRODUCT_ID}"
+      },
+      "DetailsDocument": {
+        "ProductTitle": "Elevarq Signals",
+        "LogoUrl": "https://elevarq-marketplace-public.s3.amazonaws.com/logos/elevarq-512.png",
+        "ShortDescription": "Local-first, read-only PostgreSQL diagnostic collector. Passwordless onboarding to Amazon RDS and Aurora over verify-full TLS, with no diagnostic-data egress to Elevarq.",
+        "LongDescription": "Elevarq Signals is an open-source (BSD-3-Clause) diagnostic collector for PostgreSQL that runs entirely inside your own environment. It connects to a managed database, collects a structured, read-only diagnostic snapshot on a schedule, and keeps every byte local: no telemetry and no diagnostic-data egress to Elevarq. Read-only is enforced by three independent layers, and unsafe roles (superuser, replication) are blocked before collection begins. Onboarding is passwordless against Amazon RDS and Aurora using RDS IAM authentication (or a cloud secret store via AWS Secrets Manager / AWS Systems Manager Parameter Store) over verify-full TLS, with a least-privilege pg_monitor role — no long-lived database password to store or rotate. The collector ships as a signed, multi-architecture (linux/amd64 and linux/arm64) container with an SBOM, and a production Helm chart for Amazon EKS provides liveness/readiness probes, least-privilege security contexts, and a persistent volume for local snapshots. Snapshots are exported as a portable archive for downstream analysis; the only outbound network calls are the cloud-authentication and TLS requests you configure, made to your own cloud's services.",
+        "Highlights": [
+          "Read-only by design: three independent enforcement layers, with unsafe roles (superuser, replication) blocked before collection starts",
+          "Passwordless onboarding to Amazon RDS and Aurora via RDS IAM (or a cloud secret store) over verify-full TLS with a least-privilege pg_monitor role",
+          "Local-first: no telemetry and no diagnostic-data egress to Elevarq; signed multi-arch container and Helm chart for Amazon EKS"
+        ],
+        "AdditionalResources": [
+          {
+            "Text": "Documentation",
+            "Url": "https://github.com/Elevarq/Signals"
+          },
+          {
+            "Text": "Security policy",
+            "Url": "https://github.com/Elevarq/Signals/blob/main/SECURITY.md"
+          }
+        ],
+        "SupportDescription": "Community support via GitHub Issues at https://github.com/Elevarq/Signals. Report security vulnerabilities to security@elevarq.com (see SECURITY.md).",
+        "Categories": [
+          "Infrastructure Software"
+        ],
+        "SearchKeywords": [
+          "PostgreSQL",
+          "Postgres",
+          "diagnostics",
+          "observability",
+          "monitoring",
+          "database",
+          "Amazon RDS",
+          "Aurora",
+          "pg_monitor",
+          "Kubernetes",
+          "Helm",
+          "EKS",
+          "read-only",
+          "snapshot"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/marketplace/catalog-api/README.md
+++ b/docs/marketplace/catalog-api/README.md
@@ -1,91 +1,179 @@
 # AWS Marketplace Catalog API change-sets (Signals container product)
 
-Draft change-sets to drive most of the AWS Marketplace container listing for
-Signals via the **Catalog API** (`StartChangeSet`) instead of click-ops.
+Change-sets to drive the AWS Marketplace container listing for **Elevarq
+Signals** via the **Catalog API** (`StartChangeSet`) — no AMMP web UI required.
 Tracks [Elevarq/Signals#218](https://github.com/Elevarq/Signals/issues/218);
 schemas are from the official
-[container-products Catalog API reference](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/container-products.html)
-and the `CreateProduct` change type (`ContainerProduct@1.0`).
+[container-products Catalog API reference](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/container-products.html).
 
-Run them with [`scripts/marketplace-changeset.sh`](../../../scripts/marketplace-changeset.sh)
+> **Gated.** Signals is still pre-1.0 (latest tag `v0.10.0-rc.1`). These
+> change-sets are docs prep only — **do not run any of them** until the
+> v1.0.0 release ships and the EULA clears legal sign-off (see
+> [`../aws-listing.md`](../aws-listing.md) §4). The product does not exist yet;
+> the identifiers below are populated once `CreateProduct` runs.
+
+Run a change-set with
+[`scripts/marketplace-changeset.sh`](../../../scripts/marketplace-changeset.sh)
 (renders `${VARS}`, submits, polls `DescribeChangeSet`).
 
-## What is API-driven vs portal-only
+## The first publish IS fully Catalog-API-driven (verified)
 
-| Step | How |
-|------|-----|
-| Create product (Draft) + create ECR repos | **API** — `01-create-product-and-repos.json` (`CreateProduct` + `AddRepositories`, chained via `$CreateProduct.Entity.Identifier`) |
-| Push image + Helm chart into the ECR repos | **CLI** — `scripts/marketplace-ecr-push.sh` |
-| Add the 1.0.0 Helm delivery version | **API** — `02-add-helm-delivery.json` (`AddDeliveryOptions` / `HelmDeliveryOptionDetails`) |
-| Product info (descriptions, categories, support, EULA) | **Portal** (AMMP) — or `UpdateInformation` (fields not fully captured here). Simplest in the portal for a first listing. |
-| Publish **Limited → Public** | **Portal** (AMMP). The API's `UpdateDeliveryOptionsVisibility` is **EKS-add-on only**; Helm/Container delivery options publish to Public via the portal submit + the new-product "limited listing URL" approval. |
+The first publish is **not** portal-only. Verified on the live Elevarq
+pgAgroal launch by running the calls against current AWS docs, the whole
+sequence is API-driven:
 
-## Flow
+| # | Step | Change type | State transition |
+|---|------|-------------|------------------|
+| 1 | Create product + ECR repos | `CreateProduct` + `AddRepositories` (`01-create-product-and-repos.json`, chained via `$CreateProduct.Entity.Identifier`) | → Draft |
+| 2 | Push image + Helm chart into the ECR repos | CLI re-host — see "Re-host" below | — |
+| 3 | Product info (title, descriptions, highlights, category, keywords, logo) | `UpdateInformation` (`03-update-information.json`) — **works on a Draft** | Draft |
+| 4 | Free offer: create + terms | `CreateOffer`, offer `UpdateInformation`, `UpdateLegalTerms` (`CustomEula`), `UpdateSupportTerms` — **no pricing term** (see below) | Draft |
+| 5 | Release product **and** offer (combined) | `ReleaseProduct` + `ReleaseOffer` in one change-set | Draft → **Limited** |
+| 6 | Add the Helm delivery version | `AddDeliveryOptions` (`02-add-helm-delivery.json`) — **only once Limited** | Limited |
+| 7 | Make public | `UpdateVisibility` `TargetVisibility: Public` (own change-set; AWS Seller-Ops manual review) | Limited → Public |
 
-1. **Create product + repos:**
-   ```sh
-   scripts/marketplace-changeset.sh docs/marketplace/catalog-api/01-create-product-and-repos.json
-   ```
-   Capture the new **product Identifier** (printed; also `aws marketplace-catalog
-   list-entities --catalog AWSMarketplace --entity-type ContainerProduct`).
+Notes on the ordering, all verified on the pgAgroal launch:
 
-2. **Find the created ECR repo URIs:**
-   ```sh
-   aws ecr describe-repositories \
-     --query 'repositories[?contains(repositoryName, `elevarq`)].repositoryUri'
-   ```
-   AWS prepends a seller namespace, so the full paths are
-   `<acct>.dkr.ecr.<region>.amazonaws.com/<seller-ns>/elevarq-signals` (image)
-   and `…/<seller-ns>/elevarq-signals-chart` (chart).
+1. **`UpdateInformation` requires all core fields in one call** and works on a
+   Draft: `ProductTitle`, `ShortDescription`, `LongDescription`, `LogoUrl`,
+   `Highlights` (max 3), `AdditionalResources`, `SupportDescription`,
+   `Categories` (1-3), `SearchKeywords` (max 15, ≤250 combined chars). See
+   `03-update-information.json`.
+2. **A free offer takes no pricing term.** `CreateOffer` + offer
+   `UpdateInformation` + `UpdateLegalTerms` + `UpdateSupportTerms` are the
+   terms. `UpdatePricingTerms` with `PricingModel: Free` is **rejected** —
+   omit it entirely.
+3. **`AddDeliveryOptions` needs the product Limited first.** On a Draft it
+   fails `INCOMPATIBLE_PRODUCT_STATUS` ("Use a Public or Limited or Restricted
+   product"). Release the product (step 5) before adding the version. Adding
+   the version triggers AWS's async image + chart **scan** — the long pole.
+4. **`UpdateVisibility: Public` is its own change-set** and runs an AWS Seller
+   Operations manual review. It needs a published **public seller profile**, or
+   it fails `MISSING_SELLER_PROFILE_INFORMATION`. Do not run without the EULA
+   signed and an explicit go.
 
-3. **Push the 1.0.0 image + chart** into those repos. The script also
-   **repackages the chart** so its default image points at the Marketplace ECR
-   repo (not ghcr) — required, see Constraints below:
-   ```sh
-   MP_REGISTRY=<acct>.dkr.ecr.us-east-1.amazonaws.com \
-   MP_IMAGE_REPO=<seller-ns>/elevarq-signals \
-   MP_CHART_REPO=<seller-ns>/elevarq-signals-chart \
-   VERSION=1.0.0 scripts/marketplace-ecr-push.sh
-   ```
+### LegalTerm / CustomEula (free offer)
 
-4. **Add the Helm delivery version:**
-   ```sh
-   PRODUCT_ID=<product-id> VERSION=1.0.0 \
-   IMAGE_URI=<acct>.dkr.ecr.us-east-1.amazonaws.com/<seller-ns>/elevarq-signals:1.0.0 \
-   CHART_URI=<acct>.dkr.ecr.us-east-1.amazonaws.com/<seller-ns>/elevarq-signals-chart/signals:1.0.0 \
-   RELEASE_NOTES="Elevarq Signals 1.0.0 — first stable release." \
-   DELIVERY_DESCRIPTION="Helm install on Amazon EKS. Local-first, read-only PostgreSQL diagnostic collector; passwordless onboarding; no diagnostic-data egress to Elevarq." \
-   USAGE_INSTRUCTIONS="1) aws ecr get-login-password --region <region> | helm registry login --username AWS --password-stdin <registry>. 2) Create signals-values.yaml with: target.host, target.dbname, target.user=signals, target.authMethod=aws_rds_iam, target.sslmode=verify-full. 3) helm install signals oci://<chart-repo>/signals --version 1.0.0 -n signals --create-namespace -f signals-values.yaml. Full onboarding: docs/marketplace/install-from-aws-marketplace.md" \
-     scripts/marketplace-changeset.sh docs/marketplace/catalog-api/02-add-helm-delivery.json
-   ```
+The free offer's legal term references the EULA as a **PDF in an accessible S3
+bucket** (not inline text):
 
-5. **Product info + publish** in AMMP: fill description/categories/support/EULA,
-   submit, approve the limited listing URL, request Limited → Public.
+```json
+{ "Type": "LegalTerm", "Documents": [
+  { "Type": "CustomEula",
+    "Url": "https://elevarq-marketplace-public.s3.amazonaws.com/eula/elevarq-signals-eula-v1.pdf" } ] }
+```
 
-## Constraints baked into the templates (from the API error catalog)
+Render [`../EULA.md`](../EULA.md) to PDF and host it at that S3 URL when 1.0
+ships. Rationale + counsel gates: [`../EULA-review-notes.md`](../EULA-review-notes.md).
+
+### LogoUrl must be an S3 URL
+
+`UpdateInformation`'s `LogoUrl` regex accepts any https URL, but a deeper
+`INVALID_MEDIA` check rejects non-S3 hosts (*"Provide a new URL for media
+stored in S3."*). The logo therefore lives in S3, reusing the **Elevarq
+company logo** already hosted for the portfolio (repackaged-software rule: the
+product logo is the company logo — one asset for every Elevarq listing):
+
+```
+https://elevarq-marketplace-public.s3.amazonaws.com/logos/elevarq-512.png
+```
+
+Spec: square 1:1, 120–640px, transparent PNG, <5MB (the hosted asset is a
+512×512 transparent PNG).
+
+## Re-host the image + chart (verified commands)
+
+Push the released 1.0.0 image and Helm chart into the Marketplace ECR repos.
+**skopeo is not required or installed** — `docker buildx imagetools create`
+copies the full multi-arch manifest registry-to-registry:
+
+```sh
+MP=<acct>.dkr.ecr.us-east-1.amazonaws.com   # Marketplace ECR registry host
+NS=<seller-ns>                              # AWS prepends a seller namespace
+
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin "$MP"
+aws ecr get-login-password --region us-east-1 \
+  | helm registry login --username AWS --password-stdin "$MP"
+
+# Image: multi-arch copy ghcr -> Marketplace ECR (no skopeo)
+docker buildx imagetools create \
+  -t "$MP/$NS/elevarq-signals:1.0.0" ghcr.io/elevarq/signals:1.0.0
+
+# Chart: pull, repoint default image to the MP ECR repo, rename so it lands at
+# the granted repo path, repackage, push (see "Chart path gotcha" below).
+```
+
+[`scripts/marketplace-ecr-push.sh`](../../../scripts/marketplace-ecr-push.sh)
+automates the chart repackage/rename and asserts no `ghcr.io` image remains.
+
+To find the created ECR repo URIs after step 1:
+
+```sh
+aws ecr describe-repositories \
+  --query 'repositories[?contains(repositoryName, `elevarq-signals`)].repositoryUri'
+```
+
+The full paths are `<acct>.dkr.ecr.<region>.amazonaws.com/<seller-ns>/elevarq-signals`
+(image) and `…/<seller-ns>/elevarq-signals-chart` (chart).
+
+## Apply a change-set
+
+```sh
+aws marketplace-catalog start-change-set \
+  --catalog AWSMarketplace \
+  --cli-input-json file://docs/marketplace/catalog-api/03-update-information.json
+# poll WITHOUT piping the full body to jq — embedded UsageInstructions newlines
+# break jq. Use --query instead:
+aws marketplace-catalog describe-change-set \
+  --catalog AWSMarketplace --change-set-id <id> \
+  --query '{Status:Status,Errors:ChangeSet[].ErrorDetailList}'
+```
+
+`ListEntities` for offers uses the bare entity type **`Offer`** (no `@version`);
+every other call uses **`Offer@1.0`** / `ContainerProduct@1.0`.
+
+## Constraints baked into the change-sets (from the API error catalog)
 
 - `RepositoryType` must be `"ECR"` (only allowed value).
-- Helm `HelmChartUri` tag must be **SemVer 2** (our chart tag `1.0.0` qualifies).
-- Don't use the `latest` image tag (`INVALID_CONTAINER_IMAGE_TAG`).
-- All Helm chart images must be in repos created via `AddRepositories`
-  (`INVALID_HELM_CHART_IMAGES`) — i.e. re-host everything (no ghcr). The chart's
-  **default `image.repository` must point at the Marketplace ECR repo**, not
-  ghcr — `marketplace-ecr-push.sh` repackages the chart and `helm template`-
-  asserts no ghcr image remains before pushing.
+- Helm `HelmChartUri` tag must be **SemVer 2** — `1.0.0` qualifies.
+- No `latest` image tag (`INVALID_CONTAINER_IMAGE_TAG`).
+- All Helm chart images must live in repos created via `AddRepositories`
+  (`INVALID_HELM_CHART_IMAGES`). The published chart's default
+  `image.repository` is repointed from `ghcr.io/elevarq/signals` to the
+  Marketplace ECR image repo before the chart is pushed; `helm template`
+  asserts no `ghcr.io` image remains. AWS rejects charts that still reference
+  ghcr images.
 - Repository names are **flat** (`elevarq-signals`, `elevarq-signals-chart`) —
   the API rejects names that aren't in the `nginx-web-app` format.
-- **Cosign decision:** the GHCR cosign signature does **not** carry over — the
-  `skopeo` copy moves only the image, not the `.sig` tag, and AWS re-scans (and
-  may re-sign) on ingestion. Marketplace artifacts are AWS-scanned, not
-  verifiable with our GHCR `cosign verify` commands. We accept this for 1.0
-  (re-signing the Marketplace ECR artifacts is a possible later enhancement).
 - `SCAN_ERROR` blocks the version if image scanning finds vulnerabilities —
-  our Trivy-clean base helps; patch before submitting.
-- We list `CompatibleServices: ["EKS"]` only. **Adding `EKS-Anywhere` requires
-  a license-secret `OverrideParameters` entry** (`DefaultValue:
-  "${AWSMP_LICENSE_SECRET}"`, `NO_LICENSE_SECRET_KEYS`) — out of scope for the
-  free EKS listing; add later if we want EKS-Anywhere.
+  the Trivy-clean 1.0.0 image must pass; patch before submitting.
+- `CompatibleServices: ["EKS"]` only. Adding `EKS-Anywhere` requires a
+  license-secret `OverrideParameters` entry — out of scope for the free EKS
+  listing.
 
-> All values in `02-add-helm-delivery.json` are `${PLACEHOLDERS}`; nothing is
-> submitted until you export them and run the script (which fails closed on any
-> unsubstituted variable).
+## Chart path gotcha (ECR repos are not hierarchical)
+
+`helm push chart.tgz oci://$MP/$NS/elevarq-signals-chart` appends the chart
+name and tries to create `$NS/elevarq-signals-chart/signals` — a **separate**
+ECR repository that does not exist and the seller cannot auto-create
+cross-account → `403 Forbidden`. Fix: land the chart **exactly** at the granted
+repo by renaming the chart so its name is the repo's last path segment
+(`Chart.yaml name: elevarq-signals-chart`) and pushing to the **parent**
+namespace (`oci://$MP/$NS`). Renaming the chart artifact does **not** change the
+deployed resource names: the Signals chart derives every name from the Helm
+**release name** (`{{ .Release.Name }}-signals`) and fixed
+`app.kubernetes.io/name: signals` labels, not from `.Chart.Name` — so a buyer
+running `helm install signals …` still gets `signals`-named resources, and no
+`nameOverride` is needed (unlike pgAgroal, whose chart keyed off `.Chart.Name`).
+Final chart URI: `$MP/$NS/elevarq-signals-chart:1.0.0`.
+
+## SignatureVerificationKey — not an image-signing gate
+
+The product entity carries an active RSA public key (`PublicKeyVersion 1`)
+after creation. This is the **metering** signature-verification key for the
+`RegisterUsage` flow (AWS generates the keypair, holds the private half, stamps
+the public half into the product). It is **not** an image-signing requirement:
+there is no signing field or signing-related error in the container-product
+API, image signing is not required to `AddDeliveryOptions` or publish, and free
+ECS/EKS products are exempt from `RegisterUsage`. No action needed on the key.

--- a/docs/marketplace/install-from-aws-marketplace.md
+++ b/docs/marketplace/install-from-aws-marketplace.md
@@ -44,15 +44,20 @@ target:
 ```
 
 ```sh
-helm install signals oci://<marketplace-ecr-chart-repo>/signals \
+helm install signals \
+  oci://<marketplace-ecr-registry>/<seller-ns>/elevarq-signals-chart \
   --version 1.0.0 \
   --namespace signals --create-namespace \
   -f signals-values.yaml
 ```
 
-The chart is the **same chart** as
-[`deploy/helm/signals`](../../deploy/helm/signals/) — only the registry
-differs. Its values are documented in
+The chart URI ends at the **granted Marketplace ECR repo**
+(`elevarq-signals-chart`), not a `…/signals` sub-path — the chart artifact is
+renamed to land there. Your Kubernetes resource names are unaffected: they
+derive from the Helm **release name** (`signals` above), not the chart name. It
+is otherwise the **same chart** as
+[`deploy/helm/signals`](../../deploy/helm/signals/); only the registry and the
+chart artifact name differ. Its values are documented in
 [`deploy/helm/signals/README.md`](../../deploy/helm/signals/README.md).
 
 ## 4. Complete the passwordless onboarding

--- a/scripts/marketplace-ecr-push.sh
+++ b/scripts/marketplace-ecr-push.sh
@@ -25,8 +25,10 @@
 #   AWS_REGION      default us-east-1
 #   AWS_PROFILE     default elevarq
 #
-# Requires: aws, skopeo (multi-arch-preserving copy), helm. Auth is via
-# `aws ecr get-login-password` (no long-lived creds).
+# Requires: aws, docker (with buildx), helm. Auth is via
+# `aws ecr get-login-password` (no long-lived creds). skopeo is NOT required —
+# `docker buildx imagetools create` copies the multi-arch manifest
+# registry-to-registry.
 
 set -euo pipefail
 
@@ -50,30 +52,32 @@ SOURCE_IMAGE="${SOURCE_IMAGE:-ghcr.io/elevarq/signals:${VERSION}}"
 SOURCE_CHART="${SOURCE_CHART:-oci://ghcr.io/elevarq/charts/signals}"
 export AWS_REGION AWS_PROFILE
 
-for bin in aws skopeo helm; do
+for bin in aws docker helm; do
   command -v "$bin" >/dev/null 2>&1 || die "missing required tool: $bin"
 done
+docker buildx version >/dev/null 2>&1 || die "docker buildx is required"
 
 echo "==> Authenticating to Marketplace ECR (${MP_REGISTRY})"
 PW="$(aws ecr get-login-password --region "$AWS_REGION")"
-printf '%s' "$PW" | skopeo login --username AWS --password-stdin "$MP_REGISTRY"
+printf '%s' "$PW" | docker login --username AWS --password-stdin "$MP_REGISTRY"
 printf '%s' "$PW" | helm registry login --username AWS --password-stdin "$MP_REGISTRY"
 
 DEST_IMAGE="${MP_REGISTRY}/${MP_IMAGE_REPO}:${VERSION}"
 
 echo "==> Copying image (multi-arch manifest preserved)"
 echo "    ${SOURCE_IMAGE}  ->  ${DEST_IMAGE}"
-# --all copies the full manifest list (linux/amd64 + linux/arm64) as-is.
-# Note: cosign signatures live under separate .sig tags and are NOT copied;
-# AWS Marketplace scans (and may re-sign) the image on ingestion regardless.
-skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${DEST_IMAGE}"
+# `imagetools create` copies the full manifest list (linux/amd64 + linux/arm64)
+# registry-to-registry, as-is. Note: cosign signatures live under separate .sig
+# tags and are NOT copied; AWS Marketplace scans (and may re-sign) the image on
+# ingestion regardless.
+docker buildx imagetools create -t "${DEST_IMAGE}" "${SOURCE_IMAGE}"
 
 echo "==> Repackaging + pushing Helm chart"
 # AWS rejects Helm charts whose images live outside the Marketplace ECR repos
 # (INVALID_HELM_CHART_IMAGES). The published chart must default its image to the
 # Marketplace ECR image we just pushed — NOT ghcr.io. Pull the released chart,
 # repoint image.repository, prove via `helm template` that no ghcr.io image
-# remains, then repackage and push.
+# remains, then rename + repackage + push.
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 helm pull "${SOURCE_CHART}" --version "${VERSION}" --untar --untardir "$workdir"
@@ -84,6 +88,24 @@ chartdir="$workdir/signals"
 # (The chart's default tag is already ${VERSION}; buyers can still override.)
 sed -i.bak "s#ghcr.io/elevarq/signals#${DEST_IMAGE%:*}#g" "$chartdir/values.yaml"
 rm -f "$chartdir/values.yaml.bak"
+
+# Chart-path 403 gotcha: ECR repos are NOT hierarchical. `helm push` appends the
+# chart name, so pushing the "signals" chart to oci://$MP/$MP_CHART_REPO tries to
+# create $MP_CHART_REPO/signals — a separate, non-existent repo the seller cannot
+# auto-create cross-account (403). Fix: rename the chart so its name is the
+# repo's last path segment and push to the PARENT namespace; the chart then lands
+# exactly at the granted repo. Deployed resource names are unaffected — the
+# Signals chart keys off the Helm release name ({{ .Release.Name }}-signals),
+# not .Chart.Name, so no nameOverride is needed.
+CHART_ARTIFACT_NAME="$(basename "$MP_CHART_REPO")"
+CHART_PARENT="$(dirname "$MP_CHART_REPO")"
+if [ "$CHART_PARENT" = "." ]; then
+  CHART_PUSH_TARGET="oci://${MP_REGISTRY}"
+else
+  CHART_PUSH_TARGET="oci://${MP_REGISTRY}/${CHART_PARENT}"
+fi
+sed -i.bak "s#^name:.*#name: ${CHART_ARTIFACT_NAME}#" "$chartdir/Chart.yaml"
+rm -f "$chartdir/Chart.yaml.bak"
 
 echo "==> Validating repackaged chart (helm lint + no external images)"
 helm lint "$chartdir"
@@ -97,15 +119,14 @@ printf '%s\n' "$RENDERED" | grep -q "${DEST_IMAGE%:*}" \
   || die "repackaged chart does not reference the Marketplace ECR image ${DEST_IMAGE%:*}"
 
 helm package "$chartdir" --destination "$workdir"
-chart_tgz="$(ls "$workdir"/signals-*.tgz)"
-helm push "$chart_tgz" "oci://${MP_REGISTRY}/${MP_CHART_REPO}"
+chart_tgz="$(ls "$workdir/${CHART_ARTIFACT_NAME}"-*.tgz)"
+helm push "$chart_tgz" "$CHART_PUSH_TARGET"
 
 echo
 echo "==> Done. Digests for the Marketplace AddVersion / delivery option:"
 echo "    image: ${DEST_IMAGE}"
-skopeo inspect --raw "docker://${DEST_IMAGE}" >/dev/null 2>&1 \
-  && echo "    image digest: $(skopeo inspect --format '{{.Digest}}' "docker://${DEST_IMAGE}" 2>/dev/null || echo '(inspect manually)')"
-echo "    chart: oci://${MP_REGISTRY}/${MP_CHART_REPO}/signals:${VERSION}"
+echo "    image digest: $(docker buildx imagetools inspect "${DEST_IMAGE}" 2>/dev/null | awk '/^Digest:/{print $2; exit}' || echo '(inspect manually)')"
+echo "    chart: oci://${MP_REGISTRY}/${MP_CHART_REPO}:${VERSION}"
 echo
 echo "Next: reference these in the container product's Helm delivery option,"
 echo "submit, then approve the limited listing URL (docs/marketplace/aws-listing.md)."


### PR DESCRIPTION
Ports the VERIFIED AWS Marketplace listing patterns from the live Elevarq pgAgroal launch into the Signals marketplace docs. **Docs prep only** — no AWS CLI / change-sets were run, nothing is released, and the **v1.0.0 release + EULA legal sign-off stay GATED**.

## What changed

- **`docs/marketplace/EULA.md`** — reduced to clean customer-facing contract text only (removed the Draft / for-counsel / recommended-option blocks). Content fixes: "no fees" -> "no software fee" (buyer still pays AWS infra/service charges); data section clarified (local-first, read-only; no telemetry/diagnostic-data egress to Elevarq as packaged; the only outbound calls are the optional cloud-auth/TLS requests within the buyer's own cloud; Marketplace/subscription data governed by AWS terms); commercial-support upsell removed in favour of community support via GitHub Issues + security via `SECURITY.md` / security@elevarq.com.
- **`docs/marketplace/EULA-review-notes.md`** (new) — internal rationale + counsel gates (custom-EULA-vs-SCMP, Scantr LLC d/b/a Elevarq entity gate, seller-entity / EULA-party / `LICENSE`-copyright alignment, CustomEula S3-PDF plan).
- **`docs/marketplace/catalog-api/README.md`** + **`docs/marketplace/aws-listing.md`** — replaced the "portal-only first publish" framing with the verified **fully Catalog-API-driven** sequence: CreateProduct + AddRepositories -> UpdateInformation (incl. S3 LogoUrl, works on Draft) -> CreateOffer + offer UpdateInformation + UpdateLegalTerms(CustomEula) + UpdateSupportTerms (**no pricing term** for a free offer) -> ReleaseProduct + ReleaseOffer (combined, Draft->Limited) -> AddDeliveryOptions (only once Limited; triggers the AWS scan) -> UpdateVisibility:Public (own change-set; Seller-Ops manual review; needs a public seller profile). Folded in: S3 LogoUrl reuse of the Elevarq company logo, CustomEula S3 PDF, `docker buildx imagetools create` re-host (skopeo dropped), the ECR chart-path 403 gotcha, the inert metering `SignatureVerificationKey`, and the `ListEntities` (`Offer` no `@version`) / `describe-change-set --query` quirks.
- **`docs/marketplace/catalog-api/03-update-information.json`** (new) — benefit-first listing copy: short + long description (lead with local-first / read-only / passwordless / no diagnostic-data egress), 3 highlights, 14 keywords (120 combined chars), `Infrastructure Software` category (AWS has no "Database" category), S3 LogoUrl.
- **`docs/marketplace/install-from-aws-marketplace.md`** — buyer chart URI now lands at the granted ECR repo (no hierarchical `…/signals` sub-path).
- **`scripts/marketplace-ecr-push.sh`** — aligned with the corrected docs so they don't drift: `docker buildx imagetools create` instead of skopeo (which the verified learning says is not installed), and the chart-path 403 fix (rename the chart to the repo's last segment, push to the parent namespace). shellcheck-clean.

## Signals-specific accuracy

Signals is a **read-only diagnostic collector**, not a connection pooler — pgAgroal's product specifics were not copied. One notable divergence: the Signals Helm chart derives resource names from the **Helm release name** (`{{ .Release.Name }}-signals`), not `.Chart.Name`, so renaming the chart artifact to fix the 403 needs **no `nameOverride`** (pgAgroal needed one).

## Gating

Signals is still pre-1.0 (`v0.10.0-rc.1`). The listing is gated on the v1.0.0 release and EULA legal sign-off; this PR changes documentation only.

Refs #218
closes #220