### PR TITLE
fix: make Marketplace Signals install replayable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Security
 
-- Go toolchain bumped 1.26.4 -> 1.26.5 (#253): remediates GO-2026-5856
+- Go toolchain and container builder bumped 1.26.4 -> 1.26.5 (#253): remediates GO-2026-5856
   (Encrypted Client Hello privacy leak in `crypto/tls`, reachable via the
   connection pool, HTTP server, and cloud credential fetchers). No code
-  changes.
+  changes. The release Dockerfile now pins the same fixed patch release as CI,
+  so published binaries do not retain the vulnerable standard library.
 - Documented risk acceptance for GO-2026-5932 (`.grype.yaml`, #256):
   `golang.org/x/crypto/openpgp` is unmaintained upstream with no fixed
   version; the package is not imported by this module (`go mod why`
@@ -33,6 +34,20 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Helm persistence now applies `fsGroup: 10001` with
+  `fsGroupChangePolicy: OnRootMismatch`, allowing the hardened non-root process
+  to initialize SQLite on a freshly provisioned EBS volume (#275).
+- Helm now implements the documented, schema-validated `extraEnv` path for
+  daemon TLS file settings and controlled non-secret overrides; secret-backed
+  entries use `valueFrom`, and chart-managed environment names fail closed
+  instead of rendering duplicates (#274).
+- AWS Marketplace installation instructions now provision the EBS CSI driver
+  and an explicit `gp3` StorageClass before enabling the default persistent
+  volume, preventing clean EKS installs from waiting forever on an unbound PVC
+  (#273).
+- AWS Marketplace verification commands now target the chart's actual
+  `<release>-signals` Deployment name instead of a non-existent `signals`
+  Deployment (#276).
 - Snapshot export: `query_runs.ndjson` rows now carry the persisted
   `status` and `reason` fields (R118, #250). Owner-only privilege skips
   (`skipped`/`privilege_owner_only`, R116) previously serialized as bare
@@ -40,12 +55,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   failures; ZIP consumers can now read the classification instead of
   re-deriving it from the SQLSTATE. Additive change — all pre-existing
   fields are unchanged.
-- AWS Marketplace install guide: the verification commands targeted the
-  wrong Helm Deployment name (`deploy/signals`); the chart renders the
-  Deployment as `<release>-signals`, so the documented `helm install
-  signals` produces `deploy/signals-signals`. Corrected the commands
-  and noted the `<release>-signals` mapping / label-selector fallback
-  (#276).
 
 ## [1.0.0] - 2026-06-30
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.26.4-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14 AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 RUN apk add --no-cache git
 

--- a/deploy/helm/signals/README.md
+++ b/deploy/helm/signals/README.md
@@ -9,6 +9,40 @@ block is emitted.
 > [`docs/database-connections.md`](../../../docs/database-connections.md).
 > This README covers only the Helm wiring.
 
+## Persistent volume prerequisites
+
+Persistence is enabled by default. Set `persistence.storageClass` to a class
+whose CSI provisioner is installed and Ready before running Helm. On EKS, use
+the Amazon EBS CSI add-on and an encrypted `gp3` class; the complete Marketplace
+procedure is in
+[`docs/marketplace/install-from-aws-marketplace.md`](../../../docs/marketplace/install-from-aws-marketplace.md).
+
+The pod runs as UID/GID 10001 and applies `fsGroup: 10001` with
+`fsGroupChangePolicy: OnRootMismatch`, so a freshly provisioned volume is
+writable without running the application container as root. Disabling
+`persistence.enabled` uses `emptyDir` and loses the database and snapshots when
+the pod is replaced; use it only for disposable evaluation.
+
+## Additional environment variables
+
+Use `extraEnv` for supported non-secret daemon settings such as TLS certificate
+file paths. Use `valueFrom.secretKeyRef` for secret-backed values; never place a
+credential literal in Helm values or release history. Environment variables
+managed directly by the chart cannot be overridden through `extraEnv`.
+
+```yaml
+extraEnv:
+  - name: SIGNALS_API_TLS_CERT_FILE
+    value: /etc/ssl/signals/tls.crt
+  - name: SIGNALS_API_TLS_KEY_FILE
+    value: /etc/ssl/signals/tls.key
+  - name: EXTERNAL_SERVICE_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: external-service
+        key: token
+```
+
 ## Authentication methods
 
 `target.authMethod` selects how the collector authenticates. The

--- a/deploy/helm/signals/templates/deployment.yaml
+++ b/deploy/helm/signals/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{- range $entry := .Values.extraEnv }}
+{{- if has $entry.name (list "SIGNALS_ENV" "SIGNALS_POLL_INTERVAL" "SIGNALS_RETENTION_DAYS" "SIGNALS_TARGET_TIMEOUT" "SIGNALS_QUERY_TIMEOUT" "SIGNALS_LISTEN_ADDR" "PG_PASSWORD" "SIGNALS_API_TOKEN") }}
+{{- fail (printf "extraEnv name %q is managed by the chart and cannot be overridden" $entry.name) }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,6 +36,8 @@ spec:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup | default 10001 }}
+        fsGroup: {{ .Values.securityContext.fsGroup | default 10001 }}
+        fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy | default "OnRootMismatch" }}
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -90,6 +97,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.api.tokenSecretName }}
                   key: {{ .Values.api.tokenSecretKey | default "token" }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: config

--- a/deploy/helm/signals/values.schema.json
+++ b/deploy/helm/signals/values.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "extraEnv": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object"
+          }
+        },
+        "oneOf": [
+          { "required": ["value"] },
+          { "required": ["valueFrom"] }
+        ]
+      }
+    }
+  }
+}

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -111,6 +111,17 @@ serviceAccount:
 #     azure.workload.identity/use: "true"
 podLabels: {}
 
+# Additional non-secret environment variables for the Signals container.
+# Secret values must use valueFrom.secretKeyRef; do not put credential values
+# in Helm values or release history. Built-in SIGNALS_* variables managed by
+# the chart cannot be overridden here. Example:
+#   extraEnv:
+#     - name: SIGNALS_API_TLS_CERT_FILE
+#       value: /etc/ssl/signals/tls.crt
+#     - name: SIGNALS_API_TLS_KEY_FILE
+#       value: /etc/ssl/signals/tls.key
+extraEnv: []
+
 # Extra volumes / mounts (#114). Use to mount a CA bundle for
 # sslmode: verify-full (set target.sslRootCertFile to the mount path),
 # or any other operator-supplied file. No secrets in values — mount a
@@ -182,4 +193,9 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 10001
   runAsGroup: 10001
+  # Make dynamically provisioned persistent volumes writable by the non-root
+  # process. OnRootMismatch avoids an unnecessary recursive ownership walk
+  # when a retained volume already has the expected root directory group.
+  fsGroup: 10001
+  fsGroupChangePolicy: OnRootMismatch
   readOnlyRootFilesystem: true

--- a/docs/marketplace/aws-listing.md
+++ b/docs/marketplace/aws-listing.md
@@ -74,6 +74,12 @@ aws ecr get-login-password --region us-east-1 \
 
 Configure a values file, then install with `-f`:
 
+First install/verify the Amazon EBS CSI driver and create an encrypted
+`signals-gp3` StorageClass using the exact commands in
+[`install-from-aws-marketplace.md`](install-from-aws-marketplace.md). The chart
+enables durable storage by default; installation is not ready until its PVC is
+`Bound`.
+
 ```yaml
 # signals-values.yaml
 target:
@@ -82,12 +88,17 @@ target:
   user: signals
   authMethod: aws_rds_iam      # passwordless RDS IAM
   sslmode: verify-full
+persistence:
+  storageClass: signals-gp3
 ```
 
 ```sh
 helm install signals \
   oci://<marketplace-ecr-registry>/<seller-ns>/elevarq-signals-chart \
   --version 1.0.0 -n signals --create-namespace -f signals-values.yaml
+kubectl -n signals wait --for=jsonpath='{.status.phase}'=Bound \
+  pvc/signals-signals-data --timeout=5m
+kubectl -n signals rollout status deployment/signals-signals --timeout=5m
 ```
 
 Note the chart URI ends at the **granted repo** (`elevarq-signals-chart`), not

--- a/docs/marketplace/install-from-aws-marketplace.md
+++ b/docs/marketplace/install-from-aws-marketplace.md
@@ -16,7 +16,57 @@ In **AWS Marketplace → Elevarq Signals → View purchase options**, accept the
 terms and subscribe (Signals is **free** — no charges). This grants your
 account pull access to the Marketplace ECR repositories for the product.
 
-## 2. Authenticate Helm to the Marketplace registry
+## 2. Prepare durable EBS storage
+
+The chart enables persistence by default. A fresh EKS cluster must have the
+Amazon EBS CSI driver and an explicit StorageClass before Helm creates the
+Signals PVC. The following IRSA setup keeps the driver permissions separate
+from the Signals collector identity:
+
+```sh
+export CLUSTER=<eks-cluster-name>
+export REGION=us-east-1
+export ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+export EBS_CSI_ROLE=signals-ebs-csi-${CLUSTER}
+
+eksctl utils associate-iam-oidc-provider \
+  --cluster "$CLUSTER" --region "$REGION" --approve
+eksctl create iamserviceaccount \
+  --cluster "$CLUSTER" --region "$REGION" \
+  --namespace kube-system --name ebs-csi-controller-sa \
+  --role-name "$EBS_CSI_ROLE" --role-only \
+  --attach-policy-arn arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy \
+  --approve
+eksctl create addon \
+  --cluster "$CLUSTER" --region "$REGION" \
+  --name aws-ebs-csi-driver \
+  --service-account-role-arn "arn:aws:iam::${ACCOUNT_ID}:role/${EBS_CSI_ROLE}" \
+  --force --wait
+```
+
+Create a CSI-backed `gp3` class dedicated to this installation:
+
+```sh
+kubectl apply -f - <<'EOF'
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: signals-gp3
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: gp3
+  encrypted: "true"
+EOF
+kubectl get storageclass signals-gp3
+```
+
+If the driver already exists, verify it is `ACTIVE` and skip its creation. Do
+not reuse an unrelated IAM role or make another StorageClass the cluster-wide
+default merely for Signals.
+
+## 3. Authenticate Helm to the Marketplace registry
 
 ```sh
 aws ecr get-login-password --region us-east-1 \
@@ -26,7 +76,7 @@ aws ecr get-login-password --region us-east-1 \
 `<marketplace-ecr-registry>` is the `*.dkr.ecr.us-east-1.amazonaws.com` host
 shown on the listing's launch page.
 
-## 3. Install the chart
+## 4. Install the chart
 
 Onto an existing Amazon EKS cluster (or a self-managed cluster). Put your
 configuration in a values file (`signals-values.yaml`) rather than `--set`
@@ -41,6 +91,9 @@ target:
   authMethod: aws_rds_iam      # passwordless RDS IAM
   sslmode: verify-full
   sslRootCertFile: /etc/ssl/db/rds-ca.pem
+
+persistence:
+  storageClass: signals-gp3
 ```
 
 ```sh
@@ -60,7 +113,15 @@ is otherwise the **same chart** as
 chart artifact name differ. Its values are documented in
 [`deploy/helm/signals/README.md`](../../deploy/helm/signals/README.md).
 
-## 4. Complete the passwordless onboarding
+After Helm returns, require both storage and workload readiness:
+
+```sh
+kubectl -n signals wait --for=jsonpath='{.status.phase}'=Bound \
+  pvc/signals-signals-data --timeout=5m
+kubectl -n signals rollout status deployment/signals-signals --timeout=5m
+```
+
+## 5. Complete the passwordless onboarding
 
 The Marketplace install is just the chart; the one-time identity + database
 setup is the same as the open-source path:
@@ -73,7 +134,7 @@ setup is the same as the open-source path:
   `verify-full` CA bundle: the Helm README (`#114` snippets) and
   [`docs/install/kubernetes-production.md`](../install/kubernetes-production.md).
 
-## 5. Verify
+## 6. Verify
 
 The Deployment is named `<release>-signals` (the Helm release name plus the
 chart name); with the `helm install signals …` release name above, this is
@@ -82,8 +143,9 @@ different release name, substitute `<your-release>-signals`, or use the label
 selector `deploy -l app.kubernetes.io/name=signals` instead.
 
 ```sh
-kubectl -n signals exec deploy/signals-signals -- signalsctl status
-kubectl -n signals exec deploy/signals-signals -- signalsctl export --output /data/snapshot.zip
+kubectl -n signals exec deployment/signals-signals -- signalsctl status
+kubectl -n signals exec deployment/signals-signals -- \
+  signalsctl export --output /data/snapshot.zip
 ```
 
 A healthy install connects **passwordless** over `verify-full` TLS with a
@@ -91,7 +153,7 @@ least-privilege `pg_monitor` role, and produces a local snapshot. Signals sends
 **no telemetry and no diagnostic data to Elevarq**; the only outbound calls are
 the cloud-auth/TLS requests you configure, made to your own cloud's services.
 
-## 6. Operational details (AWS Marketplace)
+## 7. Operational details (AWS Marketplace)
 
 - **Secrets / sensitive info.** With `aws_rds_iam` there is **no password** —
   the collector mints a short-lived RDS IAM token from its IRSA / Pod Identity

--- a/tests/signals_helm_runtime_wiring_test.go
+++ b/tests/signals_helm_runtime_wiring_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestHelm_DefaultPersistentVolumeOwnership(t *testing.T) {
+	out := renderHelm(t)
+	for _, want := range []string{
+		"runAsUser: 10001",
+		"runAsGroup: 10001",
+		"fsGroup: 10001",
+		"fsGroupChangePolicy: OnRootMismatch",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("default pod security context missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHelm_PersistenceStorageClassRenders(t *testing.T) {
+	out := renderHelm(t, "persistence.storageClass=signals-gp3")
+	if !strings.Contains(out, "storageClassName: \"signals-gp3\"") {
+		t.Errorf("selected storage class not rendered:\n%s", out)
+	}
+}
+
+func TestHelm_ExtraEnvRendersTLSFilePaths(t *testing.T) {
+	out := renderHelm(t,
+		"extraEnv[0].name=SIGNALS_API_TLS_CERT_FILE",
+		"extraEnv[0].value=/etc/ssl/signals/tls.crt",
+		"extraEnv[1].name=SIGNALS_API_TLS_KEY_FILE",
+		"extraEnv[1].value=/etc/ssl/signals/tls.key",
+	)
+	for _, want := range []string{
+		"name: SIGNALS_API_TLS_CERT_FILE",
+		"value: /etc/ssl/signals/tls.crt",
+		"name: SIGNALS_API_TLS_KEY_FILE",
+		"value: /etc/ssl/signals/tls.key",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("extraEnv TLS wiring missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHelm_ExtraEnvSecretReferenceDoesNotRenderValue(t *testing.T) {
+	out := renderHelm(t,
+		"extraEnv[0].name=EXTERNAL_SERVICE_TOKEN",
+		"extraEnv[0].valueFrom.secretKeyRef.name=external-service",
+		"extraEnv[0].valueFrom.secretKeyRef.key=token",
+	)
+	for _, want := range []string{
+		"name: EXTERNAL_SERVICE_TOKEN",
+		"valueFrom:",
+		"secretKeyRef:",
+		"name: external-service",
+		"key: token",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("extraEnv secret reference missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "value: external-service") {
+		t.Errorf("secret reference was rendered as a literal value:\n%s", out)
+	}
+}
+
+func TestHelm_ExtraEnvRejectsManagedName(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm CLI not on PATH; skipping helm-template assertions")
+	}
+	cmd := exec.Command("helm", "template", "signals", prodChartPath,
+		"--set", "extraEnv[0].name=SIGNALS_API_TOKEN",
+		"--set", "extraEnv[0].value=not-allowed",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("managed environment name unexpectedly accepted:\n%s", out)
+	}
+	if !strings.Contains(string(out), "managed by the chart") {
+		t.Fatalf("unexpected managed-name validation error:\n%s", out)
+	}
+}
+
+func TestHelm_ExtraEnvRejectsMalformedEntry(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm CLI not on PATH; skipping helm-template assertions")
+	}
+	cmd := exec.Command("helm", "template", "signals", prodChartPath,
+		"--set", "extraEnv[0].value=missing-name",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("malformed extraEnv entry unexpectedly accepted:\n%s", out)
+	}
+	if !strings.Contains(string(out), "missing property 'name'") {
+		t.Fatalf("unexpected schema validation error:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Outcome

Fixes the source defects found by a clean live install of the public AWS Marketplace Signals 1.0.0 artifacts on EKS:

- pins the release Docker builder to Go 1.26.5
- makes fresh CSI volumes writable by non-root UID/GID 10001 via `fsGroup` + `OnRootMismatch`
- implements schema-validated `extraEnv`, including `valueFrom.secretKeyRef` and reserved-name rejection
- documents and live-validates the EBS CSI + encrypted gp3 prerequisite
- fixes the Marketplace verification Deployment name
- adds Helm render/invalid-input regression tests

Refs #253, #273, #274, #275, #276. These issues should remain open until the fix is merged, released, re-hosted to Marketplace, and the exact new Marketplace digests pass the same acceptance run.

## Live evidence

The fixed source chart was upgraded over the exact Marketplace 1.0.0 image on EKS:

- Helm status: deployed
- PVC: Bound on EBS
- pod: Ready as UID/GID/fsGroup 10001
- collection: 99 catalog entries, 80 succeeded, 0 failed, expected least-privilege skips only
- authenticated status/export succeeded; absent/invalid token returned 401
- snapshot ZIP integrity and credential-leak checks passed
- pod replacement preserved the instance ID and snapshot count

## Verification

- `gofmt`, `go vet ./...`, `go test ./...`: pass
- chart unit/render tests: pass
- `helm lint` / representative `helm template`: pass
- docs links/version guard: pass
- Docker build uses Go 1.26.5 (`go version -m` verified)
- `govulncheck ./...`: 0 reachable vulnerabilities
- Trivy HIGH/CRITICAL + secret scan of rebuilt local image: clean
- live Helm upgrade with no manual Deployment patch: pass
