### PR TITLE
fix(imagebuilder): correct SignalsImage default to the ghcr slug

### DIFF
--- a/deploy/aws/imagebuilder/README.md
+++ b/deploy/aws/imagebuilder/README.md
@@ -34,7 +34,7 @@ same posture as the container and Helm deliveries.
 
 | Parameter | Default | Notes |
 |-----------|---------|-------|
-| `SignalsImage` | `ghcr.io/elevarq/elevarq-signals:1.0.0` | Pinned version (no `latest`). Bump per release. |
+| `SignalsImage` | `ghcr.io/elevarq/signals:1.0.0` | Pinned version (no `latest`). Bump per release. |
 
 ### Baking locally / in a pipeline
 

--- a/deploy/aws/imagebuilder/signals-collector-component.yaml
+++ b/deploy/aws/imagebuilder/signals-collector-component.yaml
@@ -18,7 +18,7 @@ schemaVersion: 1.0
 parameters:
   - SignalsImage:
       type: string
-      default: "ghcr.io/elevarq/elevarq-signals:1.0.0"
+      default: "ghcr.io/elevarq/signals:1.0.0"
       description: >-
         Pinned Signals image reference to pre-pull into the AMI. MUST be a
         specific version tag (no 'latest') so the AMI is reproducible (R-AMI-02).


### PR DESCRIPTION
The AMI Image Builder component (shipped in the #235 groundwork) defaulted `SignalsImage` to `ghcr.io/elevarq/elevarq-signals:1.0.0`, but the published ghcr image is `ghcr.io/elevarq/signals:1.0.0` — `elevarq-signals` is the **Marketplace-ECR** repo name, not the ghcr slug. As shipped, the default pointed at a non-existent repository, so a bake using defaults would fail to pull the image.

Surfaced while running the #234/#236 pre-submit smokes (the real image `ghcr.io/elevarq/signals:1.0.0` was confirmed by `docker pull` + the chart's `image.repository`).

## Change
- `deploy/aws/imagebuilder/signals-collector-component.yaml` — `SignalsImage` default -> `ghcr.io/elevarq/signals:1.0.0`.
- `deploy/aws/imagebuilder/README.md` — parameter table row -> same.

The MP-ECR `elevarq/elevarq-signals` name in the catalog-api templates is correct and unchanged.

## Validation
- No remaining `ghcr.io/elevarq/elevarq-signals` reference; `yamllint` clean; the new default is the image the #234 smoke pulled and ran.

Closes #240