### PR TITLE
docs: finalize for 1.0 GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ docker run -d --name signals \
   -e SIGNALS_ENV=dev \
   -v signals-data:/data \
   -p 8081:8081 \
-  ghcr.io/elevarq/signals:latest
+  ghcr.io/elevarq/signals:1.0.0
 ```
 
 ### Build from source

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,18 +35,17 @@ the cadence is the next routine release.
 
 ## Supported versions
 
-Elevarq Signals is **pre-1.0 / Beta**. Only the **latest tagged release on
-the active line** receives security fixes:
+Elevarq Signals is **1.0 (GA)**. The latest stable release on the most
+recent minor receives security fixes:
 
 | Version line | Status |
 |---|---|
-| `v0.10.0-beta.x` | **Active** — receives security fixes |
-| `v0.9.x` | End-of-life (superseded by the Beta line) |
-| `v0.3.x` and older | Unsupported |
+| `v1.0.x` | **Active** — receives security fixes |
+| `v0.10.0-rc.x` / `v0.10.0-beta.x` | End-of-life (superseded by 1.0) |
+| `v0.9.x` and older | Unsupported |
 
-Once `v0.10.0` (stable) ships, the latest stable release on the most
-recent minor will be the supported line; earlier minors will receive
-only Critical fixes for one minor cycle.
+When a new minor ships, the previous minor receives only Critical fixes
+for one minor cycle.
 
 ## Security model
 

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -21,7 +21,7 @@ This produces `bin/signals` (daemon) and `bin/signalsctl` (CLI).
 **Docker:**
 
 ```bash
-docker pull ghcr.io/elevarq/signals:latest
+docker pull ghcr.io/elevarq/signals:1.0.0
 ```
 
 ### 2. Configure
@@ -91,7 +91,7 @@ docker run -d \
   -v /etc/signals/signals.yaml:/etc/signals/signals.yaml:ro \
   -v signals-data:/data \
   -p 127.0.0.1:8081:8081 \
-  ghcr.io/elevarq/signals:latest
+  ghcr.io/elevarq/signals:1.0.0
 ```
 
 The container runs as a non-root user (UID 10001) on Alpine 3.21. The API listens on port 8081. Bind it to loopback unless you need external access.
@@ -113,7 +113,7 @@ docker run -d \
   -v /run/secrets/pg_password:/run/secrets/pg_password:ro \
   -v signals-data:/data \
   -p 127.0.0.1:8081:8081 \
-  ghcr.io/elevarq/signals:latest
+  ghcr.io/elevarq/signals:1.0.0
 ```
 
 The following target-level env vars are supported:

--- a/docs/marketplace/EULA-review-notes.md
+++ b/docs/marketplace/EULA-review-notes.md
@@ -6,9 +6,8 @@ must contain clean customer-facing text only. This file holds the rationale and
 the open counsel gates.
 
 > This is not legal advice. The items under "Counsel gates" must be confirmed
-> with counsel before the listing is submitted. Signals is still pre-1.0
-> (latest tag `v0.10.0-rc.1`); the listing — and therefore this EULA — is
-> gated on the v1.0.0 release and legal sign-off.
+> with counsel before the listing is submitted. Signals is GA at v1.0.0; the
+> listing — and therefore this EULA — is gated on counsel's legal sign-off.
 
 ## Custom EULA vs Standard Contract (SCMP)
 

--- a/docs/marketplace/aws-listing.md
+++ b/docs/marketplace/aws-listing.md
@@ -8,12 +8,12 @@ This file is the content + steps we drive via the AWS Marketplace Catalog API
 (`StartChangeSet`); no AMMP web UI is required. The verified publish sequence
 and per-call gotchas live in [`catalog-api/README.md`](catalog-api/README.md).
 
-> **Status: GATED — docs prep only.** Signals is still pre-1.0 (latest tag
-> `v0.10.0-rc.1`). Two gates remain before anything is submitted: (1) the
-> **v1.0.0 release** must ship, and (2) **legal sign-off** on the EULA / entity
-> wording (§4). Do **not** run the publish / visibility change-sets until both
-> clear. The `SignatureVerificationKey` question is resolved (§6 — it is the
-> inert metering key, not an image-signing requirement).
+> **Status: GATED on EULA legal sign-off.** Signals is GA at **v1.0.0**, so
+> the release gate is met. One gate remains before anything is submitted:
+> **legal sign-off** on the EULA / entity wording (§4). Do **not** run the
+> publish / visibility change-sets until it clears. The
+> `SignatureVerificationKey` question is resolved (§6 — it is the inert
+> metering key, not an image-signing requirement).
 
 ## 0. Pre-publish gate
 
@@ -169,10 +169,9 @@ chart README, and [`docs/database-connections.md`](../database-connections.md).
 
 **Open (must clear before submit)**
 
-- **v1.0.0 release** — Signals is pre-1.0 (`v0.10.0-rc.1`); the listing is
-  gated on the stable release.
 - **EULA / entity wording** — counsel review (Scantr LLC dba Elevarq); see
-  [`EULA-review-notes.md`](EULA-review-notes.md).
+  [`EULA-review-notes.md`](EULA-review-notes.md). This is the remaining gate
+  before submit (the v1.0.0 GA release is cut).
 
 **Decided**
 

--- a/docs/marketplace/catalog-api/README.md
+++ b/docs/marketplace/catalog-api/README.md
@@ -6,11 +6,11 @@ Tracks [Elevarq/Signals#218](https://github.com/Elevarq/Signals/issues/218);
 schemas are from the official
 [container-products Catalog API reference](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/container-products.html).
 
-> **Gated.** Signals is still pre-1.0 (latest tag `v0.10.0-rc.1`). These
-> change-sets are docs prep only — **do not run any of them** until the
-> v1.0.0 release ships and the EULA clears legal sign-off (see
-> [`../aws-listing.md`](../aws-listing.md) §4). The product does not exist yet;
-> the identifiers below are populated once `CreateProduct` runs.
+> **Gated on EULA legal sign-off.** Signals is GA at **v1.0.0**. These
+> change-sets are still docs prep — **do not run any of them** until the EULA
+> clears legal sign-off (see [`../aws-listing.md`](../aws-listing.md) §4). The
+> product does not exist yet; the identifiers below are populated once
+> `CreateProduct` runs.
 
 Run a change-set with
 [`scripts/marketplace-changeset.sh`](../../../scripts/marketplace-changeset.sh)


### PR DESCRIPTION
Tiny docs-finalization pass before cutting **v1.0.0** (per review).

- **SECURITY.md** — Supported versions now `1.0.x` GA (was "pre-1.0 / Beta" with `v0.10.0-beta.x` active).
- **Marketplace status banners** (`aws-listing.md`, `catalog-api/README.md`, `EULA-review-notes.md`) — the v1.0.0 release gate is met; the **EULA legal sign-off** is the remaining gate before submit. Change-sets stay "do not run" until counsel clears.
- **Pinned examples** — `:latest` image pulls -> `:1.0.0` (README, adoption-guide).

Docs-only. After merge, cut `v1.0.0`. Refs #218.