### PR TITLE
marketplace: container-image (ECS/Fargate) delivery option template

### DIFF
--- a/docs/marketplace/catalog-api/04-add-container-image-delivery.json
+++ b/docs/marketplace/catalog-api/04-add-container-image-delivery.json
@@ -1,0 +1,31 @@
+{
+  "Catalog": "AWSMarketplace",
+  "ChangeSet": [
+    {
+      "ChangeType": "AddDeliveryOptions",
+      "Entity": {
+        "Type": "ContainerProduct@1.0",
+        "Identifier": "${PRODUCT_ID}"
+      },
+      "DetailsDocument": {
+        "Version": {
+          "VersionTitle": "${VERSION}",
+          "ReleaseNotes": "${RELEASE_NOTES}"
+        },
+        "DeliveryOptions": [
+          {
+            "DeliveryOptionTitle": "Container image (Amazon ECS / Fargate)",
+            "Details": {
+              "EcrDeliveryOptionDetails": {
+                "CompatibleServices": ["ECS"],
+                "ContainerImages": ["${IMAGE_URI}"],
+                "Description": "${CI_DELIVERY_DESCRIPTION}",
+                "UsageInstructions": "${CI_USAGE_INSTRUCTIONS}"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/marketplace/catalog-api/README.md
+++ b/docs/marketplace/catalog-api/README.md
@@ -33,6 +33,16 @@ sequence is API-driven:
 | 6 | Add the Helm delivery version | `AddDeliveryOptions` (`02-add-helm-delivery.json`) — **only once Limited** | Limited |
 | 7 | Make public | `UpdateVisibility` `TargetVisibility: Public` (own change-set; AWS Seller-Ops manual review) | Limited → Public |
 
+### Reach expansion — additional delivery options (post-launch, #233)
+
+Once the listing is live, extra delivery options can be added — each reuses the
+**same** re-hosted Marketplace-ECR image and is its **own** AWS review round
+(never bundle). See `specifications/marketplace-container-image-delivery.md`.
+
+| Lever | Change type | Details type | Notes |
+|-------|-------------|--------------|-------|
+| Container image (ECS / Fargate / `docker pull`), #234 | `AddDeliveryOptions` (`04-add-container-image-delivery.json`) | `EcrDeliveryOptionDetails`, `CompatibleServices: ["ECS"]` | Additive; does not touch the Helm option. `ContainerImages` MUST equal the Helm option's image (one artifact, two options). Buyer runs it with no Helm/K8s, so `CI_USAGE_INSTRUCTIONS` must document durable snapshot storage — the Fargate task filesystem is ephemeral, attach EFS (or an EBS/bind volume on EC2-backed ECS). |
+
 Notes on the ordering, all verified on the pgAgroal launch:
 
 1. **`UpdateInformation` requires all core fields in one call** and works on a

--- a/scripts/marketplace-changeset.sh
+++ b/scripts/marketplace-changeset.sh
@@ -22,6 +22,16 @@
 #   RELEASE_NOTES="..." DELIVERY_DESCRIPTION="..." USAGE_INSTRUCTIONS="..." \
 #     scripts/marketplace-changeset.sh docs/marketplace/catalog-api/02-add-helm-delivery.json
 #
+#   # For 04-add-container-image-delivery.json (adds the ECS / Fargate /
+#   # docker-pull delivery option alongside Helm — same re-hosted image), export:
+#   PRODUCT_ID=prod-xxxx VERSION=1.0.0 \
+#   IMAGE_URI=<acct>.dkr.ecr.us-east-1.amazonaws.com/elevarq/elevarq-signals:1.0.0 \
+#   RELEASE_NOTES="..." CI_DELIVERY_DESCRIPTION="..." CI_USAGE_INSTRUCTIONS="..." \
+#     scripts/marketplace-changeset.sh docs/marketplace/catalog-api/04-add-container-image-delivery.json
+#   # IMAGE_URI MUST be the same Marketplace-ECR image the Helm option ships
+#   # (one artifact, two delivery options). CI_USAGE_INSTRUCTIONS must document
+#   # durable snapshot storage (EFS on Fargate; the task filesystem is ephemeral).
+#
 # Env: AWS_PROFILE (default elevarq), AWS_REGION (default us-east-1).
 # Requires: aws, jq, envsubst (gettext).
 
@@ -66,6 +76,19 @@ if LC_ALL=C tr -d '\11\12\15\40-\176' < "$rendered" | grep -q .; then
   exit 1
 fi
 jq . "$rendered" >/dev/null || { echo "error: rendered change set is not valid JSON" >&2; exit 1; }
+
+# Fail fast on an unsupported CompatibleServices value. AWS validates this only
+# after submission (a typo like "Fargate" or "GKE" burns a change-set); the valid
+# set is ECS, EKS, ECS-Anywhere, EKS-Anywhere, Bedrock-AgentCore. Fargate is an
+# ECS launch type -> use "ECS". See spec FC-CID-03.
+bad_services="$(jq -r '[.. | objects | .CompatibleServices? // empty] | add // [] | .[]' "$rendered" \
+  | grep -vxE 'ECS|EKS|ECS-Anywhere|EKS-Anywhere|Bedrock-AgentCore' | sort -u || true)"
+if [ -n "$bad_services" ]; then
+  echo "error: unsupported CompatibleServices value(s) in the rendered change set:" >&2
+  echo "$bad_services" | awk '{print "       " $0}' >&2
+  echo "       valid: ECS, EKS, ECS-Anywhere, EKS-Anywhere, Bedrock-AgentCore" >&2
+  exit 1
+fi
 
 echo "==> Submitting change set from $TEMPLATE"
 CHANGE_SET_ID="$(aws marketplace-catalog start-change-set \

--- a/specifications/marketplace-container-image-delivery.acceptance.md
+++ b/specifications/marketplace-container-image-delivery.acceptance.md
@@ -1,0 +1,136 @@
+# Acceptance Tests: Marketplace Container-Image Delivery Option
+
+## Feature
+
+`specifications/marketplace-container-image-delivery.md`
+
+## Test Cases
+
+### TC-CID-01: Rendered change-set adds a valid ECR delivery option (normal)
+
+**Rule:** Normal — happy path (R-CID-01, R-CID-02)
+
+**Scenario:** Release engineer renders the container-image change-set for the
+released version.
+
+**Given:**
+- `04-add-container-image-delivery.json` with `${VERSION}`, `${IMAGE_URI}`,
+  `${USAGE_INSTRUCTIONS}` supplied.
+
+**When:**
+- The template is rendered by `scripts/marketplace-changeset.sh`.
+
+**Then:**
+- The rendered document is valid JSON.
+- It contains exactly one `EcrDeliveryOptionDetails` delivery option.
+- `CompatibleServices` == `["ECS"]`.
+- The change-set does NOT modify or remove the existing Helm delivery option
+  (the template's `ChangeType` is `AddDeliveryOptions`, additive).
+
+---
+
+### TC-CID-02: Container image is identical to the Helm option's image (invariant)
+
+**Rule:** Invariant — INV-CID-01
+
+**Scenario:** Guard against the two delivery options drifting to different
+images.
+
+**Given:**
+- The rendered container-image change-set and the live/rendered Helm delivery
+  change-set for the same `${VERSION}`.
+
+**When:**
+- The `ContainerImages` entry of each is compared.
+
+**Then:**
+- Both reference the same Marketplace-ECR repository and tag.
+- The resolved image digest is identical (one artifact, two delivery options).
+
+---
+
+### TC-CID-03: Usage instructions carry the non-Helm deployment contract (boundary)
+
+**Rule:** Boundary — R-CID-03, 4000-char limit
+
+**Scenario:** A buyer with no Kubernetes reads the usage instructions to deploy
+on ECS/Fargate.
+
+**Given:**
+- The rendered `UsageInstructions` string.
+
+**When:**
+- Its content and length are inspected.
+
+**Then:**
+- Length is > 0 and <= 4000 characters.
+- It contains an ECR login line using `--region us-east-1`.
+- It documents: a writable volume mount for local snapshots, non-root execution,
+  and config-file + secret injection.
+- It warns that durable storage is required for snapshots (Amazon EFS on Fargate,
+  or an EBS / bind volume on EC2-backed ECS), because the Fargate task filesystem
+  is ephemeral.
+- It is ASCII-only.
+
+---
+
+### TC-CID-04: Unsupported CompatibleServices value is rejected before submit (invalid)
+
+**Rule:** Failure condition — FC-CID-03
+
+**Scenario:** A typo puts an unsupported orchestrator in `CompatibleServices`.
+
+**Given:**
+- A rendered change-set whose `CompatibleServices` contains a value outside
+  `{ECS, EKS, ECS-Anywhere, EKS-Anywhere, Bedrock-AgentCore}` (e.g. `GKE`).
+
+**When:**
+- Preflight validation runs before `start-change-set`.
+
+**Then:**
+- Validation fails with a message naming the offending value.
+- `start-change-set` is not called.
+
+---
+
+### TC-CID-05: Standalone container produces the same collector as Helm (failure/live)
+
+**Rule:** Invariant — INV-CID-02, INV-CID-03 (live-artifact smoke)
+
+**Scenario:** The Marketplace-ECR image is run with no Kubernetes/Helm, the way
+an ECS/Fargate buyer would, against a reachable representative RDS target.
+
+**Given:**
+- The Marketplace-ECR image at `${VERSION}` pulled with `--region us-east-1`.
+- A minimal config + secret and a writable snapshot volume, run non-root
+  (`docker run` / ECS task, no K8s).
+
+**When:**
+- The container starts and performs one collection cycle against the target.
+
+**Then:**
+- A read-only diagnostic snapshot is produced, equivalent in shape to the one
+  the Helm-deployed collector produces for the same target.
+- No writes are issued to the target (read-only preserved).
+- The container runs as a non-root user.
+
+---
+
+### TC-CID-06: Unsubstituted placeholder / non-ASCII fails fast (failure)
+
+**Rule:** Failure conditions — FC-CID-01, FC-CID-02
+
+**Scenario:** A release run forgets to export a variable, or pastes smart
+punctuation into `USAGE_INSTRUCTIONS`.
+
+**Given:**
+- The container-image template rendered with a missing `${...}` variable, OR
+  with a non-ASCII character (em-dash, curly quote) in a rendered field.
+
+**When:**
+- `scripts/marketplace-changeset.sh` runs.
+
+**Then:**
+- The script exits non-zero before `start-change-set`.
+- The unsubstituted-`${...}` guard (FC-CID-01) or the non-ASCII guard
+  (FC-CID-02) reports the offending content.

--- a/specifications/marketplace-container-image-delivery.md
+++ b/specifications/marketplace-container-image-delivery.md
@@ -1,0 +1,139 @@
+# Marketplace Container-Image Delivery Option (ECS / Fargate / `docker pull`)
+
+## Status
+
+ACTIVE
+
+## Type
+
+Integration mapping — contract across the boundary between the re-hosted
+Marketplace-ECR image, the AWS Marketplace `ContainerProduct@1.0` listing, and a
+buyer's non-Helm container runtime (Amazon ECS, including Fargate). Tests
+mandatory.
+
+## Purpose
+
+Add a **second delivery option** to the live Elevarq Signals Marketplace listing
+so buyers who do not run Helm/EKS can obtain and run the collector on Amazon ECS
+/ AWS Fargate (or any `docker pull`-based runtime). The listing today ships a
+single `HelmDeliveryOptionDetails` option (Amazon EKS). This slice adds an
+`EcrDeliveryOptionDetails` option that points at the **same** already-re-hosted
+Marketplace-ECR image — no new build, no new artifact, no change to the Helm
+option.
+
+The value is pure reach: the ECS / Fargate / non-Helm buyer segment can adopt
+Signals without a Kubernetes cluster. Part of #233 (reach expansion). Inherits
+the umbrella's cross-cutting decisions (#233) — do not restate them here.
+
+## Scope
+
+One `AddDeliveryOptions` change-set against the existing `ContainerProduct@1.0`,
+adding exactly one `EcrDeliveryOptionDetails` delivery option alongside the
+existing Helm option, plus the buyer-facing usage instructions that reproduce —
+outside of Helm — the deployment contract the chart encodes (writable snapshot
+volume, non-root, config + secret injection, `us-east-1` ECR login).
+
+In scope:
+
+- A committed change-set template `docs/marketplace/catalog-api/04-add-container-image-delivery.json`.
+- Usage instructions for the ECS/Fargate/`docker pull` path.
+- The same preflight guards the Helm change-set already passes (ASCII-only, no
+  unsubstituted `${...}`, valid JSON) via `scripts/marketplace-changeset.sh`.
+
+Out of scope (see "Out of scope").
+
+## Interfaces
+
+### Inputs (change-set, `EcrDeliveryOptionDetails`)
+
+| Field | Type | Constraint |
+|-------|------|------------|
+| `DeliveryOptionTitle` | string | Buyer-facing, e.g. `Container image (Amazon ECS / Fargate)`. ASCII. |
+| `ContainerImages` | array<string> | Exactly the Marketplace-ECR image URI at the released version, e.g. `<mp-ecr>/elevarq/elevarq-signals:<VERSION>`. Same image as the Helm option. |
+| `CompatibleServices` | array<string> | `["ECS"]`. Valid AWS set: `ECS`, `EKS`, `ECS-Anywhere`, `EKS-Anywhere`, `Bedrock-AgentCore`. Fargate is an ECS launch type — covered by `ECS`. |
+| `UsageInstructions` | string | ≤ 4000 chars. ASCII-only. Must document: `docker login`/`pull` with `--region us-east-1`, a writable volume mount for snapshots, non-root execution, and config + secret injection. |
+
+Rendered through the same `${VERSION}` / `${IMAGE_URI}` / `${USAGE_INSTRUCTIONS}`
+substitution mechanism as `02-add-helm-delivery.json`.
+
+### Outputs
+
+- A submitted change-set that, once AWS ingestion + scan pass, makes the listing
+  expose two delivery options (Helm + container image) for the same version.
+- No new listing, no new product, no price change (free product unchanged).
+
+## Rules
+
+- **R-CID-01**: The change is **additive**. It MUST NOT modify, reorder, or
+  remove the existing `HelmDeliveryOptionDetails` option.
+- **R-CID-02**: `CompatibleServices` MUST be `["ECS"]` for this option (EKS is
+  already served by the Helm option; do not duplicate).
+- **R-CID-03**: `UsageInstructions` MUST reproduce, in prose, the deployment
+  guarantees the chart encodes for an operator with no Helm/K8s: (a) writable
+  volume for local snapshots, (b) non-root / least-privilege container, (c)
+  config-file and secret (env / secret-store) injection, (d) `us-east-1` ECR
+  login region. It MUST additionally warn that the collector's local snapshot
+  store needs **durable** storage: on AWS Fargate the task filesystem is
+  ephemeral, so the buyer MUST attach an Amazon EFS volume (Fargate) or an EBS /
+  bind volume (EC2-backed ECS) — without it, snapshots are lost on task restart.
+  This is the one place ECS materially differs from the chart's PersistentVolume,
+  and calling it out is what makes INV-CID-02 honest in practice.
+- **R-CID-04**: Adding this option is its **own AWS review round** (umbrella
+  decision 3) — it MUST NOT be bundled with any other lever (#235, #236) in the
+  same change-set.
+
+## Invariants
+
+- **INV-CID-01** (one image, two options): the image referenced by
+  `EcrDeliveryOptionDetails.ContainerImages` MUST be byte-identical (same
+  Marketplace-ECR repository, tag, and resolved digest) to the image referenced
+  by the live `HelmDeliveryOptionDetails.ContainerImages`. There is exactly one
+  collector artifact; the delivery options differ only in launch method.
+- **INV-CID-02** (behavioral parity): the collector produced by the
+  container-image delivery, run standalone on ECS/Fargate/`docker run`, MUST be
+  the **same running collector** as the Helm delivery — same read-only
+  enforcement, same passwordless onboarding, same snapshot output — given an
+  equivalent configuration. Deployment mechanics differ; collector behavior does
+  not.
+- **INV-CID-03** (read-only preserved): nothing in the ECS/Fargate path relaxes
+  the collector's read-only guarantees or unsafe-role blocking; those live in the
+  image, not the chart.
+
+## Failure Conditions
+
+- **FC-CID-01**: Rendered change-set contains an unsubstituted `${...}` →
+  `scripts/marketplace-changeset.sh` exits non-zero before `start-change-set`
+  (reuses the existing placeholder guard).
+- **FC-CID-02**: Rendered change-set contains non-ASCII/control bytes →
+  the script's non-ASCII guard exits non-zero before submit.
+- **FC-CID-03**: `CompatibleServices` contains a value outside the AWS-valid set
+  → AWS rejects the change-set; preflight SHOULD catch it locally first.
+- **FC-CID-04**: `ContainerImages` points at a non-Marketplace-ECR (e.g.
+  `ghcr.io`) image → AWS rejects on ingestion; preflight MUST assert the URI is
+  the Marketplace-ECR image.
+
+## Constraints
+
+- `UsageInstructions` ≤ 4000 characters (AWS limit).
+- Image must already be re-hosted to the Marketplace ECR at the released version
+  (it is — the Helm delivery uses it). No rebuild in this slice.
+- No `latest` tag (`INVALID_CONTAINER_IMAGE_TAG`); the tag is the released
+  SemVer.
+
+## Out of scope
+
+- **EKS add-on delivery** (`EksAddOnDeliveryOptionDetails`) — that is #236.
+- **AMI product** — that is #235 (separate `AmiProduct@1.0`).
+- **A new product version / new image build.** This slice adds a delivery option
+  to the existing version.
+- **Automated live ECS smoke in CI.** The live-artifact smoke (TC-CID-05) is a
+  gated manual/representative-environment run for this slice; wiring it into CI is
+  tracked by #212.
+- **Paid pricing / dimensions.** The product stays free.
+
+## Traceability
+
+specification (this file) -> acceptance cases
+(`marketplace-container-image-delivery.acceptance.md`) -> change-set template
+`docs/marketplace/catalog-api/04-add-container-image-delivery.json` +
+`scripts/marketplace-changeset.sh` guards.


### PR DESCRIPTION
Part of #233 (Marketplace reach expansion). Adds the second delivery option to the live Elevarq Signals listing: an `EcrDeliveryOptionDetails` option for Amazon ECS / AWS Fargate / `docker pull`, alongside the existing Helm/EKS option. It reuses the **same** already-re-hosted Marketplace-ECR image — no new build, no new artifact, Helm option untouched.

## What's here (in-repo artifacts)

- **`specifications/marketplace-container-image-delivery.md`** (ACTIVE) + **`.acceptance.md`** — integration-mapping spec. Load-bearing decisions:
  - **INV-CID-01** one image, two options: the ECR option's image must be the same digest as the Helm option's.
  - **INV-CID-02/03** behavioral parity: read-only enforcement + passwordless onboarding live in the image, not the chart.
  - **R-CID-03** the UsageInstructions contract reproduces, for a buyer with no K8s, what the chart encodes — including the one real ECS difference: **Fargate's task filesystem is ephemeral**, so snapshots need durable storage (EFS on Fargate; EBS/bind on EC2-backed ECS).
- **`docs/marketplace/catalog-api/04-add-container-image-delivery.json`** — additive `AddDeliveryOptions` change-set template, `CompatibleServices: ["ECS"]` (Fargate is an ECS launch type).
- **`scripts/marketplace-changeset.sh`** — new preflight guard rejecting unsupported `CompatibleServices` values before `start-change-set` (AWS only validates this after submit, burning a change-set); usage header for step 04.
- **`docs/marketplace/catalog-api/README.md`** — reach-expansion delivery-option table.

## Decisions (confirmed)

- `CompatibleServices: ["ECS"]` only — not `ECS-Anywhere` (unvalidated for the RDS/Aurora IAM path; claim only what we've verified).
- Live smoke (TC-CID-05) is a **manual** representative-environment run gating submit; CI automation stays with #212.

## Validation

- `shellcheck scripts/marketplace-changeset.sh` — clean (default severity).
- Template renders to valid JSON, 0 leftover `${...}`, 0 non-ASCII; CompatibleServices guard passes valid input and catches an injected bad value.
- `trivy fs --scanners secret .` — clean.

## Not done by merging this

The actual AWS `AddDeliveryOptions` submission + the live ECS/Fargate smoke are a gated operator step (needs the product Limited/Public, triggers the ~40-min ingestion scan, one review round). So this uses `Refs #234` and does not auto-close it.

Refs #234, #233