### PR TITLE
build: bump Go toolchain to 1.26.5 (govulncheck GO-2026-5856)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Download modules
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache-dependency-path: go.sum
 
       - name: Trivy filesystem scan (vuln + secret)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Download modules
@@ -444,7 +444,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Build binaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- Go toolchain bumped 1.26.4 -> 1.26.5 (#253): remediates GO-2026-5856
+  (Encrypted Client Hello privacy leak in `crypto/tls`, reachable via the
+  connection pool, HTTP server, and cloud credential fetchers). No code
+  changes.
+
 ### Fixed
 
 - Snapshot export: `query_runs.ndjson` rows now carry the persisted

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elevarq/signals
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/secretmanager v1.20.0


### PR DESCRIPTION
## What

Bumps the Go toolchain 1.26.4 -> 1.26.5: `go.mod` plus the `go-version` pins in `ci.yml` (x2) and `release.yml` (x2). No code changes.

## Why

The preflight/CI vulnerability gate fails on 1.26.4: **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls`, fixed in `crypto/tls@go1.26.5`) is reachable via pgxpool, the API server, and the cloud credential fetchers. This blocks the `vuln` gate for every open PR, including #252.

## Verification

Full local preflight on 1.26.5: gofmt, vet, build, test, secrets, **vuln**, semgrep, osv, kube-lint, lint all pass.

Fixes #253