### PR TITLE
fix(helm): expose buyer config surface in values.schema.json for the EKS add-on (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Helm chart `values.schema.json` now declares the buyer-configurable surface
+  (`target.*`, `persistence.storageClass`, `serviceAccount.annotations`, `api`,
+  `env`, `extraVolumes`/`extraVolumeMounts`, alongside the existing `extraEnv`
+  guard). AWS derives the Amazon EKS add-on configuration schema from this file,
+  so the previous `extraEnv`-only schema left the add-on reporting "No
+  configuration support" — a buyer could not point it at a database. The schema
+  also adds enum validation for `target.sslmode`/`authMethod`, `env`, and
+  `image.pullPolicy`. No change to rendered manifests for existing values
+  (#285). Reaches the live EKS add-on only via a re-hosted, re-submitted release.
+
 ## [1.0.1] - 2026-07-17
 
 ### Security

--- a/deploy/helm/signals/values.schema.json
+++ b/deploy/helm/signals/values.schema.json
@@ -1,10 +1,78 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": false,
+  "description": "Elevarq Signals chart values. Also the source of the Amazon EKS add-on configuration schema (AWS derives describe-addon-configuration from this file), so the buyer-configurable surface must be declared here for the add-on to reach behavioral parity with the Helm delivery (marketplace-eks-addon-delivery.md, R-EAO-07 / INV-EAO-02).",
   "properties": {
+    "image": {
+      "type": "object",
+      "description": "Container image. Pinned to the Marketplace-ECR artifact for the add-on; override only for private mirrors.",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "target": {
+      "type": "object",
+      "description": "PostgreSQL target. Set host to enable collection; token/secret auth methods require sslmode verify-full.",
+      "properties": {
+        "host": { "type": "string", "description": "PostgreSQL hostname (e.g. the RDS endpoint). Required to enable collection." },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "dbname": { "type": "string" },
+        "user": { "type": "string" },
+        "sslmode": { "type": "string", "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"] },
+        "authMethod": { "type": "string", "enum": ["", "aws_rds_iam", "azure_entra", "gcp_cloudsql_iam", "secret_store"] },
+        "region": { "type": "string" },
+        "azureClientId": { "type": "string" },
+        "gcpImpersonateServiceAccount": { "type": "string" },
+        "secretRef": { "type": "string" },
+        "sslRootCertFile": { "type": "string" },
+        "passwordSecretName": { "type": "string" },
+        "passwordSecretKey": { "type": "string" }
+      }
+    },
+    "collector": {
+      "type": "object",
+      "properties": {
+        "pollInterval": { "type": "string" },
+        "retentionDays": { "type": "integer", "minimum": 0 },
+        "targetTimeout": { "type": "string" },
+        "queryTimeout": { "type": "string" }
+      }
+    },
+    "api": {
+      "type": "object",
+      "properties": {
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "tokenSecretName": { "type": "string", "description": "Kubernetes Secret holding the API bearer token; recommended for production so the token survives restarts." },
+        "tokenSecretKey": { "type": "string" },
+        "tls": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "env": { "type": "string", "enum": ["dev", "lab", "prod"], "description": "Runtime environment. prod hard-fails on weak API tokens and requires verify-full for token auth." },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "annotations": {
+          "type": "object",
+          "description": "Identity binding, e.g. eks.amazonaws.com/role-arn for IRSA (passwordless RDS IAM)."
+        }
+      }
+    },
+    "podLabels": {
+      "type": "object"
+    },
     "extraEnv": {
       "type": "array",
       "default": [],
+      "description": "Additional non-secret environment variables. Secret values must use valueFrom. Chart-managed SIGNALS_* names are rejected at render.",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -27,6 +95,28 @@
           { "required": ["valueFrom"] }
         ]
       }
-    }
+    },
+    "extraVolumes": {
+      "type": "array",
+      "description": "Extra pod volumes, e.g. a Secret/ConfigMap holding the verify-full CA bundle.",
+      "items": { "type": "object" }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "description": "Mounts for extraVolumes, e.g. the CA bundle at target.sslRootCertFile.",
+      "items": { "type": "object" }
+    },
+    "networkPolicy": { "type": "object" },
+    "podDisruptionBudget": { "type": "object" },
+    "resources": { "type": "object" },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "size": { "type": "string" },
+        "storageClass": { "type": "string", "description": "StorageClass for the collector's PersistentVolume. On EKS set an EBS-CSI class (e.g. an encrypted gp3)." }
+      }
+    },
+    "securityContext": { "type": "object" }
   }
 }

--- a/specifications/marketplace-eks-addon-delivery.acceptance.md
+++ b/specifications/marketplace-eks-addon-delivery.acceptance.md
@@ -133,3 +133,29 @@ add-on flow, against a reachable RDS target.
 - The script exits non-zero before `start-change-set`.
 - The unsubstituted-`${...}` guard (FC-EAO-01) or the non-ASCII guard
   (FC-EAO-02) reports the offending content.
+
+---
+
+### TC-EAO-07: Chart values.schema.json exposes the add-on config contract (invariant)
+
+**Rule:** R-EAO-07 / FC-EAO-05 / INV-EAO-02
+
+**Scenario:** Guard against shipping an add-on that `aws eks
+describe-addon-configuration` reports as "No configuration support", which leaves
+a buyer unable to point the add-on at a database.
+
+**Given:**
+- `deploy/helm/signals/values.schema.json`.
+
+**When:**
+- The schema is parsed and its declared properties are inspected.
+
+**Then:**
+- `target` declares `host`, `user`, `authMethod`, `sslmode`, and
+  `sslRootCertFile`.
+- `persistence` declares `storageClass`.
+- `serviceAccount` declares `annotations`.
+- `extraEnv` is still declared (the chart-managed-name guard is preserved).
+- `helm template` with the default values and with a representative buyer values
+  file both still validate against the schema (no regression for existing Helm
+  installs).

--- a/specifications/marketplace-eks-addon-delivery.md
+++ b/specifications/marketplace-eks-addon-delivery.md
@@ -81,6 +81,19 @@ In scope:
 - **R-EAO-06**: EKS add-on delivery-option visibility is **not** auto-Public
   (unlike Helm/container options). Making the add-on public is a separate
   `UpdateDeliveryOptions`/visibility step, gated on an explicit go.
+- **R-EAO-07**: The add-on's buyer configuration surface is **derived by AWS from
+  the Helm chart's `values.schema.json`** (`aws eks describe-addon-configuration`
+  returns it; a chart with no declared configurable properties yields *"No
+  configuration support"*). Because `create-addon` is the only way an add-on
+  buyer supplies values, `deploy/helm/signals/values.schema.json` MUST declare
+  the buyer-configurable contract — at minimum `target.host`, `target.user`,
+  `target.authMethod`, `target.sslmode`, `target.sslRootCertFile`,
+  `persistence.storageClass`, and `serviceAccount.annotations` — so the add-on
+  can be pointed at a database (and given passwordless-IAM identity + TLS +
+  durable storage). Without it, INV-EAO-02 is unreachable via the add-on path.
+  The schema change ships in the chart and reaches the live add-on only via a
+  new released version that is re-hosted and re-submitted (the config schema is
+  derived at ingestion, per release).
 
 ## Invariants
 
@@ -106,6 +119,12 @@ In scope:
 - **FC-EAO-04**: `ContainerImages`/`HelmChartUri` pointing at a
   non-Marketplace-ECR (e.g. `ghcr.io`) artifact → AWS rejects on ingestion;
   preflight asserts MP-ECR.
+- **FC-EAO-05**: The chart's `values.schema.json` declares no buyer-configurable
+  properties (or omits the required keys in R-EAO-07) →
+  `describe-addon-configuration` reports *"No configuration support"* → the
+  add-on cannot be pointed at a database and INV-EAO-02 is unreachable. Guard: a
+  chart test asserts `values.schema.json` exposes the required configurable keys
+  (Elevarq/Signals#285).
 
 ## Constraints
 

--- a/tests/signals_helm_addon_config_schema_test.go
+++ b/tests/signals_helm_addon_config_schema_test.go
@@ -1,0 +1,59 @@
+package tests
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// The Amazon EKS add-on configuration schema is derived by AWS from the chart's
+// values.schema.json (aws eks describe-addon-configuration). If the required
+// buyer-configurable keys are absent, the add-on reports "No configuration
+// support" and cannot be pointed at a database, so it cannot reach behavioral
+// parity with the Helm delivery. Guards R-EAO-07 / FC-EAO-05 / INV-EAO-02 of
+// specifications/marketplace-eks-addon-delivery.md (Elevarq/Signals#285).
+func TestHelm_ValuesSchemaExposesAddOnConfigContract(t *testing.T) {
+	raw, err := os.ReadFile("../deploy/helm/signals/values.schema.json")
+	if err != nil {
+		t.Fatalf("read values.schema.json: %v", err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("values.schema.json is not valid JSON: %v", err)
+	}
+
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("values.schema.json has no top-level \"properties\" object")
+	}
+
+	// Nested buyer-configurable keys the add-on install path requires
+	// (R-EAO-07): parent -> child properties that must be declared.
+	nested := map[string][]string{
+		"target":         {"host", "user", "authMethod", "sslmode", "sslRootCertFile"},
+		"persistence":    {"storageClass"},
+		"serviceAccount": {"annotations"},
+	}
+	for parent, children := range nested {
+		p, ok := props[parent].(map[string]any)
+		if !ok {
+			t.Errorf("values.schema.json: missing configurable property %q", parent)
+			continue
+		}
+		cp, ok := p["properties"].(map[string]any)
+		if !ok {
+			t.Errorf("values.schema.json: %q declares no sub-properties", parent)
+			continue
+		}
+		for _, child := range children {
+			if _, ok := cp[child]; !ok {
+				t.Errorf("values.schema.json: %q must declare %q for the add-on config schema", parent, child)
+			}
+		}
+	}
+
+	// The chart-managed extraEnv guard must survive the expansion.
+	if _, ok := props["extraEnv"]; !ok {
+		t.Errorf("values.schema.json: extraEnv property was dropped (the #274 guard must be preserved)")
+	}
+}


### PR DESCRIPTION
## Summary

AWS derives the Amazon EKS add-on configuration schema from the chart's
`values.schema.json` ([AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/creating-an-add-on.html);
confirmed via `describe-addon-configuration`). The prior schema described **only
`extraEnv`**, so `aws eks describe-addon-configuration --addon-name elevarq_signals`
returned **"No configuration support"** for both v1.0.0 and v1.0.1. With no
config, an add-on buyer cannot set `target.host`, `persistence.storageClass`, or
the `serviceAccount` IRSA annotation — the add-on collects nothing and cannot
reach behavioral parity with the Helm delivery (spec INV-EAO-02).

Found during the #236 full add-on-install verification (at the config-schema
inspection, before a cluster spin).

## Changes

- `deploy/helm/signals/values.schema.json`: declare the buyer-configurable surface
  (`target.*`, `persistence.storageClass`, `serviceAccount.annotations`, `api`,
  `env`, `extraVolumes`/`extraVolumeMounts`, `image`, `collector`, `resources`,
  etc.), keeping the strict `extraEnv` item guard. Adds enum validation for
  `target.sslmode`/`authMethod`, `env`, `image.pullPolicy`. Top-level
  `additionalProperties: false` with every existing key enumerated (rejects typos
  without breaking valid installs).
- Spec: **R-EAO-07** (values.schema.json must expose the config contract) +
  **FC-EAO-05**; acceptance **TC-EAO-07**.
- `tests/signals_helm_addon_config_schema_test.go`: asserts the schema exposes the
  required keys and preserves `extraEnv` (fails against the pre-fix extraEnv-only
  schema).

## Testing

- New test + full `go test ./tests/` pass (no regression; caught + fixed one
  over-strict `podLabels`/`annotations` typing mid-review).
- `helm template` with default values **and** a representative buyer values file
  both validate; bad `sslmode` enum and chart-managed `extraEnv` name still
  rejected.
- gofmt/vet, helm lint, docs guard: clean.

## Delivery note

`values.schema.json` reaches the **live** EKS add-on only via a new released
version (1.0.2) that is re-hosted + re-submitted (the config schema is derived at
ingestion, per release). This PR is the source fix; the re-release + re-submit is
the follow-on operator step.

Closes #285. Unblocks #236.