### PR TITLE
deploy/aws: enable SSM Session Manager access on the collector instance

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -17,6 +17,11 @@ pre-wired for `aws_rds_iam`. See
 [`docs/database-connections.md`](../../docs/database-connections.md) for the
 full `auth_method` reference.
 
+The collector role also carries the AWS-managed
+`AmazonSSMManagedInstanceCore` policy, so the verify steps below run over
+Systems Manager Session Manager / Run Command — no SSH key pair is
+provisioned.
+
 ## Prerequisites
 
 - An RDS / Aurora PostgreSQL instance with **IAM database authentication
@@ -76,7 +81,8 @@ aws cloudformation deploy \
 
 Live verification provisions real infrastructure and is operator-gated —
 it is not part of default CI (mirrors the provider live smokes, #94). After
-apply/deploy, on the collector instance:
+apply/deploy, open a shell on the collector instance via SSM Session Manager
+(`aws ssm start-session --target <instance-id>`) or SSM Run Command, then:
 
 ```bash
 # the collector container should be running and collecting
@@ -106,6 +112,9 @@ rejected for `rds_iam`, re-check Step 1 and that the EC2 role's
   `/etc/signals/rds-ca.pem`).
 - IMDSv2 is enforced (`http_tokens = required`); the root volume is encrypted;
   the API listener binds to `127.0.0.1` only.
+- **No SSH.** Shell access for the verify steps goes through SSM Session
+  Manager (`AmazonSSMManagedInstanceCore` on the collector role); no key pair
+  exists and no inbound port is open.
 - The loopback **control-plane API token** is a separate credential class from
   the (non-existent) DB password: user-data mints a random 32-byte token, passes
   it to the container via the environment (`SIGNALS_API_TOKEN`, the same path the

--- a/deploy/aws/cloudformation/signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/signals-rds-iam.yaml
@@ -62,6 +62,10 @@ Resources:
             Principal:
               Service: ec2.amazonaws.com
             Action: sts:AssumeRole
+      # Session Manager / Run Command access for the operator-gated verify
+      # steps — the template provisions no SSH key pair.
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
         - PolicyName: rds-iam-connect
           PolicyDocument:
@@ -110,6 +114,10 @@ Resources:
           set -euo pipefail
           dnf install -y docker
           systemctl enable --now docker
+          # AL2023 ships the SSM agent; ensure it is running so the operator
+          # can reach the instance via Session Manager / Run Command (no SSH
+          # key pair).
+          systemctl enable --now amazon-ssm-agent || true
           mkdir -p /etc/signals
           curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
             -o /etc/signals/rds-ca.pem

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -27,6 +27,9 @@ locals {
     set -euo pipefail
     dnf install -y docker
     systemctl enable --now docker
+    # AL2023 ships the SSM agent; ensure it is running so the operator can
+    # reach the instance via Session Manager / Run Command (no SSH key pair).
+    systemctl enable --now amazon-ssm-agent || true
     mkdir -p /etc/signals
     # RDS server CA bundle for sslmode=verify-full.
     curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
@@ -101,6 +104,13 @@ resource "aws_iam_role_policy" "rds_connect" {
   name   = "${var.name_prefix}-rds-connect"
   role   = aws_iam_role.collector.id
   policy = data.aws_iam_policy_document.rds_connect.json
+}
+
+# Session Manager / Run Command access for the operator-gated verify steps —
+# the templates provision no SSH key pair.
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.collector.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_instance_profile" "collector" {


### PR DESCRIPTION
## Summary

The deploy/aws README's "Verify (live)" steps say to run commands on the collector instance, but the templates provision no SSH key pair and no SSM permissions — there was no supported way onto the box. This adds the standard SSM path:

- **Terraform**: `aws_iam_role_policy_attachment` of the AWS-managed `AmazonSSMManagedInstanceCore` policy on the collector role; `amazon-ssm-agent` enabled in user-data.
- **CloudFormation**: same managed policy via `ManagedPolicyArns`; same user-data change.
- **README**: Verify (live) now names Session Manager / Run Command as the access path; security notes record the no-SSH posture (no key pair, no inbound port).

No change to the scoped `rds-db:connect` policy, the token flow, or any image default.

## Preflight

- `terraform validate` + `terraform fmt -check`: pass
- `trivy config deploy/aws` (HIGH/CRITICAL): 0 misconfigurations
- yamllint findings on the CFN template are identical to main (pre-existing default-config nits; not a CI gate)

Closes #246