### PR TITLE
release: v1.0.2 — EKS add-on configurable via values.schema.json (#287)

### DIFF
--- a/.github/workflows/aws-rds-iam-live-smoke.yml
+++ b/.github/workflows/aws-rds-iam-live-smoke.yml
@@ -53,7 +53,7 @@ on:
       image_uri:
         description: Signals container image (pinned tag)
         required: false
-        default: ghcr.io/elevarq/signals:1.0.1
+        default: ghcr.io/elevarq/signals:1.0.2
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-07-19
+
 ### Fixed
 
 - Helm chart `values.schema.json` now declares the buyer-configurable surface

--- a/deploy/aws/LIVE-SMOKE.md
+++ b/deploy/aws/LIVE-SMOKE.md
@@ -79,7 +79,7 @@ fill the inputs:
 | `security_group_ids` | `["sg-0123…"]` | **JSON array** string |
 | `db_user` | `signals` | role granted `rds_iam` + `pg_monitor` |
 | `name_prefix` | `signals-livesmoke` | prefixes the throwaway resources |
-| `image_uri` | `ghcr.io/elevarq/signals:1.0.1` | pinned tag |
+| `image_uri` | `ghcr.io/elevarq/signals:1.0.2` | pinned tag |
 
 A green run means: the collector minted an RDS IAM token from its instance
 role, connected `verify-full` with **no password on disk**, and produced

--- a/deploy/aws/cloudformation/signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/signals-rds-iam.yaml
@@ -38,7 +38,7 @@ Parameters:
     Default: t3.small
   ImageUri:
     Type: String
-    Default: ghcr.io/elevarq/signals:1.0.1
+    Default: ghcr.io/elevarq/signals:1.0.2
     Description: Elevarq Signals container image (pinned tag).
   Env:
     Type: String

--- a/deploy/aws/imagebuilder/README.md
+++ b/deploy/aws/imagebuilder/README.md
@@ -34,7 +34,7 @@ same posture as the container and Helm deliveries.
 
 | Parameter | Default | Notes |
 |-----------|---------|-------|
-| `SignalsImage` | `ghcr.io/elevarq/signals:1.0.1` | Pinned version (no `latest`). Bump per release. |
+| `SignalsImage` | `ghcr.io/elevarq/signals:1.0.2` | Pinned version (no `latest`). Bump per release. |
 
 ### Baking locally / in a pipeline
 
@@ -44,7 +44,7 @@ Linux 2023 base image. Register it and reference it from a recipe:
 ```bash
 aws imagebuilder create-component \
   --name signals-collector \
-  --semantic-version 1.0.1 \
+  --semantic-version 1.0.2 \
   --platform Linux \
   --data file://signals-collector-component.yaml
 # -> ComponentArn, referenced by an image recipe + pipeline that produces the AMI.

--- a/deploy/aws/imagebuilder/signals-collector-component.yaml
+++ b/deploy/aws/imagebuilder/signals-collector-component.yaml
@@ -18,7 +18,7 @@ schemaVersion: 1.0
 parameters:
   - SignalsImage:
       type: string
-      default: "ghcr.io/elevarq/signals:1.0.1"
+      default: "ghcr.io/elevarq/signals:1.0.2"
       description: >-
         Pinned Signals image reference to pre-pull into the AMI. MUST be a
         specific version tag (no 'latest') so the AMI is reproducible (R-AMI-02).

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "instance_type" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:1.0.1"
+  default     = "ghcr.io/elevarq/signals:1.0.2"
 }
 
 variable "env" {

--- a/deploy/azure/bicep/main.bicep
+++ b/deploy/azure/bicep/main.bicep
@@ -46,7 +46,7 @@ param adminUsername string = 'azureuser'
 param adminSshPublicKey string
 
 @description('Elevarq Signals container image (pinned tag).')
-param imageUri string = 'ghcr.io/elevarq/signals:1.0.1'
+param imageUri string = 'ghcr.io/elevarq/signals:1.0.2'
 
 @description('URL of the CA bundle for sslmode=verify-full. Default is the DigiCert Global Root G2 that Azure Database for PostgreSQL Flexible Server chains to.')
 param dbCaCertUrl string = 'https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem'

--- a/deploy/azure/terraform/variables.tf
+++ b/deploy/azure/terraform/variables.tf
@@ -66,7 +66,7 @@ variable "admin_ssh_public_key" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:1.0.1"
+  default     = "ghcr.io/elevarq/signals:1.0.2"
 }
 
 variable "db_ca_cert_url" {

--- a/deploy/gcp/terraform/variables.tf
+++ b/deploy/gcp/terraform/variables.tf
@@ -82,7 +82,7 @@ variable "image" {
 variable "image_uri" {
   type        = string
   description = "Elevarq Signals container image (pinned tag)."
-  default     = "ghcr.io/elevarq/signals:1.0.1"
+  default     = "ghcr.io/elevarq/signals:1.0.2"
 }
 
 variable "env" {

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 1.0.1
-appVersion: "1.0.1"
+version: 1.0.2
+appVersion: "1.0.2"
 keywords:
   - postgresql
   - monitoring

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "1.0.1"
+  tag: "1.0.2"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration. Rendered into the mounted


### PR DESCRIPTION
## Summary

Prepares **v1.0.2**, delivering the #285 chart `values.schema.json` fix so the
Amazon EKS add-on exposes a usable configuration schema (was "No configuration
support"). Version bump only — the schema fix landed in #286.

## Changes
- `Chart.yaml` version/appVersion + `values.yaml` image tag: 1.0.1 -> 1.0.2.
- `CHANGELOG.md`: dated `[1.0.2]` section (the #285 entry) + empty `[Unreleased]`.
- Cloud deploy-example image pins 1.0.1 -> 1.0.2 (version consistency).

## Out of scope
- Marketplace listing docs (bump with the re-host).

## Release sequence (after merge)
1. Merge → verify main HEAD carries the bump → tag `v1.0.2` (human gate).
2. Publish workflow builds + signs image + chart.
3. Re-host 1.0.2 to MP ECR (using the fixed marketplace-ecr-push.sh, #284).
4. Re-submit the EKS add-on at 1.0.2; verify describe-addon-configuration; live create-addon; then Public review. Unblocks #236.

## Testing
- helm lint clean; template renders `ghcr.io/elevarq/signals:1.0.2`.
- actionlint clean; check-docs passes; gofmt clean; no Go changed.

Closes #287