### PR TITLE
docs: add ACKNOWLEDGEMENTS.md recognizing project contributors (#279)

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -1,0 +1,14 @@
+# Acknowledgements
+
+Elevarq Signals is made better by the people who take the time to report
+issues, improve the documentation, and contribute code. Thank you.
+
+## Contributors
+
+Listed in the order their first contribution was merged:
+
+```
+Giorgio Maria Federico Birnthaler (@Dodothereal)
+```
+
+To be added here, open a pull request — see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,11 @@ artifacts in `features/signals/` and add corresponding tests.
 - Add comments only where the logic is not self-evident
 - Use table-driven tests where appropriate
 
+## Acknowledgements
+
+Contributors are recognized in [ACKNOWLEDGEMENTS.md](ACKNOWLEDGEMENTS.md).
+New contributors are added there as their first pull request is merged.
+
 ## License
 
 By contributing to Elevarq Signals, you agree that your contributions will be


### PR DESCRIPTION
## Summary

Adds a top-level `ACKNOWLEDGEMENTS.md`, following the upstream pgAgroal
acknowledgement convention, and links it from `CONTRIBUTING.md`. Records
Giorgio Maria Federico Birnthaler (@Dodothereal) as the project's first
external contributor.

## Changes

- `ACKNOWLEDGEMENTS.md` (new): Contributors section, listed in merge order.
- `CONTRIBUTING.md`: an Acknowledgements section pointing to the new file.

## Testing

- `bash scripts/check-docs.sh` — passed (no hard-coded image version; all relative links resolve).
- Docs-only change; no Go, Helm, or test surface touched.

Closes #279