### PR TITLE
spec(ami): live AmiProduct@1.0 standup uses AmiSource, not a component ARN (#235)

### DIFF
--- a/deploy/aws/imagebuilder/README.md
+++ b/deploy/aws/imagebuilder/README.md
@@ -50,24 +50,30 @@ aws imagebuilder create-component \
 # -> ComponentArn, referenced by an image recipe + pipeline that produces the AMI.
 ```
 
-## Live AMI product (deferred — demand-gated, #235)
+## Live AMI product (#235 — un-deferred 2026-07-19)
 
-Publishing the baked AMI as a Marketplace **`AmiProduct@1.0`** is a *separate
-product* with its own onboarding and review, pursued only on **real demand for
-non-container, EC2-baked deployment** (#235's gate). It is NOT set up here and no
-runnable change-set is committed for it. When demand justifies it, the Catalog
-API path is:
+Publishing Signals as a Marketplace **`AmiProduct@1.0`** is a *separate product*
+with its own onboarding and review (#235; un-deferred per the #233 decision log).
+Governed by `specifications/marketplace-ami-product.md`.
 
-1. `CreateProduct` with `Type: AmiProduct@1.0` (separate from the container
+**The AMI product ships a *pre-baked AMI*, not the component.** The AWS
+Marketplace Catalog API AMI delivery option is `AmiDeliveryOptionDetails` →
+`AmiSource` (a built `AmiId` + an `AccessRoleArn` AWS uses to scan/copy it); there
+is **no** `ComponentArn` field. This component is the reproducible **build input**
+for that AMI, not the thing sold. The Catalog-API path is:
+
+1. Bake a golden AMI: an EC2 Image Builder image recipe (Amazon Linux 2023 base +
+   this `signals-collector` component at the released version) → `AmiId`.
+2. `CreateProduct` with `Type: AmiProduct@1.0` (separate from the container
    product `prod-...`).
-2. `UpdateInformation` — title, descriptions, logo (S3), categories, keywords
+3. `UpdateInformation` — title, descriptions, logo (S3), categories, keywords
    (reuse the shared Elevarq assets).
-3. Offer + legal terms (`CustomEula`) + support terms; free offer takes no
+4. Offer + legal terms (`CustomEula`) + support terms; free offer takes no
    pricing term.
-4. `AddDeliveryOptions` for the AMI, providing the Image Builder integration:
-   the component `ComponentArn` and an `AccessRoleArn` AWS Marketplace assumes to
-   read it, so buyers find the component in EC2 Image Builder.
-5. `ReleaseProduct` + `ReleaseOffer`, then `UpdateVisibility: Public` (Seller-Ops
+5. `AddDeliveryOptions` with `AmiDeliveryOptionDetails`: the `AmiSource`
+   (`AmiId` + the AMI-product `AccessRoleArn`), `OperatingSystem`,
+   `RecommendedInstanceType`, supported instance types, and regions.
+6. `ReleaseProduct` + `ReleaseOffer`, then `UpdateVisibility: Public` (Seller-Ops
    review).
 
 Human gates (never automate): the EULA/entity wording (counsel), the AMI build

--- a/specifications/marketplace-ami-image-builder.md
+++ b/specifications/marketplace-ami-image-builder.md
@@ -35,9 +35,10 @@ In scope (shipped now):
 - `deploy/aws/imagebuilder/signals-collector-component.yaml` — an AWSTOE
   (`schemaVersion: 1.0`) component with `build`, `validate`, and `test` phases.
 - `deploy/aws/imagebuilder/README.md` — how the component works, and the
-  demand-gated `AmiProduct@1.0` publish path scaffolding (Catalog API
-  `CreateProduct` + `AddDeliveryOptions` with `ComponentArn` + `AccessRoleArn` +
-  visibility), documented but not run.
+  `AmiProduct@1.0` publish path (Catalog API `CreateProduct` +
+  `AddDeliveryOptions` with `AmiDeliveryOptionDetails`/`AmiSource` — the component
+  is the AMI *build input*, not a delivery field; the live standup is #235,
+  governed by `specifications/marketplace-ami-product.md`).
 - This spec + acceptance cases.
 
 Out of scope (deferred, demand-gated):

--- a/specifications/marketplace-ami-product.acceptance.md
+++ b/specifications/marketplace-ami-product.acceptance.md
@@ -1,0 +1,114 @@
+# Acceptance Tests: Marketplace AMI Product (live AmiProduct@1.0 standup)
+
+## Feature
+
+`specifications/marketplace-ami-product.md`
+
+## Test Cases
+
+### TC-AMIP-01: AMI baked only from the committed component + pinned image (invariant)
+
+**Rule:** INV-AMIP-01 / FC-AMIP-01 / R-AMIP-02
+
+**Scenario:** The listed AMI must be traceable to the reviewed component + a
+pinned released image, not an out-of-band hand-built AMI.
+
+**Given:**
+- The EC2 Image Builder image recipe and the `create-component` at the released
+  semantic version, whose `data` equals
+  `deploy/aws/imagebuilder/signals-collector-component.yaml`.
+
+**When:**
+- The recipe's components and the component's `SignalsImage` are inspected.
+
+**Then:**
+- The recipe uses the `signals-collector` component (byte-identical `data`) on an
+  Amazon Linux 2023 base and no divergent inline packages.
+- `SignalsImage` is a pinned tag (no `latest`), matching the released version.
+
+---
+
+### TC-AMIP-02: AccessRole is least-privilege (invariant)
+
+**Rule:** R-AMIP-04 / FC-AMIP-02
+
+**Scenario:** Guard against an over-broad role AWS Marketplace assumes to
+scan/copy the AMI.
+
+**Given:**
+- The `AccessRoleArn` policy document and trust policy.
+
+**When:**
+- The attached policy is inspected.
+
+**Then:**
+- The policy grants only the AWS-documented AMI-product access (AMI
+  scan/copy — e.g. the `AWSMarketplaceAmiIngestion`-scoped actions), scoped to
+  the listed AMI/snapshot resources.
+- The trust policy is scoped to the AWS Marketplace service principal.
+- No `ec2:*`, no wildcard resource.
+
+---
+
+### TC-AMIP-03: Change-set copy is ASCII-only and fully substituted (failure)
+
+**Rule:** R-AMIP-05 / FC-AMIP-03
+
+**Scenario:** A standup run leaves a `${...}` unsubstituted or pastes smart
+punctuation into the description.
+
+**Given:**
+- The AMI product change-set(s) rendered by `scripts/marketplace-changeset.sh`.
+
+**When:**
+- The render + guards run.
+
+**Then:**
+- The script exits non-zero before `start-change-set` on any leftover `${...}`
+  or non-ASCII byte.
+- `VersionTitle`/advertised version is the real released SemVer (no literal
+  `${VERSION}`).
+
+---
+
+### TC-AMIP-04: Separate product, container product untouched (invariant)
+
+**Rule:** R-AMIP-01
+
+**Scenario:** The AMI standup must not modify or bundle with the container
+product.
+
+**Given:**
+- The `CreateProduct` change-set with `Type: AmiProduct@1.0`.
+
+**When:**
+- The change-set is inspected.
+
+**Then:**
+- It creates a new `AmiProduct@1.0` entity, not a delivery option or edit on
+  `prod-7tz6zxncwjmw4`.
+- No change references the container product id.
+
+---
+
+### TC-AMIP-05: Live baked-AMI parity smoke (deferred — gated)
+
+**Rule:** INV-AMIP-02
+
+**Scenario:** A buyer bakes an AMI with the shared component and boots it with
+launch-supplied config.
+
+**Given:**
+- An AMI baked from an Amazon Linux 2023 recipe + the `signals-collector`
+  component, launched with `/etc/signals` config supplied at launch.
+
+**When:**
+- The instance boots and `signals.service` starts.
+
+**Then:**
+- The collector runs (same image, read-only, passwordless onboarding) and
+  produces a snapshot equivalent to the container/Helm deliveries.
+- No credentials are present in the AMI itself (INV-AMI-01).
+
+This is a live, gated smoke (real AMI bake + launch); run when the standup
+reaches representative-environment validation.

--- a/specifications/marketplace-ami-product.md
+++ b/specifications/marketplace-ami-product.md
@@ -1,0 +1,138 @@
+# Marketplace AMI Product (live AmiProduct@1.0 standup)
+
+## Status
+
+DRAFT
+
+## Type
+
+Integration mapping — contract between a **pre-baked Signals golden AMI** (built
+by EC2 Image Builder from the committed `signals-collector` component) and a live
+AWS Marketplace `AmiProduct@1.0` listing that shares that AMI. Tests mandatory
+for the statically-checkable parts; the live AMI bake, submit, and AWS review are
+gated operator steps.
+
+## Purpose
+
+Stand up the live `AmiProduct@1.0` Marketplace listing for Signals (#235, part of
+#233), un-deferred by the product owner on 2026-07-19 (see #233 decision log).
+The listing ships a **pre-baked Amazon Linux 2023 AMI** with the collector
+installed by the committed `signals-collector` Image Builder component (docker +
+the pinned `SignalsImage` + the `signals.service` unit). Reach: non-container,
+EC2-baked deployments — buyers launch the AMI and supply config at launch.
+
+**Correction (2026-07-19):** an earlier groundwork premise (share the Image
+Builder *component* via `AddDeliveryOptions` with a `ComponentArn`) does not match
+the AWS Marketplace Catalog API. The AMI product delivery option is
+`AmiDeliveryOptionDetails` → `AmiSource` (a built `AmiId` + an `AccessRoleArn` AWS
+uses to scan it); there is no component ARN in the schema. This spec uses the
+supported model: publish a pre-baked AMI. The EC2 Image Builder component remains
+the reproducible *build input* for that AMI (INV-AMI-01..03 still hold).
+
+## Scope
+
+In scope:
+
+- Build a golden AMI via EC2 Image Builder: an image recipe (Amazon Linux 2023
+  base + the `signals-collector` component at the released version), an
+  infrastructure configuration, and a build that yields an `AmiId`.
+- An `AccessRoleArn` IAM role AWS Marketplace assumes to scan/copy the AMI
+  (the AWS-documented AMI-product access role; least-privilege).
+- Catalog-API standup of a **separate** `AmiProduct@1.0`: `CreateProduct`,
+  `UpdateInformation` (reuse shared Elevarq assets), offer + `CustomEula` +
+  support terms (free — no pricing term), `AddDeliveryOptions` with the
+  `AmiSource` (`AmiId`, `AccessRoleArn`), `OperatingSystem`,
+  `RecommendedInstanceType`, supported instance types, and regions, then
+  `ReleaseProduct` + `ReleaseOffer`.
+- Documentation of the sequence + identifiers under `docs/marketplace/`.
+
+Out of scope:
+
+- Any change to the container product (`prod-7tz6zxncwjmw4`) or its options.
+- Component-catalog "Image Builder integration" (a separate mechanism; not this
+  Catalog-API path).
+- Pricing (free product).
+
+## Interfaces
+
+### Inputs
+
+| Field | Value / constraint |
+|-------|--------------------|
+| Image recipe | Amazon Linux 2023 base + `signals-collector` component at the released SemVer; `SignalsImage` pinned (R-AMI-02). |
+| `Type` | `AmiProduct@1.0` (separate product; not a delivery option on the container product). |
+| `AmiSource.AmiId` | The built golden AMI id in the seller account. |
+| `AmiSource.AccessRoleArn` | IAM role trusted by AWS Marketplace for AMI scanning/copy — the AWS-documented AMI-product access role, least-privilege. |
+| `OperatingSystem` | Amazon Linux 2023 (name + version), matching the recipe base. |
+| `RecommendedInstanceType` | A small general-purpose type (e.g. `t3.small`); the collector is lightweight. |
+| Supported instance types / Regions | The validated set (honest-claim; only what is tested). |
+| `UsageInstructions` | ASCII, launch-time config path: how the buyer supplies `/etc/signals/signals.yaml`, the RDS CA, and `SIGNALS_API_TOKEN` via user-data/SSM; how `signals.service` starts on first boot. |
+| `UpdateInformation` | Title, ShortDescription (≤1000), LongDescription (≤5000), Highlights (1-3), Categories (`Infrastructure Software`), SearchKeywords (≤15), LogoUrl (shared S3 Elevarq logo). ASCII-only. |
+| `LegalTerm` | `CustomEula` → the shared Elevarq EULA PDF in S3. |
+
+### Outputs
+
+- A `Limited` `AmiProduct@1.0` listing shipping the pre-baked AMI, pending the
+  explicit-go Public submit.
+
+## Rules
+
+- **R-AMIP-01**: Separate product. MUST NOT modify the container product or bundle
+  with #234/#236 (umbrella decision 3 — its own AWS review round).
+- **R-AMIP-02**: The AMI is baked from the committed `signals-collector` component
+  at a pinned `SignalsImage` (no `latest`) — reproducible and traceable to a
+  released image (R-AMI-02).
+- **R-AMIP-03**: Credentials-by-reference — the baked AMI contains no secret,
+  token, or database config (INV-AMI-01); buyer supplies config at launch.
+- **R-AMIP-04**: `AccessRoleArn` is the least-privilege AMI-product access role
+  AWS documents (AMI scan/copy on the specific AMI), trust scoped to the AWS
+  Marketplace service principal. No broader EC2 permissions.
+- **R-AMIP-05**: Change-set copy is ASCII-only and fully `${...}`-substituted
+  (same guards as the container change-sets; `${VERSION}==literal` trap and
+  version immutability apply).
+
+## Invariants
+
+- **INV-AMIP-01** (traceable bake): the AMI is built solely from the committed
+  component + the pinned released image on an AL2023 base — no out-of-band
+  manual mutation.
+- **INV-AMIP-02** (parity): a collector from the baked AMI (given buyer-supplied
+  config at launch) equals the container/Helm collector — same image, read-only
+  enforcement, passwordless onboarding (inherits INV-AMI-02).
+
+## Failure Conditions
+
+- **FC-AMIP-01**: The AMI is built from anything other than the committed
+  component + pinned image (out-of-band packages, unpinned image) → violates
+  INV-AMIP-01 / R-AMIP-02.
+- **FC-AMIP-02**: `AccessRoleArn` grants more than the documented AMI-product
+  scan/copy access → violates R-AMIP-04.
+- **FC-AMIP-03**: Non-ASCII / unsubstituted `${...}` in a rendered change-set →
+  script guards exit non-zero before `start-change-set`.
+- **FC-AMIP-04**: A secret/token/config baked into the AMI → violates R-AMIP-03 /
+  INV-AMI-01.
+
+## Constraints
+
+- The released image the component pins (`SignalsImage`) MUST exist before the
+  bake (the release is published) — the AMI pre-pulls it at build time.
+- `AmiProduct@1.0` uses the Catalog-API AMI schema (`AmiDeliveryOptionDetails` /
+  `AmiSource`); the container-product `ContainerProduct@1.0` schema does not
+  apply. All delivery options in one version share the same `AmiSource`, and
+  delivery options cannot be added to an existing version.
+
+## Human gates (never automate)
+
+- EULA / entity wording — counsel (reuse the signed shared Elevarq EULA).
+- AMI build provenance sign-off.
+- Final `UpdateVisibility: Public` submit — explicit go + AWS Seller-Ops review.
+
+## Traceability
+
+specification (this file) -> acceptance cases
+(`marketplace-ami-product.acceptance.md`) -> change-set templates
+`docs/marketplace/catalog-api/06-create-ami-product.json` +
+`07-add-ami-delivery.json`, authored and dry-run validated against the live
+Catalog API (`StartChangeSet` with `Intent: VALIDATE`, which does not create the
+product) during the standup, then submitted + `scripts/marketplace-changeset.sh`
+guards.


### PR DESCRIPTION
## Summary

Un-defers #235 (per the #233 decision log, 2026-07-19) and corrects a
docs-vs-reality error in the committed groundwork.

**The error:** the groundwork README + spec described publishing the AMI product
via `AddDeliveryOptions` with a `ComponentArn` (sharing the EC2 Image Builder
component). The AWS Marketplace Catalog API `AmiProduct@1.0` has **no such
field** — its delivery option is `AmiDeliveryOptionDetails` -> `AmiSource` (a
built `AmiId` + a scan `AccessRoleArn`). Source: [Catalog API — AMI-based products](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/ami-products.html).

**The correction:** the AMI product ships a **pre-baked golden AMI** (Amazon
Linux 2023 + the committed `signals-collector` component -> `AmiId`). The
component is the reproducible *build input*, not a delivery field.

## Changes
- `specifications/marketplace-ami-product.md` (new) — live-standup spec (AmiSource model, human gates).
- `specifications/marketplace-ami-product.acceptance.md` (new) — TC-AMIP-01..05.
- `specifications/marketplace-ami-image-builder.md` — corrected the groundwork scope line.
- `deploy/aws/imagebuilder/README.md` — corrected the "Live AMI product" publish path to AmiSource.

## Testing
- imagebuilder component guard + docs guard: pass. (Component YAML unchanged.)

## Next (this issue, live ops)
Bake the AMI (Image Builder recipe = AL2023 + component at 1.0.2, once the
release image exists), then Catalog-API standup (`CreateProduct AmiProduct@1.0`
-> UpdateInformation -> offer+EULA -> AddDeliveryOptions AmiSource -> release ->
Public review). Change-sets dry-run validated (`Intent: VALIDATE`) before submit.
Human gates: EULA/counsel, AMI provenance, final public submit.

Refs #235.