### PR TITLE
deploy/aws README: document secret-store credential options + collect-now verify step

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -86,8 +86,11 @@ docker logs signals 2>&1 | grep -iE "collector|snapshot|connected"
 # stored it root-only on the instance, outside the bind-mounted config.
 TOKEN="$(sudo cat /root/signals-api-token)"
 
-# confirm collector status and trigger an export over the loopback API
+# confirm collector status over the loopback API
 docker exec -e SIGNALS_API_TOKEN="$TOKEN" signals signalsctl status
+
+# force an immediate collection (bypasses min_snapshot_interval), then export
+docker exec -e SIGNALS_API_TOKEN="$TOKEN" signals signalsctl collect now --force
 docker exec -e SIGNALS_API_TOKEN="$TOKEN" signals signalsctl export --output /data/snapshot.zip
 ```
 
@@ -95,6 +98,28 @@ A healthy run connects with **no password in config**, mints a token from the
 instance role, and collects at least one snapshot. If the connection is
 rejected for `rds_iam`, re-check Step 1 and that the EC2 role's
 `rds-db:connect` resource ARN matches the instance `DbiResourceId` + DB user.
+
+## Other AWS credential options
+
+These templates are intentionally focused on the passwordless `aws_rds_iam`
+path. If IAM database authentication is not enabled on your instance, Signals
+also supports secret-store backed password auth (`auth_method: secret_store`);
+the backend is selected by the shape of `secret_ref`:
+
+- **AWS Secrets Manager** — `secret_ref:
+  arn:aws:secretsmanager:<region>:<account>:secret:<name>`. Grant the
+  collector role `secretsmanager:GetSecretValue` on that one secret.
+- **AWS Systems Manager Parameter Store** — `secret_ref:
+  arn:aws:ssm:<region>:<account>:parameter/<name>`. Grant `ssm:GetParameter`
+  (+ `kms:Decrypt` for a `SecureString`).
+- If the secret value is a JSON document (e.g. an RDS-managed secret), set
+  `secret_json_key: password` to extract the password field; omit it when the
+  secret value is the bare password.
+
+Secret-store targets require `sslmode: verify-full` in every environment —
+same as the token methods. See
+[`docs/database-connections.md`](../../docs/database-connections.md) for the
+full configuration examples.
 
 ## Security notes
 


### PR DESCRIPTION
## Summary

Docs-only change to `deploy/aws/README.md`:

1. New **"Other AWS credential options"** section: the templates stay focused on the passwordless `aws_rds_iam` path, but buyers without IAM DB auth enabled now get a pointer to `auth_method: secret_store` — Secrets Manager and SSM Parameter Store `secret_ref` shapes, the exact least-privilege IAM grants (`secretsmanager:GetSecretValue` / `ssm:GetParameter` + `kms:Decrypt` for SecureString), `secret_json_key` for RDS-style JSON secrets, and the `verify-full` requirement. All claims cross-checked against `docs/database-connections.md` (no drift).
2. **Verify (live)** gains a `signalsctl collect now --force` step so a fresh deployment can be exercised immediately instead of waiting out `min_snapshot_interval`.

No template or default changes.

Note: #248 also touches this README (different sections); whichever lands second may need a trivial rebase.

Closes #247