### PR TITLE
chore(ci): align Dependabot time/timezone to 02:00 America/Los_Angeles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: "06:00"
-      timezone: Europe/Amsterdam
+      time: "02:00"
+      timezone: America/Los_Angeles
     open-pull-requests-limit: 5
     labels:
       - area:tooling
@@ -47,8 +47,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: "06:00"
-      timezone: Europe/Amsterdam
+      time: "02:00"
+      timezone: America/Los_Angeles
     open-pull-requests-limit: 5
     labels:
       - area:tooling


### PR DESCRIPTION
Changes the existing `06:00 Europe/Amsterdam` to `02:00 America/Los_Angeles` on both ecosystems, so all repos fire at the same planned time. Weekly/Monday + groups already set. Completes the cross-repo standardization (Analyzer #1533, Workbench #961, pgAgroal #92).

closes #268