### PR TITLE
marketplace: EKS add-on delivery option template

### DIFF
--- a/docs/marketplace/catalog-api/05-add-eks-addon-delivery.json
+++ b/docs/marketplace/catalog-api/05-add-eks-addon-delivery.json
@@ -1,0 +1,38 @@
+{
+  "Catalog": "AWSMarketplace",
+  "ChangeSet": [
+    {
+      "ChangeType": "AddDeliveryOptions",
+      "Entity": {
+        "Type": "ContainerProduct@1.0",
+        "Identifier": "${PRODUCT_ID}"
+      },
+      "DetailsDocument": {
+        "Version": {
+          "VersionTitle": "${VERSION}",
+          "ReleaseNotes": "${RELEASE_NOTES}"
+        },
+        "DeliveryOptions": [
+          {
+            "DeliveryOptionTitle": "Amazon EKS add-on",
+            "Visibility": "Limited",
+            "Details": {
+              "EksAddOnDeliveryOptionDetails": {
+                "AddOnName": "signals",
+                "AddOnType": "observability",
+                "AddOnVersion": "${VERSION}",
+                "Namespace": "signals",
+                "ContainerImages": ["${IMAGE_URI}"],
+                "HelmChartUri": "${CHART_URI}",
+                "CompatibleKubernetesVersions": ${K8S_VERSIONS},
+                "SupportedArchitectures": ["amd64", "arm64"],
+                "Description": "${ADDON_DELIVERY_DESCRIPTION}",
+                "UsageInstructions": "${ADDON_USAGE_INSTRUCTIONS}"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/marketplace/catalog-api/README.md
+++ b/docs/marketplace/catalog-api/README.md
@@ -42,6 +42,7 @@ Once the listing is live, extra delivery options can be added — each reuses th
 | Lever | Change type | Details type | Notes |
 |-------|-------------|--------------|-------|
 | Container image (ECS / Fargate / `docker pull`), #234 | `AddDeliveryOptions` (`04-add-container-image-delivery.json`) | `EcrDeliveryOptionDetails`, `CompatibleServices: ["ECS"]` | Additive; does not touch the Helm option. `ContainerImages` MUST equal the Helm option's image (one artifact, two options). Buyer runs it with no Helm/K8s, so `CI_USAGE_INSTRUCTIONS` must document durable snapshot storage — the Fargate task filesystem is ephemeral, attach EFS (or an EBS/bind volume on EC2-backed ECS). |
+| EKS add-on, #236 | `AddDeliveryOptions` (`05-add-eks-addon-delivery.json`) | `EksAddOnDeliveryOptionDetails` | Additive; reuses the same image **and** chart as the Helm option. `AddOnName: signals`, `AddOnType: observability`, `Namespace: signals` are **immutable across all future versions** — do not change once published (`INCOMPATIBLE_ADDON_*`). Only **one** add-on option per version. `K8S_VERSIONS` must list only tested EKS versions. Unlike Helm/container options, the add-on option is **not** auto-Public — publishing it is a separate visibility step. See `specifications/marketplace-eks-addon-delivery.md`. |
 
 Notes on the ordering, all verified on the pgAgroal launch:
 

--- a/scripts/marketplace-changeset.sh
+++ b/scripts/marketplace-changeset.sh
@@ -32,6 +32,19 @@
 #   # (one artifact, two delivery options). CI_USAGE_INSTRUCTIONS must document
 #   # durable snapshot storage (EFS on Fargate; the task filesystem is ephemeral).
 #
+#   # For 05-add-eks-addon-delivery.json (adds the EKS add-on delivery option —
+#   # same re-hosted image AND chart), export. K8S_VERSIONS is a JSON array of
+#   # the EKS Kubernetes versions ACTUALLY validated for this release (declare
+#   # only tested versions):
+#   PRODUCT_ID=prod-xxxx VERSION=1.0.0 \
+#   IMAGE_URI=<acct>.dkr.ecr.us-east-1.amazonaws.com/elevarq/elevarq-signals:1.0.0 \
+#   CHART_URI=<acct>.dkr.ecr.us-east-1.amazonaws.com/elevarq/elevarq-signals-chart:1.0.0 \
+#   K8S_VERSIONS='["1.30","1.31","1.32"]' \
+#   RELEASE_NOTES="..." ADDON_DELIVERY_DESCRIPTION="..." ADDON_USAGE_INSTRUCTIONS="..." \
+#     scripts/marketplace-changeset.sh docs/marketplace/catalog-api/05-add-eks-addon-delivery.json
+#   # AddOnName/AddOnType/Namespace in the template are IMMUTABLE across versions
+#   # (signals / observability / signals) — do not change once published.
+#
 # Env: AWS_PROFILE (default elevarq), AWS_REGION (default us-east-1).
 # Requires: aws, jq, envsubst (gettext).
 
@@ -87,6 +100,19 @@ if [ -n "$bad_services" ]; then
   echo "error: unsupported CompatibleServices value(s) in the rendered change set:" >&2
   echo "$bad_services" | awk '{print "       " $0}' >&2
   echo "       valid: ECS, EKS, ECS-Anywhere, EKS-Anywhere, Bedrock-AgentCore" >&2
+  exit 1
+fi
+
+# Fail fast on an unsupported EKS add-on AddOnType. AWS validates this only after
+# submission (INVALID_ADDON_TYPE), and AddOnType is immutable across versions
+# once published, so a typo is costly. See spec FC-EAO-03.
+addon_valid='Gitops|monitoring|logging|cert-management|policy-management|cost-management|autoscaling|storage|kubernetes-management|service-mesh|etcd-backup|ingress-service-type|load-balancer|local-registry|networking|Security|backup|ingress-controller|observability'
+bad_addon_type="$(jq -r '[.. | objects | .AddOnType? // empty] | .[]' "$rendered" \
+  | grep -vxE "$addon_valid" | sort -u || true)"
+if [ -n "$bad_addon_type" ]; then
+  echo "error: unsupported EKS AddOnType value(s) in the rendered change set:" >&2
+  echo "$bad_addon_type" | awk '{print "       " $0}' >&2
+  echo "       valid: $(echo "$addon_valid" | tr '|' ' ')" >&2
   exit 1
 fi
 

--- a/specifications/marketplace-eks-addon-delivery.acceptance.md
+++ b/specifications/marketplace-eks-addon-delivery.acceptance.md
@@ -1,0 +1,135 @@
+# Acceptance Tests: Marketplace EKS Add-On Delivery Option
+
+## Feature
+
+`specifications/marketplace-eks-addon-delivery.md`
+
+## Test Cases
+
+### TC-EAO-01: Rendered change-set adds a valid EKS add-on option (normal)
+
+**Rule:** Normal — happy path (R-EAO-01, R-EAO-02, R-EAO-03)
+
+**Scenario:** Release engineer renders the EKS add-on change-set for the released
+version.
+
+**Given:**
+- `05-add-eks-addon-delivery.json` with `${VERSION}`, `${IMAGE_URI}`,
+  `${CHART_URI}`, `${K8S_VERSIONS}`, and the description/usage vars supplied.
+
+**When:**
+- The template is rendered by `scripts/marketplace-changeset.sh`.
+
+**Then:**
+- The rendered document is valid JSON.
+- It contains exactly one `EksAddOnDeliveryOptionDetails` delivery option.
+- `AddOnName` == `signals`, `AddOnType` == `observability`, `Namespace` ==
+  `signals`.
+- `SupportedArchitectures` == `["amd64", "arm64"]`.
+- `ChangeType` is `AddDeliveryOptions` (additive; Helm + container options
+  untouched).
+
+---
+
+### TC-EAO-02: Add-on image and chart match the Helm option (invariant)
+
+**Rule:** Invariant — INV-EAO-01
+
+**Scenario:** Guard against the add-on referencing a different image/chart than
+the live Helm delivery.
+
+**Given:**
+- The rendered add-on change-set and the Helm delivery change-set for the same
+  `${VERSION}`.
+
+**When:**
+- `ContainerImages` and `HelmChartUri` of each are compared.
+
+**Then:**
+- The add-on's `ContainerImages` equals the Helm option's `ContainerImages`
+  (same MP-ECR repo, tag, resolved digest).
+- The add-on's `HelmChartUri` equals the Helm option's `HelmChartUri`.
+
+---
+
+### TC-EAO-03: Usage instructions carry the add-on install path + durability note (boundary)
+
+**Rule:** Boundary — 4000-char limit, durable-storage note
+
+**Scenario:** A buyer installs Signals from the EKS add-on catalog.
+
+**Given:**
+- The rendered `UsageInstructions` string.
+
+**When:**
+- Its content and length are inspected.
+
+**Then:**
+- Length is > 0 and <= 4000 characters.
+- It documents the EKS add-on install path (console or `aws eks create-addon` /
+  `eksctl`).
+- It states that the collector's local snapshot store needs a PersistentVolume.
+- It is ASCII-only.
+
+---
+
+### TC-EAO-04: Unsupported AddOnType is rejected before submit (invalid)
+
+**Rule:** Failure condition — FC-EAO-03
+
+**Scenario:** A typo puts an unsupported add-on type in the template.
+
+**Given:**
+- A rendered change-set whose `AddOnType` is outside the AWS-valid set (e.g.
+  `diagnostics`).
+
+**When:**
+- Preflight validation runs before `start-change-set`.
+
+**Then:**
+- Validation fails with a message naming the offending value.
+- `start-change-set` is not called.
+
+---
+
+### TC-EAO-05: Add-on install produces the same collector as Helm (failure/live)
+
+**Rule:** Invariant — INV-EAO-02 (live-artifact smoke)
+
+**Scenario:** The add-on is installed on a representative EKS cluster via the
+add-on flow, against a reachable RDS target.
+
+**Given:**
+- An EKS cluster on a `CompatibleKubernetesVersions` version.
+- The Signals add-on installed via `aws eks create-addon` (not `helm install`)
+  with a durable volume and a reachable target.
+
+**When:**
+- The add-on deploys and performs one collection cycle.
+
+**Then:**
+- A read-only diagnostic snapshot is produced, equivalent to the one the
+  Helm-installed collector produces for the same target.
+- No writes are issued to the target (read-only preserved).
+- The collector runs in the `signals` namespace, non-root.
+
+---
+
+### TC-EAO-06: Unsubstituted placeholder / non-ASCII fails fast (failure)
+
+**Rule:** Failure conditions — FC-EAO-01, FC-EAO-02
+
+**Scenario:** A release run forgets a variable, or pastes smart punctuation into
+`ADDON_USAGE_INSTRUCTIONS`.
+
+**Given:**
+- The add-on template rendered with a missing `${...}` variable, OR with a
+  non-ASCII character in a rendered field.
+
+**When:**
+- `scripts/marketplace-changeset.sh` runs.
+
+**Then:**
+- The script exits non-zero before `start-change-set`.
+- The unsubstituted-`${...}` guard (FC-EAO-01) or the non-ASCII guard
+  (FC-EAO-02) reports the offending content.

--- a/specifications/marketplace-eks-addon-delivery.md
+++ b/specifications/marketplace-eks-addon-delivery.md
@@ -1,0 +1,136 @@
+# Marketplace EKS Add-On Delivery Option
+
+## Status
+
+ACTIVE
+
+## Type
+
+Integration mapping — contract across the boundary between the re-hosted
+Marketplace-ECR image + Helm chart, the AWS Marketplace `ContainerProduct@1.0`
+listing, and the Amazon EKS add-on catalog (console / `eksctl` add-on flow).
+Tests mandatory.
+
+## Purpose
+
+Add an **Amazon EKS add-on** delivery option to the live Elevarq Signals
+listing, so the collector is discoverable and installable directly from the EKS
+console and the `eksctl`/`aws eks create-addon` flow — native EKS-console reach.
+It reuses the **same** re-hosted Marketplace-ECR image **and** Helm chart the
+existing Helm/EKS delivery option ships (`EksAddOnDeliveryOptionDetails` wraps
+both `ContainerImages` and `HelmChartUri`). No new build, no new chart, and the
+existing Helm and container-image options are untouched.
+
+The value is reach within the EKS audience: buyers who discover software through
+the EKS add-on catalog rather than `helm install`. Part of #233 (reach
+expansion). Inherits the umbrella's cross-cutting decisions (#233) — do not
+restate them here.
+
+## Scope
+
+One `AddDeliveryOptions` change-set against the existing `ContainerProduct@1.0`,
+adding exactly one `EksAddOnDeliveryOptionDetails` delivery option (AWS allows
+only one add-on option per version), plus the buyer-facing usage instructions
+for the add-on install path.
+
+In scope:
+
+- A committed change-set template
+  `docs/marketplace/catalog-api/05-add-eks-addon-delivery.json`.
+- A preflight guard on the immutable `AddOnType` (valid-set check).
+- README documentation of the add-on step, its immutability constraints, and the
+  separate add-on visibility step.
+
+## Interfaces
+
+### Inputs (`EksAddOnDeliveryOptionDetails`)
+
+| Field | Type | Constraint / value |
+|-------|------|--------------------|
+| `AddOnName` | string | **`signals`** (immutable). Buyer sees `<SellerAlias>_signals` in the EKS catalog. Changing it later fails `INCOMPATIBLE_ADDON_NAME`. |
+| `AddOnType` | string | **`observability`** (immutable — decided in #236, confirmed with product owner). Changing it later fails `INCOMPATIBLE_ADDON_TYPE`. Valid AWS set: Gitops, monitoring, logging, cert-management, policy-management, cost-management, autoscaling, storage, kubernetes-management, service-mesh, etcd-backup, ingress-service-type, load-balancer, local-registry, networking, Security, backup, ingress-controller, observability. |
+| `AddOnVersion` | string | `${VERSION}` — semantic `major.minor.patch` (AWS pattern; the released SemVer satisfies it). |
+| `Namespace` | string | **`signals`** (immutable; matches the chart's release namespace). Changing it later fails `INCOMPATIBLE_ADDON_NAMESPACE`. |
+| `ContainerImages` | array<string> | The Marketplace-ECR image at `${VERSION}` — the same image the Helm option ships. |
+| `HelmChartUri` | string | The Marketplace-ECR chart at `${VERSION}` — the same chart the Helm option ships. |
+| `CompatibleKubernetesVersions` | array<string> | `${K8S_VERSIONS}` — the EKS Kubernetes versions actually validated for this release, set at submit time (honest-claim: declare only tested versions). |
+| `SupportedArchitectures` | array<string> | `["amd64", "arm64"]` — the image is genuinely multi-arch. |
+| `Description` | string | `${ADDON_DELIVERY_DESCRIPTION}`. |
+| `UsageInstructions` | string | `${ADDON_USAGE_INSTRUCTIONS}`, ≤ 4000 chars, ASCII. The EKS add-on install path (console / `aws eks create-addon`), plus the same durable-storage note as the chart (the collector's local snapshot store needs a PersistentVolume). |
+
+### Outputs
+
+- A submitted change-set that makes the listing expose the EKS add-on option
+  (in addition to Helm and container-image), all for the same version.
+- No new listing, no new product, no price change (free product unchanged).
+
+## Rules
+
+- **R-EAO-01**: Additive. MUST NOT modify, reorder, or remove the existing Helm
+  or container-image delivery options.
+- **R-EAO-02**: Exactly **one** `EksAddOnDeliveryOptionDetails` per version
+  (AWS: `TOO_MANY_EKS_ADDON_DELIVERY_OPTIONS` otherwise).
+- **R-EAO-03**: `AddOnName`, `AddOnType`, and `Namespace` are **immutable across
+  all future versions**. They are pinned in the committed template and MUST NOT
+  be changed once the first add-on version is published.
+- **R-EAO-04**: `CompatibleKubernetesVersions` MUST list only EKS Kubernetes
+  versions validated for the release (honest-claim; do not declare untested
+  versions).
+- **R-EAO-05**: Its own AWS review round (umbrella decision 3) — not bundled with
+  #234 or #235.
+- **R-EAO-06**: EKS add-on delivery-option visibility is **not** auto-Public
+  (unlike Helm/container options). Making the add-on public is a separate
+  `UpdateDeliveryOptions`/visibility step, gated on an explicit go.
+
+## Invariants
+
+- **INV-EAO-01** (one artifact set): the `ContainerImages` and `HelmChartUri` the
+  add-on references MUST be byte-identical (same MP-ECR repo, tag, resolved
+  digest) to those the live Helm delivery option ships. One image + one chart,
+  installed three ways.
+- **INV-EAO-02** (behavioral parity): the collector installed via the EKS add-on
+  MUST be the **same running collector** as the Helm delivery — same read-only
+  enforcement, passwordless onboarding, snapshot output. The add-on is a
+  console-native installer of the same chart; behavior is unchanged.
+- **INV-EAO-03** (immutable identity stable): across versions, `AddOnName`,
+  `AddOnType`, `Namespace` never change.
+
+## Failure Conditions
+
+- **FC-EAO-01**: Unsubstituted `${...}` in the rendered change-set → script exits
+  non-zero before `start-change-set` (existing guard).
+- **FC-EAO-02**: Non-ASCII/control bytes in the rendered change-set → script's
+  non-ASCII guard exits non-zero (existing guard).
+- **FC-EAO-03**: `AddOnType` outside the AWS-valid set → preflight guard rejects
+  before submit (new guard); AWS would otherwise fail `INVALID_ADDON_TYPE`.
+- **FC-EAO-04**: `ContainerImages`/`HelmChartUri` pointing at a
+  non-Marketplace-ECR (e.g. `ghcr.io`) artifact → AWS rejects on ingestion;
+  preflight asserts MP-ECR.
+
+## Constraints
+
+- `UsageInstructions` ≤ 4000 characters.
+- Image + chart already re-hosted to the Marketplace ECR at the released version
+  (they are — the Helm option uses them). No rebuild.
+- The Helm chart must satisfy EKS add-on packaging requirements
+  (namespace-scoped install, no unmet cluster-admin assumptions). Validated as
+  part of the live add-on smoke.
+
+## Out of scope
+
+- **Container-image delivery** (`EcrDeliveryOptionDetails`) — that is #234
+  (shipped).
+- **AMI product** — that is #235 (separate `AmiProduct@1.0`).
+- **A new product version / new image or chart build.**
+- **Automated live add-on smoke in CI** — the live install smoke is a gated
+  manual/representative-environment run for this slice; CI wiring is #212.
+- **`EnvironmentOverrideParameters`.** Signals does not require EKS system
+  parameters (cluster name/region) injected at launch; omitted unless a future
+  need appears.
+
+## Traceability
+
+specification (this file) -> acceptance cases
+(`marketplace-eks-addon-delivery.acceptance.md`) -> change-set template
+`docs/marketplace/catalog-api/05-add-eks-addon-delivery.json` +
+`scripts/marketplace-changeset.sh` guards.


### PR DESCRIPTION
Part of #233 (Marketplace reach expansion). Adds an `EksAddOnDeliveryOptionDetails` delivery option so Signals is discoverable and installable from the **Amazon EKS add-on catalog** (console / `aws eks create-addon` / `eksctl`), alongside the live Helm/EKS and container-image (#234) options. Reuses the **same** re-hosted Marketplace-ECR image *and* chart — one artifact set, installed three ways. Additive; existing options untouched.

## What's here (in-repo artifacts)

- **`specifications/marketplace-eks-addon-delivery.md`** (ACTIVE) + **`.acceptance.md`** — integration-mapping spec. Load-bearing points:
  - **INV-EAO-01** one artifact set: the add-on's `ContainerImages`/`HelmChartUri` must be the same digest as the Helm option's.
  - **INV-EAO-02** behavioral parity: it's the same chart, console-installed — same read-only collector.
  - **R-EAO-03 / INV-EAO-03** immutable identity: `AddOnName`/`AddOnType`/`Namespace` are fixed across all future versions (`INCOMPATIBLE_ADDON_*` if changed).
  - **R-EAO-06** the add-on option is **not** auto-Public (unlike Helm/container) — publishing it is a separate visibility step.
- **`docs/marketplace/catalog-api/05-add-eks-addon-delivery.json`** — additive template. `AddOnName: signals`, `AddOnType: observability`, `Namespace: signals`, `SupportedArchitectures: [amd64, arm64]`, `CompatibleKubernetesVersions` parameterized via `K8S_VERSIONS`.
- **`scripts/marketplace-changeset.sh`** — new `AddOnType` preflight guard (AWS only validates post-submit, and it's immutable — costly to typo); step-05 usage header.
- **`docs/marketplace/catalog-api/README.md`** — EKS add-on row with the immutability + visibility notes.

## Decisions (confirmed)

- **`AddOnType: observability`** — confirmed with product owner. Immutable, so locked deliberately; Signals is diagnostic collection, which is the modern EKS observability framing.
- `AddOnName`/`Namespace` = `signals` (matches the chart's release namespace).
- `CompatibleKubernetesVersions` is operator-supplied at submit (`K8S_VERSIONS`) so we declare only *tested* EKS versions — a stale hardcoded default would silently over-claim.

## Validation

- `shellcheck` clean; template renders to valid JSON, 0 leftover `${}`, 0 non-ASCII; `AddOnType` guard passes valid and catches an injected bad value; `trivy fs --scanners secret .` clean.

## Not done by merging this

The AWS `AddDeliveryOptions` submission + the live EKS add-on install smoke (TC-EAO-05) are a gated operator step (one review round; add-on visibility is a separate publish). So this is `Refs #236`, not `closes`.

Refs #236, #233