### PR TITLE
docs(marketplace): EULA Section 3 wording fix + sign-off

### DIFF
--- a/docs/marketplace/EULA-review-notes.md
+++ b/docs/marketplace/EULA-review-notes.md
@@ -5,9 +5,11 @@ customer-facing contract — the upload-ready EULA is [`EULA.md`](EULA.md), whic
 must contain clean customer-facing text only. This file holds the rationale and
 the open counsel gates.
 
-> This is not legal advice. The items under "Counsel gates" must be confirmed
-> with counsel before the listing is submitted. Signals is GA at v1.0.0; the
-> listing — and therefore this EULA — is gated on counsel's legal sign-off.
+> This is not legal advice. Signals is GA at v1.0.0; the EULA wording is
+> finalized and the gates below were **reviewed and signed off (2026-06-30,
+> product/compliance)** — see "Sign-off" at the end. The remaining
+> pre-submission items are the website Marketplace-install path and the
+> Catalog-API execution itself.
 
 ## Custom EULA vs Standard Contract (SCMP)
 
@@ -43,6 +45,26 @@ the free offer's legal term then references that S3 URL
    and the absence of any support upsell satisfy AWS's container-product
    policies for free products (no metadata redirecting buyers to offerings not
    available on AWS Marketplace).
+
+## Sign-off (2026-06-30)
+
+Product/compliance sign-off given after a review against AWS container-product
+policies. Resolutions to the gates above:
+
+- **Section 3 wording corrected.** The outbound-network sentence now states
+  that calls are limited to the configured **PostgreSQL targets** plus the
+  optional cloud-authentication / secret-store / TLS requests the operator
+  configures — made to the operator's own cloud services, never to Elevarq.
+  (Previously it omitted the PostgreSQL targets.)
+- **Gate 1 (entity).** **Scantr LLC, doing business as Elevarq** is the
+  contracting party; confirmed it must match the AWS seller registration
+  record operationally before submit.
+- **Gate 2 (LICENSE copyright).** Accepted as-is — `LICENSE` reads
+  `Copyright (c) 2026, Elevarq`. Tightening it to "Scantr LLC d/b/a Elevarq"
+  is a separate entity-cleanup decision, **not** a blocker to the EULA text.
+- **Gate 3 (free-listing framing).** Confirmed: no software fee (§2), no
+  support upsell, listing support copy is community-only, and no metadata
+  redirects buyers to offerings unavailable on AWS Marketplace.
 
 ## Customer-facing hygiene
 

--- a/docs/marketplace/EULA.md
+++ b/docs/marketplace/EULA.md
@@ -22,10 +22,11 @@ Elevarq** ("Elevarq"), through AWS Marketplace.
    **no telemetry and no diagnostic data to Elevarq**. The diagnostic snapshots
    it collects remain within your own AWS account and customer-controlled
    infrastructure; the Software exports data only to the local destination you
-   explicitly choose. The Software's only outbound network calls are the
-   optional cloud-authentication and TLS requests you configure (for example,
-   Amazon RDS IAM authentication, AWS Secrets Manager, or AWS Systems Manager
-   Parameter Store), which are made to your own cloud's services and never to
+   explicitly choose. The Software's outbound network calls are limited to the
+   PostgreSQL targets you configure and the optional cloud-authentication,
+   secret-store, and TLS-related requests you configure (for example, Amazon
+   RDS IAM authentication, AWS Secrets Manager, or AWS Systems Manager
+   Parameter Store), which are made to your own cloud services and never to
    Elevarq. Any data associated with your AWS Marketplace subscription, Amazon
    ECR access, or AWS account (for example, subscription and entitlement
    records) is handled by AWS under the applicable AWS Marketplace and AWS

--- a/docs/marketplace/aws-listing.md
+++ b/docs/marketplace/aws-listing.md
@@ -8,10 +8,13 @@ This file is the content + steps we drive via the AWS Marketplace Catalog API
 (`StartChangeSet`); no AMMP web UI is required. The verified publish sequence
 and per-call gotchas live in [`catalog-api/README.md`](catalog-api/README.md).
 
-> **Status: GATED on EULA legal sign-off.** Signals is GA at **v1.0.0**, so
-> the release gate is met. One gate remains before anything is submitted:
-> **legal sign-off** on the EULA / entity wording (§4). Do **not** run the
-> publish / visibility change-sets until it clears. The
+> **Status: EULA signed off; pre-submission items remain.** Signals is GA at
+> **v1.0.0** (release gate met) and the **EULA wording is finalized and signed
+> off** (product/compliance, 2026-06-30 — see
+> [`EULA-review-notes.md`](EULA-review-notes.md)). Before public submission:
+> (1) add the **website Marketplace-install path**, and (2) operationally
+> confirm the AWS seller-registration entity matches "Scantr LLC d/b/a
+> Elevarq". Then run the Catalog-API sequence (§5). The
 > `SignatureVerificationKey` question is resolved (§6 — it is the inert
 > metering key, not an image-signing requirement).
 

--- a/docs/marketplace/catalog-api/README.md
+++ b/docs/marketplace/catalog-api/README.md
@@ -6,11 +6,12 @@ Tracks [Elevarq/Signals#218](https://github.com/Elevarq/Signals/issues/218);
 schemas are from the official
 [container-products Catalog API reference](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/container-products.html).
 
-> **Gated on EULA legal sign-off.** Signals is GA at **v1.0.0**. These
-> change-sets are still docs prep — **do not run any of them** until the EULA
-> clears legal sign-off (see [`../aws-listing.md`](../aws-listing.md) §4). The
-> product does not exist yet; the identifiers below are populated once
-> `CreateProduct` runs.
+> **EULA signed off; pre-submission items remain.** Signals is GA at
+> **v1.0.0** and the EULA is finalized + signed off. Before running these
+> change-sets, land the website Marketplace-install path and confirm the
+> seller-registration entity (see [`../aws-listing.md`](../aws-listing.md)
+> status banner). The product does not exist yet; the identifiers below are
+> populated once `CreateProduct` runs.
 
 Run a change-set with
 [`scripts/marketplace-changeset.sh`](../../../scripts/marketplace-changeset.sh)


### PR DESCRIPTION
Applies the one EULA wording fix from review and records the product/compliance sign-off.

- **EULA.md §3** — outbound-network calls now state they are limited to the configured **PostgreSQL targets** plus the optional cloud-auth / secret-store / TLS requests the operator configures (made to the operator's own cloud services, never to Elevarq). The PostgreSQL targets were previously omitted.
- **EULA-review-notes** — records the sign-off (2026-06-30) and resolves the three gates: entity = Scantr LLC d/b/a Elevarq (confirm matches seller registration), LICENSE copyright accepted as-is (separate entity-cleanup, not a blocker), free-listing framing confirmed.
- **Status banners** (aws-listing, catalog-api) — EULA gate cleared; remaining pre-submission items: the website Marketplace-install path + operational seller-entity confirmation, then the Catalog-API sequence.

Docs-only. Refs #218.