### PR TITLE
docs: reconcile adoption guide with current auth and deployment paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Test
         run: bash scripts/preflight.sh test
 
+      - name: Docs drift guard
+        run: bash scripts/preflight.sh docs
+
       - name: Boundary tests
         run: >
           go test -v -run

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -21,8 +21,13 @@ This produces `bin/signals` (daemon) and `bin/signalsctl` (CLI).
 **Docker:**
 
 ```bash
-docker pull ghcr.io/elevarq/signals:1.0.0
+docker pull ghcr.io/elevarq/signals:<version>
 ```
+
+Throughout this guide, `<version>` stands for a concrete released tag —
+for example `1.0.0`. Pin the exact tag you deploy (see the
+[releases page](https://github.com/Elevarq/Signals/releases)); the image
+does not publish a `latest` tag, so do not rely on one.
 
 ### 2. Configure
 
@@ -91,7 +96,7 @@ docker run -d \
   -v /etc/signals/signals.yaml:/etc/signals/signals.yaml:ro \
   -v signals-data:/data \
   -p 127.0.0.1:8081:8081 \
-  ghcr.io/elevarq/signals:1.0.0
+  ghcr.io/elevarq/signals:<version>
 ```
 
 The container runs as a non-root user (UID 10001) on Alpine 3.21. The API listens on port 8081. Bind it to loopback unless you need external access.
@@ -113,7 +118,7 @@ docker run -d \
   -v /run/secrets/pg_password:/run/secrets/pg_password:ro \
   -v signals-data:/data \
   -p 127.0.0.1:8081:8081 \
-  ghcr.io/elevarq/signals:1.0.0
+  ghcr.io/elevarq/signals:<version>
 ```
 
 The following target-level env vars are supported:
@@ -129,6 +134,12 @@ The following target-level env vars are supported:
 | `SIGNALS_TARGET_PASSWORD_ENV` | Env var containing the password | -- |
 | `SIGNALS_TARGET_PGPASS_FILE` | Path to pgpass file | -- |
 | `SIGNALS_TARGET_SSLMODE` | TLS mode | -- |
+| `SIGNALS_TARGET_SSLROOTCERT_FILE` | Path to CA certificate (required for `verify-ca`/`verify-full`) | -- |
+
+The single-target environment path covers the `password` auth method
+only (password file, env var, or pgpass). The cloud-identity,
+`secret_store`, and `mtls` methods below need a config file — set
+`auth_method` and its fields in `signals.yaml`.
 
 ### TLS
 
@@ -155,9 +166,53 @@ For the HTTP API, place Elevarq Signals behind a TLS-terminating reverse proxy (
 
 ## Credential Management
 
-Elevarq Signals supports three credential sources. Choose whichever fits your environment. Only one may be specified per target.
+Each target picks one `auth_method`. The method decides *how* Elevarq
+Signals obtains the credential it connects with; it never changes *what*
+the connection may do — the read-only, least-privilege model is identical
+for every method. Omitting `auth_method` keeps the default `password`
+behaviour, so existing deployments need no change.
 
-| Method | Config field | Description |
+**No database password has to live in Signals' config.** The
+cloud-identity methods (`aws_rds_iam`, `azure_entra`, `gcp_cloudsql_iam`)
+mint a short-lived token from the collector's ambient cloud identity at
+connect time, and `secret_store` fetches the password live from a cloud
+vault. The credential is re-resolved on every reconnect (automatic
+rotation) and is never written to disk, logs, audit events, metrics, or
+exports.
+
+### Choosing a method by platform
+
+| Platform | `auth_method` | Credential |
+|----------|--------------|------------|
+| Amazon RDS / Aurora | `aws_rds_iam` | Short-lived RDS IAM token — **passwordless** |
+| Amazon RDS / Aurora | `secret_store` | Password from AWS Secrets Manager or SSM Parameter Store |
+| Azure Flexible Server | `azure_entra` | Entra ID token via Managed Identity — **passwordless** |
+| Azure Flexible Server | `secret_store` | Password from Azure Key Vault |
+| Google Cloud SQL | `gcp_cloudsql_iam` | Google IAM token via Workload Identity / ADC — **passwordless** |
+| Google Cloud SQL | `secret_store` | Password from GCP Secret Manager |
+| Self-managed | `password` (default) | Password from a file, env var, or pgpass file |
+| Self-managed | `mtls` | Client X.509 certificate |
+| Self-managed | `secret_store` | Password from any of the four cloud vaults |
+
+Every method authenticates **as the same read-only role** — a `LOGIN`
+role granted `pg_monitor` (see [Monitoring Role Setup](#monitoring-role-setup)).
+The cloud-identity and `secret_store` methods also require
+`sslmode: verify-full` with an `sslrootcert_file`, in **every**
+environment (stricter than the general prod-only TLS rule below).
+
+Full per-cloud recipes — the exact database grants, least-privilege IAM
+policies, prerequisites, and limitations for `aws_rds_iam`,
+`azure_entra`, `gcp_cloudsql_iam`, `secret_store` (all four vaults), and
+`mtls` — live in the canonical reference:
+**[docs/database-connections.md](database-connections.md)**. The rest of
+this section covers the default `password` method.
+
+### The `password` method (default)
+
+The credential is a password supplied locally via **exactly one** of
+`password_file`, `password_env`, or `pgpass_file` per target:
+
+| Source | Config field | Description |
 |--------|-------------|-------------|
 | Password file | `password_file: /path/to/file` | Reads the password from a file. Compatible with Docker secrets and Kubernetes secret volumes. |
 | Environment variable | `password_env: PG_PASSWORD` | Reads the password from the named environment variable. The value of that variable is the password. |
@@ -208,6 +263,11 @@ GRANT pg_monitor TO signals;
 -- Optional: enable query-level statistics
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 ```
+
+For the passwordless cloud-identity methods (`aws_rds_iam`,
+`azure_entra`, `gcp_cloudsql_iam`) and `mtls`, create the role **without**
+a password (`CREATE ROLE signals LOGIN;`) and add the method-specific
+binding — see [docs/database-connections.md](database-connections.md).
 
 On **Amazon RDS / Aurora**, `pg_monitor` is available on all supported versions (14+).
 
@@ -303,7 +363,9 @@ targets:
     port: 5432
     dbname: postgres
     user: signals
-    password_file: /path/to/password    # or password_env or pgpass_file
+    auth_method: password               # password (default), aws_rds_iam, azure_entra,
+                                        # gcp_cloudsql_iam, secret_store, mtls
+    password_file: /path/to/password    # password method: or password_env or pgpass_file
     sslmode: prefer
     sslrootcert_file: /path/to/ca.crt   # required for verify-ca/verify-full
     enabled: true
@@ -315,6 +377,12 @@ api:
   read_timeout: 30s
   write_timeout: 180s
 ```
+
+The per-target fields for the non-`password` methods (`region`,
+`azure_client_id`, `gcp_impersonate_service_account`, `secret_ref`,
+`secret_json_key`, `max_cache_ttl`, `sslcert`, `sslkey`,
+`sslkey_passphrase_file`) are documented with each method in
+[docs/database-connections.md](database-connections.md).
 
 ---
 

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# check-docs.sh — lightweight documentation-drift guard.
+#
+# Catches the two failure modes that let docs/adoption-guide.md drift
+# from reality between releases (Elevarq/Signals#261):
+#
+#   1. A hard-coded image version. The guide must reference the image
+#      as ghcr.io/elevarq/signals:<version> (a placeholder), never a
+#      pinned SemVer that silently goes stale every release.
+#   2. A broken relative link. Every relative Markdown link in the
+#      guarded files must resolve to a file that exists in the tree,
+#      so a moved/renamed doc is caught here instead of by a reader.
+#
+# Dependency-free (bash + grep + sed) so it runs anywhere CI or the
+# pre-push hook runs, with no toolchain to install.
+#
+# Usage:
+#   scripts/check-docs.sh          # check the guarded doc set
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — at least one check failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+if [ -t 1 ]; then
+  C_RED=$'\033[0;31m'; C_GREEN=$'\033[0;32m'; C_YELLOW=$'\033[0;33m'; C_RESET=$'\033[0m'
+else
+  C_RED=""; C_GREEN=""; C_YELLOW=""; C_RESET=""
+fi
+log_step() { printf "%s==> %s%s\n" "${C_YELLOW}" "$1" "${C_RESET}"; }
+log_ok()   { printf "%s   ✓ %s%s\n" "${C_GREEN}" "$1" "${C_RESET}"; }
+log_fail() { printf "%s   ✗ %s%s\n" "${C_RED}"   "$1" "${C_RESET}" >&2; }
+
+# The docs whose examples and links are load-bearing for adopters.
+# Add files here as their content becomes release-sensitive.
+GUARDED_DOCS=(
+  "docs/adoption-guide.md"
+)
+
+fail=0
+
+# --- Check 1: no hard-coded image SemVer -----------------------------------
+# The guide must use the :<version> placeholder. A pinned tag such as
+# ghcr.io/elevarq/signals:1.0.0 is the exact stale-version drift #261
+# removed; reject any digit after the image's colon.
+log_step "docs: no hard-coded image version"
+for doc in "${GUARDED_DOCS[@]}"; do
+  [ -f "${doc}" ] || continue
+  if hits="$(grep -nE 'ghcr\.io/elevarq/signals:[0-9]' "${doc}")"; then
+    log_fail "${doc}: hard-coded image version — use ghcr.io/elevarq/signals:<version>"
+    printf "%s\n" "${hits}" >&2
+    fail=1
+  fi
+done
+[ "${fail}" -eq 0 ] && log_ok "no hard-coded image version"
+
+# --- Check 2: relative Markdown links resolve ------------------------------
+# Extract [text](target) links, keep only relative ones (skip http(s):,
+# mailto:, and pure #anchors), strip any #fragment, and assert the file
+# exists relative to the linking doc's directory.
+log_step "docs: relative links resolve"
+link_fail=0
+for doc in "${GUARDED_DOCS[@]}"; do
+  [ -f "${doc}" ] || continue
+  doc_dir="$(dirname "${doc}")"
+  while IFS= read -r target; do
+    [ -z "${target}" ] && continue
+    case "${target}" in
+      http://*|https://*|mailto:*|"#"*) continue ;;
+    esac
+    path="${target%%#*}"                       # drop #fragment
+    [ -z "${path}" ] && continue               # was a pure anchor
+    if [ ! -e "${doc_dir}/${path}" ]; then
+      log_fail "${doc}: broken relative link -> ${target}"
+      link_fail=1
+    fi
+  done < <(grep -oE '\]\([^)]+\)' "${doc}" | sed -E 's/^\]\(//; s/\)$//')
+done
+if [ "${link_fail}" -eq 0 ]; then
+  log_ok "relative links resolve"
+else
+  fail=1
+fi
+
+if [ "${fail}" -ne 0 ]; then
+  printf "%sdocs: check failed%s\n" "${C_RED}" "${C_RESET}" >&2
+  exit 1
+fi
+printf "%sdocs: all checks passed%s\n" "${C_GREEN}" "${C_RESET}"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -16,6 +16,7 @@
 #   scripts/preflight.sh vet         # go vet ./...
 #   scripts/preflight.sh build       # go build ./...
 #   scripts/preflight.sh test        # go test -count=1 -race ./...
+#   scripts/preflight.sh docs        # check-docs.sh (link/version drift guard)
 #   scripts/preflight.sh secrets     # gitleaks protect --staged + current-commit detect
 #   scripts/preflight.sh vuln        # govulncheck ./...
 #   scripts/preflight.sh semgrep     # semgrep --config p/golang --config p/security-audit
@@ -107,6 +108,19 @@ run_test() {
     return 1
   fi
   log_ok "go test: passing"
+}
+
+# #261: documentation-drift guard. Dependency-free, so it sits with the
+# fast Go gates rather than the security bundle. Asserts docs/adoption
+# -guide.md carries no hard-coded image version and no broken relative
+# links.
+run_docs() {
+  log_step "check-docs.sh"
+  if ! bash "${SCRIPT_DIR}/check-docs.sh"; then
+    log_fail "docs check failed"
+    return 1
+  fi
+  log_ok "docs: clean"
 }
 
 # #160: secrets / vuln / lint are local-fast security gates. CI keeps
@@ -248,6 +262,7 @@ run_all() {
   run_vet
   run_build
   run_test
+  run_docs
   run_security
   echo ""
   printf "%spreflight: all checks passed%s\n" "${C_GREEN}" "${C_RESET}"
@@ -262,6 +277,7 @@ case "${1:-all}" in
   vet)      run_vet ;;
   build)    run_build ;;
   test)     run_test ;;
+  docs)     run_docs ;;
   secrets)  run_secrets ;;
   vuln)     run_vuln ;;
   semgrep)  run_semgrep ;;


### PR DESCRIPTION
## Summary

`docs/adoption-guide.md` had drifted from current Signals and from the
extended docs on elevarq.com: it documented only the three password
sub-variants (`password_file`, `password_env`, `pgpass_file`) and
hard-coded the image tag `:1.0.0` in three places. Current Signals
supports six auth methods (`password`, `aws_rds_iam`, `azure_entra`,
`gcp_cloudsql_iam`, `secret_store` across four vaults, `mtls`).

This reconciles the guide against the canonical
`docs/database-connections.md` and the `elevarq.com/docs/signals`
reference, and adds a lightweight guard so it cannot silently drift again.

## Changes

- **Credential Management** rewritten: the three-source table becomes the
  platform-grouped six-method model, matching the website's grouping and
  `database-connections.md` terminology. Cloud-IAM, `secret_store`, and
  `mtls` paths **link** to the canonical reference for prerequisites and
  limitations rather than duplicating them — the anti-drift choice.
- **Image tag**: hard-coded `:1.0.0` → `:<version>` placeholder + a
  pin-a-concrete-tag note (the image publishes no `:latest`), mirroring
  the website install page.
- **Env single-target path**: add `SIGNALS_TARGET_SSLROOTCERT_FILE`
  (present in code, missing from the table) and note the path is
  password-only; other methods need a config file.
- **Full config reference**: surface `auth_method` and point to the
  per-method fields.
- **Monitoring role**: note the passwordless-role variant for cloud/mtls.
- **`scripts/check-docs.sh`** (new): dependency-free guard failing on a
  hard-coded image SemVer or a broken relative link in the guide. Wired
  into `scripts/preflight.sh` (`docs` gate, in `all`) and `ci.yml`.

## Acceptance criteria (#261)

- [x] Authentication choices match the canonical README/authentication docs
- [x] Cloud-IAM and mTLS paths linked with prerequisites and limitations
- [x] Current image/tag convention, no stale hard-coded versions
- [x] Commands exercised from a clean checkout (`make build`, `signalsctl`
      subcommands verified present)
- [x] Lightweight link/example check added to catch future divergence

## Verification

- `scripts/preflight.sh docs` passes; negative test confirms it fails on
  an injected stale version and a broken link.
- `shellcheck` clean on both scripts; `actionlint` clean on `ci.yml`.
- `gofmt -l .` empty (no Go changed).

Documentation + one guard script; no behaviour change.

closes #261