### PR TITLE
fix(helm): open top-level values.schema.json for add-on ingestion (1.0.3) (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-07-19
+
+### Fixed
+
+- Chart `values.schema.json` no longer sets top-level `additionalProperties:
+  false`. AWS's Amazon EKS add-on ingestion renders the chart with Helm's
+  reserved `global` value injected, and a closed top level made `helm template`
+  fail (`additional properties 'global' not allowed`), so the add-on version
+  failed ingestion with `INVALID_HELM_TEMPLATE`. The declared buyer-configurable
+  properties (from #285) and enum validation are retained, so the derived add-on
+  configuration schema is unchanged; only the top level is left open (#290).
+  Buyer Helm/ECS installs were unaffected (pure-default render always passed).
+
 ## [1.0.2] - 2026-07-19
 
 ### Fixed

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 1.0.2
-appVersion: "1.0.2"
+version: 1.0.3
+appVersion: "1.0.3"
 keywords:
   - postgresql
   - monitoring

--- a/deploy/helm/signals/values.schema.json
+++ b/deploy/helm/signals/values.schema.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
-  "description": "Elevarq Signals chart values. Also the source of the Amazon EKS add-on configuration schema (AWS derives describe-addon-configuration from this file), so the buyer-configurable surface must be declared here for the add-on to reach behavioral parity with the Helm delivery (marketplace-eks-addon-delivery.md, R-EAO-07 / INV-EAO-02).",
+  "description": "Elevarq Signals chart values. Also the source of the Amazon EKS add-on configuration schema (AWS derives describe-addon-configuration from this file), so the buyer-configurable surface must be declared here for the add-on to reach behavioral parity with the Helm delivery (marketplace-eks-addon-delivery.md, R-EAO-07 / INV-EAO-02). NOTE: the top-level object stays open (no additionalProperties:false) because AWS add-on ingestion renders the chart with Helm's reserved `global` value injected, and a closed top level fails `helm template` -> INVALID_HELM_TEMPLATE (#290).",
   "properties": {
     "image": {
       "type": "object",

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "1.0.2"
+  tag: "1.0.3"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration. Rendered into the mounted

--- a/tests/signals_helm_addon_config_schema_test.go
+++ b/tests/signals_helm_addon_config_schema_test.go
@@ -3,8 +3,31 @@ package tests
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
 )
+
+// AWS EKS add-on ingestion renders the chart with Helm's reserved `global`
+// value injected. A top-level `additionalProperties: false` in values.schema.json
+// makes `helm template` fail ("additional properties 'global' not allowed") ->
+// the add-on change-set fails INVALID_HELM_TEMPLATE. The top-level object must
+// stay open. Guards Elevarq/Signals#290 (regression from #285).
+func TestHelm_ValuesSchemaToleratesInjectedGlobal(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm CLI not on PATH; skipping helm-template assertion")
+	}
+	cmd := exec.Command("helm", "template", "signals", "../deploy/helm/signals",
+		"--set", "global.foo=bar")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template with an injected `global` value must render "+
+			"(add-on ingestion injects it); got error: %v\n%s", err, out)
+	}
+	if strings.Contains(string(out), "additional properties") {
+		t.Fatalf("schema rejected an injected top-level key:\n%s", out)
+	}
+}
 
 // The Amazon EKS add-on configuration schema is derived by AWS from the chart's
 // values.schema.json (aws eks describe-addon-configuration). If the required


### PR DESCRIPTION
## Summary

The #285 `values.schema.json` expansion set top-level `additionalProperties:
false`. AWS's EKS add-on ingestion renders the chart with Helm's reserved
`global` value injected, which the closed schema rejects — `helm template`
fails `additional properties 'global' not allowed`, so the add-on version
failed ingestion with `INVALID_HELM_TEMPLATE` (caught pre-Public on the 1.0.2
add-on re-submit).

## Fix
- Remove top-level `additionalProperties: false` (keep declared properties +
  enums → the derived add-on config schema is unchanged; #285 goal intact).
- Regression test: `helm template --set global.foo=bar` must render.
- Bump chart to **1.0.3** (chart-only hotfix; image + image-based deploy pins
  are functionally unchanged from 1.0.2, left as-is).

## Testing
- `helm template` with injected `global`: renders. New test + full `go test`: pass.
- Config-schema contract test still passes (exposure intact). helm lint + docs guard clean.

## Next
Tag `v1.0.3` → re-host → re-submit the EKS add-on (which then passes the
`helm template` gate). Closes #290; unblocks #236.