### PR TITLE
docs(marketplace): fix verification commands to target deploy/signals-signals (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   failures; ZIP consumers can now read the classification instead of
   re-deriving it from the SQLSTATE. Additive change — all pre-existing
   fields are unchanged.
+- AWS Marketplace install guide: the verification commands targeted the
+  wrong Helm Deployment name (`deploy/signals`); the chart renders the
+  Deployment as `<release>-signals`, so the documented `helm install
+  signals` produces `deploy/signals-signals`. Corrected the commands
+  and noted the `<release>-signals` mapping / label-selector fallback
+  (#276).
 
 ## [1.0.0] - 2026-06-30
 

--- a/docs/marketplace/install-from-aws-marketplace.md
+++ b/docs/marketplace/install-from-aws-marketplace.md
@@ -75,9 +75,15 @@ setup is the same as the open-source path:
 
 ## 5. Verify
 
+The Deployment is named `<release>-signals` (the Helm release name plus the
+chart name); with the `helm install signals …` release name above, this is
+`signals-signals`. The commands below use that name. If you installed under a
+different release name, substitute `<your-release>-signals`, or use the label
+selector `deploy -l app.kubernetes.io/name=signals` instead.
+
 ```sh
-kubectl -n signals exec deploy/signals -- signalsctl status
-kubectl -n signals exec deploy/signals -- signalsctl export --output /data/snapshot.zip
+kubectl -n signals exec deploy/signals-signals -- signalsctl status
+kubectl -n signals exec deploy/signals-signals -- signalsctl export --output /data/snapshot.zip
 ```
 
 A healthy install connects **passwordless** over `verify-full` TLS with a


### PR DESCRIPTION
# docs(marketplace): fix verification commands to target deploy/signals-signals (#276)

## Summary

The AWS Marketplace install guide's verification commands referenced the
wrong Helm Deployment name (`deploy/signals`). The chart renders the
Deployment as `<release>-signals` (`{{ .Release.Name }}-signals` in
`deploy/helm/signals/templates/deployment.yaml`), so with the documented
`helm install signals …` release name the Deployment is `signals-signals`,
not `signals`. Copy-pasting the old commands would fail with a
not-found error. This PR corrects the commands and notes the mapping.

Fixes #276

## Changes

- `docs/marketplace/install-from-aws-marketplace.md`: changed the two
  verification `kubectl … exec deploy/signals` commands to
  `deploy/signals-signals`, and added a short note above them explaining
  the `<release>-signals` naming (Helm release name + chart name) with a
  label-selector fallback (`deploy -l app.kubernetes.io/name=signals`)
  for installs under a custom release name.
- `CHANGELOG.md`: added a `### Fixed` entry under `[Unreleased]`.

## Context / verification

- Confirmed the naming convention at the source: the chart's
  `templates/deployment.yaml` uses `name: {{ .Release.Name }}-signals`
  and labels the pod with `app.kubernetes.io/name: signals`, matching the
  corrected commands and the label selector.
- The same `signals-signals` Deployment name is already used in
  `docs/install/kubernetes-production.md` (there under release/namespace
  `observability` as `deploy/signals-signals`), so this brings the
  Marketplace guide in line with the rest of the docs.
- Searched the repo for other occurrences of `deploy/signals` (excluding
  `deploy/signals-signals`): the only two hits were the lines fixed here.
- No code or tests reference these docs/commands; this is a docs-only
  change with no behavioral surface.

## Testing

Docs-only change, so testing was limited to the repo's documentation guards:
- `bash scripts/check-docs.sh` — passed (no hard-coded image version; all
  relative links resolve). The marketplace file is not in the guarded
  set, and the edits add no relative links or image tags.

Per the standing rules I did not run `go test`/build commands (the change
touches no Go, no Helm template, and no test).

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
