### PR TITLE
fix(ci): harden nightly grype SARIF upload; accept GO-2026-5932 with rationale (#256)

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -167,6 +167,29 @@ jobs:
           severity-cutoff: high
           output-format: sarif
 
+      - name: Normalise SARIF artifact locations
+        if: always()
+        # SBOM-sourced grype results carry an empty (or missing)
+        # physicalLocation.artifactLocation.uri — there is no file
+        # path inside an SBOM. The code-scanning upload rejects such
+        # results ("locationFromSarifResult: expected artifact
+        # location", #256), which only surfaces on the FIRST real
+        # finding: empty result sets upload fine. Point empty
+        # locations at go.mod, the manifest that pulls the flagged
+        # module.
+        run: |
+          jq '
+            .runs[].results[]? |= (
+              if ((.locations // []) | length) == 0 then
+                .locations = [{"physicalLocation":{"artifactLocation":{"uri":"go.mod"},"region":{"startLine":1}}}]
+              else . end
+            )
+            | .runs[].results[]?.locations[]?.physicalLocation.artifactLocation |= (
+                if (.uri // "") == "" then .uri = "go.mod" else . end
+              )
+          ' "${{ steps.grype.outputs.sarif }}" > grype-normalised.sarif
+          mv grype-normalised.sarif "${{ steps.grype.outputs.sarif }}"
+
       - name: Upload SARIF to Security tab
         if: always()
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,21 @@
+# Grype configuration — documented vulnerability risk acceptances.
+#
+# Same policy as our .trivyignore usage: every entry carries the
+# reachability rationale and a removal trigger. Do not add entries
+# without both.
+
+ignore:
+  # GO-2026-5932 — golang.org/x/crypto/openpgp is unmaintained and
+  # unsafe by design (no fixed version exists; the package is frozen
+  # upstream forever).
+  #
+  # Reachability: `go mod why golang.org/x/crypto/openpgp` reports
+  # the main module does not need the package — x/crypto is an
+  # indirect dependency and nothing in our build imports openpgp.
+  # The symbol-level govulncheck preflight gate stays enabled and
+  # would flag any future import that makes it reachable.
+  #
+  # Removal trigger: drop this entry if x/crypto ever removes the
+  # openpgp package, or if the dependency that pulls x/crypto is
+  # removed. Issue: #256.
+  - vulnerability: GO-2026-5932

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (Encrypted Client Hello privacy leak in `crypto/tls`, reachable via the
   connection pool, HTTP server, and cloud credential fetchers). No code
   changes.
+- Documented risk acceptance for GO-2026-5932 (`.grype.yaml`, #256):
+  `golang.org/x/crypto/openpgp` is unmaintained upstream with no fixed
+  version; the package is not imported by this module (`go mod why`
+  confirms), and the symbol-level govulncheck gate would flag any future
+  import. Nightly grype SARIF uploads also hardened against
+  SBOM-sourced results without artifact locations, which broke the
+  code-scanning upload on the first real finding.
 
 ### Fixed
 


### PR DESCRIPTION
## What

- **SARIF normalisation step** before the code-scanning upload in `nightly-security.yml`: SBOM-sourced grype results carry an empty `physicalLocation.artifactLocation.uri` (an SBOM has no file paths); GitHub rejects them with `locationFromSarifResult: expected artifact location`. Empty/missing locations now point at `go.mod`. jq filter verified against the actual failed SARIF artifact from run 2026-07-09 (analysis 1458140460).
- **`.grype.yaml` documented risk acceptance** for GO-2026-5932 (`golang.org/x/crypto/openpgp` unmaintained, unsafe by design, **no fixed version exists**): `go mod why golang.org/x/crypto/openpgp` reports the main module does not need the package — nothing imports it, x/crypto is indirect. The symbol-level govulncheck preflight gate stays on and would catch any future import. Rationale + removal trigger in the file, per our `.trivyignore` policy.

## Why

The nightly only broke when the first real finding appeared — empty result sets upload fine. This is also what produced the "Several tools are reporting errors" banner on the Security tab (Grype tool status: `locationFromSarifResult: expected artifact location`).

Scorecard alert #57 (`VulnerabilitiesID`, GO-2026-5932) is the same vulnerability flagged module-level; it should be dismissed with this justification once this lands.

## Verification

- jq normalisation tested against the real failed SARIF: the GO-2026-5932 result's empty uri becomes `go.mod`.
- `actionlint` clean; yamllint warnings are pre-existing lines.
- Full preflight green (gofmt, vet, build, test, secrets, vuln, semgrep, osv, kube-lint, lint).

Fixes #256