### PR TITLE
docs(marketplace): pin buyer ECR login/host to us-east-1

### DIFF
--- a/docs/marketplace/aws-listing.md
+++ b/docs/marketplace/aws-listing.md
@@ -68,7 +68,7 @@ These are the `UpdateInformation` fields — captured in
 
 ```sh
 # Authenticate Helm to the AWS Marketplace registry (buyer side)
-aws ecr get-login-password --region <region> \
+aws ecr get-login-password --region us-east-1 \
   | helm registry login --username AWS --password-stdin <marketplace-ecr-registry>
 ```
 

--- a/docs/marketplace/install-from-aws-marketplace.md
+++ b/docs/marketplace/install-from-aws-marketplace.md
@@ -19,11 +19,11 @@ account pull access to the Marketplace ECR repositories for the product.
 ## 2. Authenticate Helm to the Marketplace registry
 
 ```sh
-aws ecr get-login-password --region <region> \
+aws ecr get-login-password --region us-east-1 \
   | helm registry login --username AWS --password-stdin <marketplace-ecr-registry>
 ```
 
-`<marketplace-ecr-registry>` is the `*.dkr.ecr.<region>.amazonaws.com` host
+`<marketplace-ecr-registry>` is the `*.dkr.ecr.us-east-1.amazonaws.com` host
 shown on the listing's launch page.
 
 ## 3. Install the chart


### PR DESCRIPTION
The AWS Marketplace ECR registry for Signals is region-fixed at
`us-east-1` (`709825985650.dkr.ecr.us-east-1.amazonaws.com`). The
`aws ecr get-login-password` token is scoped to the **registry** region, so
buyer authentication must be `--region us-east-1` regardless of the buyer’s
cluster region. The `<region>` placeholder led a buyer to substitute their own
cluster region and fail on the first authenticate step.

## Changes (three buyer-facing references, one concern)

- `install-from-aws-marketplace.md` — login `--region <region>` → `us-east-1`
- `install-from-aws-marketplace.md` — registry host `*.dkr.ecr.<region>.amazonaws.com` → `*.dkr.ecr.us-east-1.amazonaws.com`
- `aws-listing.md` — buyer-usage login `--region <region>` → `us-east-1`

## Out of scope (deliberately not touched)

- `catalog-api/README.md` seller-side path template `<acct>.dkr.ecr.<region>.amazonaws.com/<seller-ns>/...` (structural, seller-facing).
- Seller push script `scripts/marketplace-ecr-push.sh` region handling (separate seller-ops concern; own PR).
- ECS supported-services copy (the over-claim is in the AWS portal, not the repo; handled by hand).

closes #229