### PR TITLE
docs: extend image-version drift guard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,8 +338,12 @@ docker run -d --name signals \
   -e SIGNALS_ENV=dev \
   -v signals-data:/data \
   -p 8081:8081 \
-  ghcr.io/elevarq/signals:1.0.0
+  ghcr.io/elevarq/signals:<version>
 ```
+
+`<version>` is a concrete released tag — for example `1.0.0`. Pin the tag
+you deploy (see the [releases page](https://github.com/Elevarq/Signals/releases));
+the image publishes no `latest` tag.
 
 ### Build from source
 

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -37,10 +37,18 @@ log_step() { printf "%s==> %s%s\n" "${C_YELLOW}" "$1" "${C_RESET}"; }
 log_ok()   { printf "%s   ✓ %s%s\n" "${C_GREEN}" "$1" "${C_RESET}"; }
 log_fail() { printf "%s   ✗ %s%s\n" "${C_RED}"   "$1" "${C_RESET}" >&2; }
 
-# The docs whose examples and links are load-bearing for adopters.
-# Add files here as their content becomes release-sensitive.
+# Prose docs whose `docker pull` / `docker run` examples must use the
+# ghcr.io/elevarq/signals:<version> placeholder (the image publishes no
+# `latest`). Add a file here when it instructs adopters to pull the image.
+#
+# Deliberately NOT guarded (policy, Elevarq/Signals#263): deployable
+# defaults must stay a concrete, runnable tag — a placeholder would not
+# deploy — so CloudFormation / EC2 Image Builder / workflow `default:`
+# values (deploy/**, .github/workflows/**) and version-specific factual
+# references (e.g. docs/release-verification.md) are intentionally excluded.
 GUARDED_DOCS=(
   "docs/adoption-guide.md"
+  "README.md"
 )
 
 fail=0


### PR DESCRIPTION
## Summary

Follow-up to #261. After reconciling `docs/adoption-guide.md`, a repo-wide
sweep found `ghcr.io/elevarq/signals:1.0.0` in nine files. They are not the
same case — most are legitimately pinned. This PR classifies them, fixes
the one prose doc that should use a placeholder, and extends the guard.

Cross-checked the extended docs' **source repo** (`elevarq-website`,
`app/(marketing)/docs/signals/`): it already uses `:<version>` + a
pin-a-tag note, so the signals repo was the outlier. This brings it in line.

## Changes

- **`README.md`**: the `docker run` example uses
  `ghcr.io/elevarq/signals:<version>` with a pin-a-concrete-tag note (no
  `latest` is published).
- **`scripts/check-docs.sh`**: guards `README.md` in addition to the
  adoption guide, and records the pinned-vs-placeholder policy in the
  `GUARDED_DOCS` comment.

## Policy (ratified in #263)

| Case | Treatment |
|---|---|
| Prose `docker pull`/`run` examples | `:<version>` placeholder + note |
| Deployable defaults (CFN / Image Builder / workflow `default:`) | stay pinned — a placeholder won't deploy |
| Version-specific factual references (e.g. `release-verification.md`) | stay pinned |

Deploy manifests and workflow defaults are **intentionally excluded** from
the guard (verified: they remain pinned and unflagged).

## Verification

- `scripts/preflight.sh docs` passes with README guarded; negative test
  confirms it fails on a stale version injected into README.
- Deploy defaults still pinned and not flagged.
- `shellcheck` clean.

closes #263