### PR TITLE
fix(marketplace): re-host copies platform manifests only, not attestations (#283)

### DIFF
--- a/docs/marketplace/catalog-api/README.md
+++ b/docs/marketplace/catalog-api/README.md
@@ -96,29 +96,42 @@ Spec: square 1:1, 120–640px, transparent PNG, <5MB (the hosted asset is a
 
 ## Re-host the image + chart (verified commands)
 
-Push the released 1.0.0 image and Helm chart into the Marketplace ECR repos.
+Push the released image and Helm chart into the Marketplace ECR repos.
 **skopeo is not required or installed** — `docker buildx imagetools create`
-copies the full multi-arch manifest registry-to-registry:
+rebuilds the multi-arch index registry-to-registry. **Copy the platform image
+manifests by digest, never the whole index:** a release built with `sbom: true`
+/ `provenance: mode=max` carries SBOM/SLSA **attestation manifests**
+(`unknown/unknown` entries), and copying them makes AWS ingestion fail
+`SECURITY_ISSUES_DETECTED: ...UnsupportedImageType` (Elevarq/Signals#283):
 
 ```sh
 MP=<acct>.dkr.ecr.us-east-1.amazonaws.com   # Marketplace ECR registry host
 NS=<seller-ns>                              # AWS prepends a seller namespace
+SRC=ghcr.io/elevarq/signals:<version>
 
 aws ecr get-login-password --region us-east-1 \
   | docker login --username AWS --password-stdin "$MP"
 aws ecr get-login-password --region us-east-1 \
   | helm registry login --username AWS --password-stdin "$MP"
 
-# Image: multi-arch copy ghcr -> Marketplace ECR (no skopeo)
+# Image: select the platform manifests only (skip attestation-manifest /
+# unknown/unknown), then rebuild the index from those digests.
+mapfile -t D < <(docker buildx imagetools inspect --raw "$SRC" \
+  | jq -r '.manifests[]
+      | select((.platform.architecture // "") != "unknown")
+      | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
+      | .digest')
 docker buildx imagetools create \
-  -t "$MP/$NS/elevarq-signals:1.0.0" ghcr.io/elevarq/signals:1.0.0
+  -t "$MP/$NS/elevarq-signals:<version>" "${D[@]/#/ghcr.io/elevarq/signals@}"
 
 # Chart: pull, repoint default image to the MP ECR repo, rename so it lands at
 # the granted repo path, repackage, push (see "Chart path gotcha" below).
 ```
 
 [`scripts/marketplace-ecr-push.sh`](../../../scripts/marketplace-ecr-push.sh)
-automates the chart repackage/rename and asserts no `ghcr.io` image remains.
+automates both: it copies platform manifests only (asserting the destination
+index has zero `unknown/unknown` manifests), and repackages/renames the chart
+(asserting no `ghcr.io` image remains).
 
 To find the created ECR repo URIs after step 1:
 

--- a/scripts/marketplace-ecr-push.sh
+++ b/scripts/marketplace-ecr-push.sh
@@ -25,10 +25,11 @@
 #   AWS_REGION      default us-east-1
 #   AWS_PROFILE     default elevarq
 #
-# Requires: aws, docker (with buildx), helm. Auth is via
+# Requires: aws, docker (with buildx), helm, jq. Auth is via
 # `aws ecr get-login-password` (no long-lived creds). skopeo is NOT required —
-# `docker buildx imagetools create` copies the multi-arch manifest
-# registry-to-registry.
+# `docker buildx imagetools create` rebuilds the multi-arch index from the
+# source platform digests, registry-to-registry (attestation manifests
+# excluded — see the image-copy step below).
 
 set -euo pipefail
 
@@ -52,7 +53,7 @@ SOURCE_IMAGE="${SOURCE_IMAGE:-ghcr.io/elevarq/signals:${VERSION}}"
 SOURCE_CHART="${SOURCE_CHART:-oci://ghcr.io/elevarq/charts/signals}"
 export AWS_REGION AWS_PROFILE
 
-for bin in aws docker helm; do
+for bin in aws docker helm jq; do
   command -v "$bin" >/dev/null 2>&1 || die "missing required tool: $bin"
 done
 docker buildx version >/dev/null 2>&1 || die "docker buildx is required"
@@ -72,13 +73,45 @@ printf '%s' "$PW" | helm registry login --username AWS --password-stdin "$MP_REG
 
 DEST_IMAGE="${MP_REGISTRY}/${MP_IMAGE_REPO}:${VERSION}"
 
-echo "==> Copying image (multi-arch manifest preserved)"
+echo "==> Copying image (platform manifests only; attestations stripped)"
 echo "    ${SOURCE_IMAGE}  ->  ${DEST_IMAGE}"
-# `imagetools create` copies the full manifest list (linux/amd64 + linux/arm64)
-# registry-to-registry, as-is. Note: cosign signatures live under separate .sig
-# tags and are NOT copied; AWS Marketplace scans (and may re-sign) the image on
-# ingestion regardless.
-docker buildx imagetools create -t "${DEST_IMAGE}" "${SOURCE_IMAGE}"
+# Copy ONLY the platform image manifests, by digest — never the whole index.
+# A release built with `sbom: true` / `provenance: mode=max` carries SBOM/SLSA
+# attestation manifests (the `unknown/unknown` entries) in its OCI index.
+# Copying the whole index makes AWS Marketplace ingestion fail with
+# SECURITY_ISSUES_DETECTED "...UnsupportedImageType" (a format error, not a
+# CVE). So select the `image`-type platform manifests and rebuild the index
+# from those digests. cosign signatures live under separate .sig tags and are
+# NOT copied; AWS re-scans (and may re-sign) on ingestion regardless.
+# See Elevarq/Signals#283.
+SOURCE_REPO="${SOURCE_IMAGE%:*}"
+SRC_REFS=()
+while IFS= read -r digest; do
+  [ -n "$digest" ] || continue
+  SRC_REFS+=("${SOURCE_REPO}@${digest}")
+done < <(
+  docker buildx imagetools inspect --raw "${SOURCE_IMAGE}" \
+    | jq -r '.manifests[]
+        | select((.platform.os // "") != "unknown"
+                 and (.platform.architecture // "") != "unknown")
+        | select((.annotations["vnd.docker.reference.type"] // "")
+                 != "attestation-manifest")
+        | .digest'
+)
+[ "${#SRC_REFS[@]}" -ge 1 ] \
+  || die "no platform manifests found in ${SOURCE_IMAGE}"
+echo "    platform manifests: ${#SRC_REFS[@]}"
+docker buildx imagetools create -t "${DEST_IMAGE}" "${SRC_REFS[@]}"
+
+# Fail closed: assert the destination index carries no attestation/unknown
+# manifest. If any slipped through, AWS ingestion would fail UnsupportedImageType.
+unknown_count="$(
+  docker buildx imagetools inspect --raw "${DEST_IMAGE}" \
+    | jq '[.manifests[]
+        | select((.platform.architecture // "") == "unknown")] | length'
+)"
+[ "${unknown_count}" = "0" ] \
+  || die "destination index has ${unknown_count} unknown/unknown manifest(s) — AWS ingestion would fail UnsupportedImageType"
 
 echo "==> Repackaging + pushing Helm chart"
 # AWS rejects Helm charts whose images live outside the Marketplace ECR repos


### PR DESCRIPTION
## Summary

`scripts/marketplace-ecr-push.sh` re-hosted the released image with
`docker buildx imagetools create -t DEST SOURCE`, copying the **entire** ghcr
OCI index. Since `release.yml` builds with `sbom: true` + `provenance: mode=max`,
that index carries SBOM/SLSA **attestation manifests** (`unknown/unknown`), and
AWS Marketplace ingestion rejects it with `SECURITY_ISSUES_DETECTED: ...UnsupportedImageType`.
Verified while re-hosting **v1.0.1** (the copy had to be done by hand).

## Changes

- Image copy now selects only the `image`-type platform manifests (skips
  `attestation-manifest` / `unknown/unknown`) and rebuilds the index from those
  digests.
- **Fail closed:** asserts the destination index has 0 `unknown/unknown`
  manifests after the copy.
- Adds `jq` to the required-tools check (now used by the copy step).
- Updates `docs/marketplace/catalog-api/README.md` re-host commands to the
  platform-digest-only pattern.
- Bash-3.2 portable (no `mapfile`) so it runs on macOS operators too.

## Testing

- `bash -n` syntax: pass
- `shellcheck`: clean
- `scripts/check-docs.sh`: pass
- Selector verified against the live `ghcr.io/elevarq/signals:1.0.1` index —
  yields exactly the 2 platform digests, excludes both attestation manifests.

Not a product/behavioral change (operator tooling only), so no CHANGELOG entry.

Closes #283