### PR TITLE
release: v1.0.1 — Marketplace container-path fixes (#281)

### DIFF
--- a/.github/workflows/aws-rds-iam-live-smoke.yml
+++ b/.github/workflows/aws-rds-iam-live-smoke.yml
@@ -53,7 +53,7 @@ on:
       image_uri:
         description: Signals container image (pinned tag)
         required: false
-        default: ghcr.io/elevarq/signals:1.0.0
+        default: ghcr.io/elevarq/signals:1.0.1
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-17
+
 ### Security
 
 - Go toolchain and container builder bumped 1.26.4 -> 1.26.5 (#253): remediates GO-2026-5856

--- a/deploy/aws/LIVE-SMOKE.md
+++ b/deploy/aws/LIVE-SMOKE.md
@@ -79,7 +79,7 @@ fill the inputs:
 | `security_group_ids` | `["sg-0123…"]` | **JSON array** string |
 | `db_user` | `signals` | role granted `rds_iam` + `pg_monitor` |
 | `name_prefix` | `signals-livesmoke` | prefixes the throwaway resources |
-| `image_uri` | `ghcr.io/elevarq/signals:1.0.0` | pinned tag |
+| `image_uri` | `ghcr.io/elevarq/signals:1.0.1` | pinned tag |
 
 A green run means: the collector minted an RDS IAM token from its instance
 role, connected `verify-full` with **no password on disk**, and produced

--- a/deploy/aws/cloudformation/signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/signals-rds-iam.yaml
@@ -38,7 +38,7 @@ Parameters:
     Default: t3.small
   ImageUri:
     Type: String
-    Default: ghcr.io/elevarq/signals:1.0.0
+    Default: ghcr.io/elevarq/signals:1.0.1
     Description: Elevarq Signals container image (pinned tag).
   Env:
     Type: String

--- a/deploy/aws/imagebuilder/README.md
+++ b/deploy/aws/imagebuilder/README.md
@@ -34,7 +34,7 @@ same posture as the container and Helm deliveries.
 
 | Parameter | Default | Notes |
 |-----------|---------|-------|
-| `SignalsImage` | `ghcr.io/elevarq/signals:1.0.0` | Pinned version (no `latest`). Bump per release. |
+| `SignalsImage` | `ghcr.io/elevarq/signals:1.0.1` | Pinned version (no `latest`). Bump per release. |
 
 ### Baking locally / in a pipeline
 
@@ -44,7 +44,7 @@ Linux 2023 base image. Register it and reference it from a recipe:
 ```bash
 aws imagebuilder create-component \
   --name signals-collector \
-  --semantic-version 1.0.0 \
+  --semantic-version 1.0.1 \
   --platform Linux \
   --data file://signals-collector-component.yaml
 # -> ComponentArn, referenced by an image recipe + pipeline that produces the AMI.

--- a/deploy/aws/imagebuilder/signals-collector-component.yaml
+++ b/deploy/aws/imagebuilder/signals-collector-component.yaml
@@ -18,7 +18,7 @@ schemaVersion: 1.0
 parameters:
   - SignalsImage:
       type: string
-      default: "ghcr.io/elevarq/signals:1.0.0"
+      default: "ghcr.io/elevarq/signals:1.0.1"
       description: >-
         Pinned Signals image reference to pre-pull into the AMI. MUST be a
         specific version tag (no 'latest') so the AMI is reproducible (R-AMI-02).

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "instance_type" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:1.0.0"
+  default     = "ghcr.io/elevarq/signals:1.0.1"
 }
 
 variable "env" {

--- a/deploy/azure/bicep/main.bicep
+++ b/deploy/azure/bicep/main.bicep
@@ -46,7 +46,7 @@ param adminUsername string = 'azureuser'
 param adminSshPublicKey string
 
 @description('Elevarq Signals container image (pinned tag).')
-param imageUri string = 'ghcr.io/elevarq/signals:1.0.0'
+param imageUri string = 'ghcr.io/elevarq/signals:1.0.1'
 
 @description('URL of the CA bundle for sslmode=verify-full. Default is the DigiCert Global Root G2 that Azure Database for PostgreSQL Flexible Server chains to.')
 param dbCaCertUrl string = 'https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem'

--- a/deploy/azure/terraform/variables.tf
+++ b/deploy/azure/terraform/variables.tf
@@ -66,7 +66,7 @@ variable "admin_ssh_public_key" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:1.0.0"
+  default     = "ghcr.io/elevarq/signals:1.0.1"
 }
 
 variable "db_ca_cert_url" {

--- a/deploy/gcp/terraform/variables.tf
+++ b/deploy/gcp/terraform/variables.tf
@@ -82,7 +82,7 @@ variable "image" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:1.0.0"
+  default     = "ghcr.io/elevarq/signals:1.0.1"
 }
 
 variable "env" {

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.0.1
+appVersion: "1.0.1"
 keywords:
   - postgresql
   - monitoring

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "1.0.0"
+  tag: "1.0.1"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration. Rendered into the mounted


### PR DESCRIPTION
## Summary

Prepares the **v1.0.1** patch release carrying the already-merged Marketplace
container-path fixes, so the broken `:1.0.0` container path is superseded by a
signed, published `:1.0.1`.

Version bump only — no functional code changes (the fixes landed in #277).

## Included fixes (already on main)

- #253 Go toolchain 1.26.5 (govulncheck stdlib GO-2026-5856)
- #273 EBS CSI + gp3 storage prerequisite (install docs)
- #274 schema-validated `extraEnv` chart path
- #275 `fsGroup: 10001` / `OnRootMismatch` non-root EBS write
- #276 Marketplace verification Deployment name

## Changes

- `Chart.yaml` `version`/`appVersion` and `values.yaml` `image.tag`: 1.0.0 -> 1.0.1 (lockstep policy).
- `CHANGELOG.md`: dated `[1.0.1]` section + fresh empty `[Unreleased]`.
- Cloud deploy-example image pins (AWS/Azure/GCP terraform/CFN/bicep, EC2 Image Builder, RDS IAM live-smoke default): `:1.0.0` -> `:1.0.1` so examples stop shipping the broken container.

## Out of scope (deliberate)

- `docs/marketplace/*` stays at 1.0.0 until the separate, human-gated Marketplace ECR re-host + exact-digest re-test. That step is what closes #273/#274/#275; this PR does not close them.

## Release sequence (human gates after merge)

1. Merge this PR (Chart.yaml version now matches the intended tag).
2. Verify main HEAD carries the bump, then cut the `v1.0.1` GA tag (your call).
3. Publish workflow builds + cosign-signs image + chart on ghcr.
4. Re-host `:1.0.1` image + chart into the Marketplace ECR; re-run the ingestion scan.
5. Exact-digest re-test on EKS, then close #273/#274/#275.

## Testing

- `helm lint` clean; `helm template` renders `ghcr.io/elevarq/signals:1.0.1`.
- `actionlint` clean on the edited workflow.
- `scripts/check-docs.sh` passes (guarded docs keep the `:<version>` placeholder).
- No Go changed.

Closes #281