### PR TITLE
fix(aws): forward whole signals.env to the collector across EC2 paths (#292)

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -141,10 +141,13 @@ full configuration examples.
   Manager (`AmazonSSMManagedInstanceCore` on the collector role); no key pair
   exists and no inbound port is open.
 - The loopback **control-plane API token** is a separate credential class from
-  the (non-existent) DB password: user-data mints a random 32-byte token, passes
-  it to the container via the environment (`SIGNALS_API_TOKEN`, the same path the
-  Helm chart uses), and stores it root-only at `/root/signals-api-token` — outside
-  the bind-mounted config, so `signals.yaml` itself stays secret-free.
+  the (non-existent) DB password: user-data mints a random 32-byte token and
+  writes it to `/etc/signals/signals.env` (root-only, `0600`), which the
+  container receives via `docker run --env-file` (`SIGNALS_API_TOKEN`, the same
+  env path the Helm chart uses) — by reference, so the value is never on the
+  docker command line or in the journal (#292). A plain copy of just the token is
+  also stored at `/root/signals-api-token` for the operator verify step. The
+  world-readable `signals.yaml` stays secret-free.
 
 ## Reusing the identity elsewhere
 

--- a/deploy/aws/cloudformation/signals-rds-iam.yaml
+++ b/deploy/aws/cloudformation/signals-rds-iam.yaml
@@ -144,17 +144,23 @@ Resources:
           # The config carries no secret; make the bind-mounted files
           # world-readable so the non-root container (uid 10001) can read them.
           chmod 0644 /etc/signals/signals.yaml /etc/signals/rds-ca.pem
-          # Mint a strong control-plane API token. It is passed to the
-          # container via the environment (mirrors the Helm SIGNALS_API_TOKEN
-          # path) and stored root-only, outside the bind mount, so the operator
-          # can authenticate the verify step — it is never written into config.
-          SIGNALS_API_TOKEN="$(openssl rand -hex 32)"
+          # Mint a strong control-plane API token and write it to the same
+          # /etc/signals/signals.env the AMI unit uses (#292 parity), so the
+          # whole file — this token plus any buyer-added SIGNALS_* — is forwarded
+          # to the container by reference via `--env-file`. Root-only (0600): the
+          # docker client reads it as root at run time. The token value is NEVER
+          # put on the docker command line (it would be visible in the journal /
+          # `ps`) — R-AMI-06 / INV-AMI-04.
           umask 077
-          printf '%s\n' "$SIGNALS_API_TOKEN" > /root/signals-api-token
+          printf 'SIGNALS_API_TOKEN=%s\n' "$(openssl rand -hex 32)" > /etc/signals/signals.env
+          chmod 0600 /etc/signals/signals.env
+          # Keep the operator-readable copy of just the token for the verify step.
+          sed -n 's/^SIGNALS_API_TOKEN=//p' /etc/signals/signals.env > /root/signals-api-token
+          chmod 0600 /root/signals-api-token
           # ENTRYPOINT is `tini --` with CMD `signals`; the `signals` arg below
           # is required, else the image args replace CMD and tini execs --config.
           docker run -d --name signals --restart=always \
-            -e SIGNALS_API_TOKEN="$SIGNALS_API_TOKEN" \
+            --env-file /etc/signals/signals.env \
             -v /etc/signals:/etc/signals:ro \
             -v signals-data:/data \
             -p 127.0.0.1:8081:8081 \

--- a/deploy/aws/imagebuilder/README.md
+++ b/deploy/aws/imagebuilder/README.md
@@ -23,8 +23,14 @@ buyer **at launch**:
 
 - `/etc/signals/signals.yaml` — collector config + target (user-data / SSM).
 - `/etc/signals/rds-ca.pem` — RDS CA bundle if using verify-full TLS.
-- `/etc/signals/signals.env` — `SIGNALS_API_TOKEN=...` (root-only), read by the
-  unit's `EnvironmentFile`.
+- `/etc/signals/signals.env` — `SIGNALS_API_TOKEN=...` (root-only) plus **any
+  other `SIGNALS_*`** the collector reads (e.g. `SIGNALS_LOG_LEVEL`, or the
+  dev-only `SIGNALS_ALLOW_INSECURE_PG_TLS`). The unit forwards the **whole file**
+  to the container via `docker run --env-file /etc/signals/signals.env` (#292),
+  so every buyer-supplied variable reaches the collector — not only the token.
+  `EnvironmentFile=/etc/signals/signals.env` is also kept so systemd fails
+  cleanly if the file is absent. Both pass values **by reference**: neither the
+  file's contents nor the token is ever printed to the journal.
 
 On first boot, once `/etc/signals` is populated, `signals.service` starts the
 collector. This keeps the AMI credential-free (credentials-by-reference), the

--- a/deploy/aws/imagebuilder/signals-collector-component.yaml
+++ b/deploy/aws/imagebuilder/signals-collector-component.yaml
@@ -66,13 +66,21 @@ phases:
               [Service]
               Restart=always
               RestartSec=5
-              # Buyer supplies /etc/signals/signals.env at launch with
-              # SIGNALS_API_TOKEN=... (root-only). ENTRYPOINT is `tini --`;
-              # the `signals` arg is required so image args do not replace CMD.
+              # Buyer supplies /etc/signals/signals.env at launch (root-only)
+              # with SIGNALS_API_TOKEN=... and any other SIGNALS_* the collector
+              # reads (e.g. SIGNALS_LOG_LEVEL, or the dev-only
+              # SIGNALS_ALLOW_INSECURE_PG_TLS). #292: the WHOLE file is
+              # forwarded to the container via `--env-file` so every
+              # buyer-supplied SIGNALS_* var reaches the collector, not only
+              # the token.
+              # EnvironmentFile= is kept so systemd fails cleanly if the file is
+              # absent. Both are by-reference: neither prints the file or the
+              # token to the journal (R-AMI-06). ENTRYPOINT is `tini --`; the
+              # `signals` arg is required so image args do not replace CMD.
               EnvironmentFile=/etc/signals/signals.env
               ExecStartPre=-/usr/bin/docker rm -f signals
               ExecStart=/usr/bin/docker run --rm --name signals \
-                -e SIGNALS_API_TOKEN \
+                --env-file /etc/signals/signals.env \
                 -v /etc/signals:/etc/signals:ro \
                 -v signals-data:/data \
                 {{ SignalsImage }} signals --config /etc/signals/signals.yaml

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -57,16 +57,23 @@ locals {
     # The config carries no secret; make the bind-mounted files world-readable
     # so the non-root container (uid 10001) can read them.
     chmod 0644 /etc/signals/signals.yaml /etc/signals/rds-ca.pem
-    # Mint a strong control-plane API token, passed to the container via the
-    # environment (mirrors the Helm SIGNALS_API_TOKEN path) and stored root-only,
-    # outside the bind mount, so the operator can authenticate the verify step.
-    SIGNALS_API_TOKEN="$(openssl rand -hex 32)"
+    # Mint a strong control-plane API token and write it to the same
+    # /etc/signals/signals.env the AMI unit uses (#292 parity, INV-AMI-03), so
+    # the whole file — this token plus any buyer-added SIGNALS_* — is forwarded
+    # to the container by reference via `--env-file`. Root-only (0600): the
+    # docker client reads it as root at run time, so the container does not need
+    # to. The token value is NEVER put on the docker command line (it would be
+    # visible in the journal / `ps`) — R-AMI-06 / INV-AMI-04.
     umask 077
-    printf '%s\n' "$SIGNALS_API_TOKEN" > /root/signals-api-token
+    printf 'SIGNALS_API_TOKEN=%s\n' "$(openssl rand -hex 32)" > /etc/signals/signals.env
+    chmod 0600 /etc/signals/signals.env
+    # Keep the operator-readable copy of just the token for the verify step.
+    sed -n 's/^SIGNALS_API_TOKEN=//p' /etc/signals/signals.env > /root/signals-api-token
+    chmod 0600 /root/signals-api-token
     # ENTRYPOINT is `tini --` with CMD `signals`; the `signals` arg below is
     # required, else the image args replace CMD and tini execs --config.
     docker run -d --name signals --restart=always \
-      -e SIGNALS_API_TOKEN="$SIGNALS_API_TOKEN" \
+      --env-file /etc/signals/signals.env \
       -v /etc/signals:/etc/signals:ro \
       -v signals-data:/data \
       -p 127.0.0.1:8081:8081 \

--- a/specifications/marketplace-ami-image-builder.acceptance.md
+++ b/specifications/marketplace-ami-image-builder.acceptance.md
@@ -106,3 +106,55 @@ collector.
 
 **Note:** This case is realized only if #235's demand gate opens; it is
 documented here so the contract is defined, not run in the groundwork slice.
+
+---
+
+### TC-AMI-06: Buyer-supplied SIGNALS_* env reaches the collector, in parity (normal + invariant)
+
+**Rule:** Normal / invariant — R-AMI-05, INV-AMI-03, FC-AMI-04 (#292)
+
+**Scenario:** A buyer places an arbitrary `SIGNALS_*` variable (e.g. the dev-only
+`SIGNALS_ALLOW_INSECURE_PG_TLS=true`, which surfaced this in the #235 AMI
+launch-test) in `/etc/signals/signals.env`. It must reach the containerized
+collector, and the AMI component and the terraform run path must forward env the
+same way.
+
+**Given:**
+- `deploy/aws/imagebuilder/signals-collector-component.yaml`.
+- `deploy/aws/terraform/main.tf`.
+- `deploy/aws/cloudformation/signals-rds-iam.yaml`.
+
+**When:**
+- The `signals.service` unit's `docker run` line (component) and the terraform /
+  cloudformation `docker run` invocations are inspected.
+
+**Then:**
+- All three docker-run the image with `--env-file /etc/signals/signals.env`,
+  forwarding the whole file — not only `-e SIGNALS_API_TOKEN`.
+- The component's `EnvironmentFile=/etc/signals/signals.env` is retained (systemd
+  fails cleanly if absent).
+- All three paths forward env identically (INV-AMI-03 parity).
+
+---
+
+### TC-AMI-07: The env-forwarding path never logs a secret (invariant / security)
+
+**Rule:** Invariant — R-AMI-06, INV-AMI-04, FC-AMI-05 (#292)
+
+**Scenario:** Env is passed to the container through the process environment,
+never rendered to a log stream, so a buyer's `SIGNALS_API_TOKEN` value cannot
+leak into the journal / stdout.
+
+**Given:**
+- The component YAML, `deploy/aws/terraform/main.tf`, and
+  `deploy/aws/cloudformation/signals-rds-iam.yaml`.
+
+**When:**
+- Every line that references `signals.env` or a token value is inspected.
+
+**Then:**
+- No step `cat`s, `echo`s, `tee`s, or otherwise prints the contents of
+  `signals.env`.
+- No `-e SIGNALS_API_TOKEN=<value>` or token value appears on a docker command
+  line (env is passed by reference via `--env-file` / `-e NAME` only).
+- No `set -x` is enabled around a line carrying a token value.

--- a/specifications/marketplace-ami-image-builder.md
+++ b/specifications/marketplace-ami-image-builder.md
@@ -76,6 +76,28 @@ Out of scope (deferred, demand-gated):
 - **R-AMI-04**: The live `AmiProduct@1.0` listing is a **separate product** with
   its own onboarding/review, pursued only on real demand (#235 gate). The
   groundwork here MUST NOT trigger any live Marketplace change-set.
+- **R-AMI-05** (env passthrough — #292): The unit MUST forward the **whole**
+  buyer-supplied `/etc/signals/signals.env` to the container via docker's
+  `--env-file /etc/signals/signals.env`, so **any** `SIGNALS_*` variable a buyer
+  places there (not only `SIGNALS_API_TOKEN`) reaches the collector. The
+  `deploy/aws/terraform` and `deploy/aws/cloudformation` IaC run paths forward
+  the same env file the same way for parity (INV-AMI-03). **Decision (#292,
+  forward-all vs document-only):**
+  forward-all — chosen 2026-07-20 by Frank. Rationale: the collector already
+  reads its full runtime config from `SIGNALS_*` env (`internal/config`), so a
+  buyer tuning any of those (e.g. the dev-only `SIGNALS_ALLOW_INSECURE_PG_TLS`
+  that surfaced this in the #235 AMI launch-test) must be able to set it in
+  `signals.env` without editing the baked unit; document-only would leave the
+  unit silently ignoring buyer env and diverge from the container/Helm env
+  contract. `EnvironmentFile=` still loads the file into the unit's environment
+  so systemd fails cleanly if it is absent; `--env-file` is what actually
+  crosses the container boundary.
+- **R-AMI-06** (env secrets never logged — #292): The env-forwarding mechanism
+  MUST NOT echo, `cat`, `tee`, or otherwise print the contents of `signals.env`
+  or any token value to the journal / stdout / stderr. `--env-file` and
+  `EnvironmentFile=` pass values into the process environment without rendering
+  them on the command line or in logs; no bake or launch step may `cat`/`echo`
+  the file, and no `set -x` may be enabled around a line carrying a token value.
 
 ## Invariants
 
@@ -88,7 +110,14 @@ Out of scope (deferred, demand-gated):
   passwordless onboarding.
 - **INV-AMI-03** (single EC2 contract): the component and
   `deploy/aws/terraform` install the collector the same way (docker-run the
-  image), differing only in bake-time vs launch-time.
+  image), differing only in bake-time vs launch-time. This parity extends to env
+  forwarding: both paths forward the buyer-supplied `signals.env` into the
+  container via `--env-file /etc/signals/signals.env` (R-AMI-05).
+- **INV-AMI-04** (env secrets never leak to logs — #292): no artifact in either
+  EC2 path prints the contents of `signals.env` or a token value to any log
+  stream. A buyer's `SIGNALS_API_TOKEN` (or any other `SIGNALS_*` secret) reaches
+  the collector only through the process environment, never through stdout /
+  stderr / the systemd journal (R-AMI-06).
 
 ## Failure Conditions
 
@@ -99,6 +128,11 @@ Out of scope (deferred, demand-gated):
 - **FC-AMI-03**: The component writes a credential/config/token value into the
   image (e.g. a hardcoded token or a `signals.yaml` with a password) → violates
   R-AMI-01 / INV-AMI-01.
+- **FC-AMI-04**: The unit forwards only `SIGNALS_API_TOKEN` (not the whole
+  `signals.env`), so a buyer-supplied `SIGNALS_*` var is silently ignored →
+  violates R-AMI-05 (the #292 defect).
+- **FC-AMI-05**: A step `cat`/`echo`/`tee`s `signals.env` or a token value to a
+  log stream → violates R-AMI-06 / INV-AMI-04.
 
 ## Constraints
 
@@ -125,5 +159,8 @@ specification (this file) -> acceptance cases
 The statically-checkable cases **TC-AMI-01..04** are enforced in CI by
 `scripts/check-imagebuilder-component.sh` (wired into `scripts/preflight.sh`
 as the `imagebuilder` gate and into `.github/workflows/ci.yml`), so the
-demand-gated groundwork cannot regress (#266). **TC-AMI-05** (live baked-AMI
-smoke) remains deferred until #235's demand gate opens.
+demand-gated groundwork cannot regress (#266). **TC-AMI-06** and **TC-AMI-07**
+(#292: env passthrough parity + secrets-never-logged) are enforced by
+`tests/signals_ami_env_forwarding_test.go` (run under `go test`, the repo's
+`test` gate). **TC-AMI-05** (live baked-AMI smoke) remains deferred until #235's
+demand gate opens.

--- a/tests/signals_ami_env_forwarding_test.go
+++ b/tests/signals_ami_env_forwarding_test.go
@@ -1,0 +1,135 @@
+package tests
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// AMI / EC2 env-forwarding contract (Elevarq/Signals#292).
+//
+// Spec: specifications/marketplace-ami-image-builder.md
+//   - R-AMI-05 / INV-AMI-03 (TC-AMI-06): the buyer-supplied signals.env is
+//     forwarded WHOLE (`--env-file /etc/signals/signals.env`) in BOTH the AMI
+//     Image Builder component and the deploy/aws/terraform run path, so any
+//     SIGNALS_* var (not just SIGNALS_API_TOKEN) reaches the collector; both
+//     paths forward env identically.
+//   - R-AMI-06 / INV-AMI-04 (TC-AMI-07): the forwarding mechanism never echoes,
+//     cats, tees, or otherwise logs the contents of signals.env or a token
+//     value; env crosses the boundary by reference only.
+//
+// These assert on the committed deployment artifacts as text (the same style
+// as tests/signals_helm_production_test.go asserts on the rendered chart) so a
+// regression to the pre-#292 "-e SIGNALS_API_TOKEN only" form fails CI.
+
+const (
+	amiComponentPath = "../deploy/aws/imagebuilder/signals-collector-component.yaml"
+	awsTerraformPath = "../deploy/aws/terraform/main.tf"
+	awsCloudFormPath = "../deploy/aws/cloudformation/signals-rds-iam.yaml"
+)
+
+// The EC2 run paths that must stay in env-forwarding parity (INV-AMI-03): the
+// AMI Image Builder component and the two IaC launch paths. All three docker-run
+// the collector; all three must forward the whole signals.env by reference.
+var ec2RunPaths = []struct{ name, path string }{
+	{"component", amiComponentPath},
+	{"terraform", awsTerraformPath},
+	{"cloudformation", awsCloudFormPath},
+}
+
+func readArtifact(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// TC-AMI-06: both EC2 paths forward the WHOLE signals.env via --env-file, so a
+// buyer-supplied SIGNALS_* var reaches the collector (R-AMI-05), and they do it
+// the same way (INV-AMI-03 parity).
+func TestAMI_EnvFileForwardedInAllPaths(t *testing.T) {
+	const envFileFlag = "--env-file /etc/signals/signals.env"
+
+	for _, tc := range ec2RunPaths {
+		body := readArtifact(t, tc.path)
+		if !strings.Contains(body, envFileFlag) {
+			t.Errorf("%s: docker run must forward the whole env with %q so any "+
+				"SIGNALS_* var reaches the collector (R-AMI-05, INV-AMI-03 parity); "+
+				"not found", tc.name, envFileFlag)
+		}
+	}
+
+	// The component keeps EnvironmentFile= so systemd fails cleanly if the file
+	// is absent (R-AMI-05).
+	component := readArtifact(t, amiComponentPath)
+	if !strings.Contains(component, "EnvironmentFile=/etc/signals/signals.env") {
+		t.Errorf("AMI component: must retain EnvironmentFile=/etc/signals/signals.env")
+	}
+}
+
+// TC-AMI-06 (regression guard): the pre-#292 form forwarded ONLY the token, so
+// other SIGNALS_* vars were silently dropped. Neither path may pass token-only
+// (a bare `-e SIGNALS_API_TOKEN` on the docker-run line with no --env-file).
+func TestAMI_TokenOnlyForwardingRejected(t *testing.T) {
+	for _, tc := range ec2RunPaths {
+		body := readArtifact(t, tc.path)
+		if strings.Contains(body, "-e SIGNALS_API_TOKEN") &&
+			!strings.Contains(body, "--env-file /etc/signals/signals.env") {
+			t.Errorf("%s: forwards SIGNALS_API_TOKEN alone without --env-file; "+
+				"buyer SIGNALS_* vars would be dropped (FC-AMI-04, #292)", tc.name)
+		}
+	}
+}
+
+// TC-AMI-07: no artifact prints the contents of signals.env or a token value to
+// a log stream (R-AMI-06 / INV-AMI-04). Env crosses the boundary by reference.
+func TestAMI_EnvSecretsNeverLogged(t *testing.T) {
+	// A read of the env file's CONTENTS onto a log stream (stdout/stderr) is the
+	// leak (R-AMI-06). Matched forms: a reader command taking signals.env as
+	// input (`cat/less/tee/... signals.env`), or a `$(cat ...signals.env)`
+	// command substitution feeding an echo/printf. A redirect INTO the file
+	// (`... > /etc/signals/signals.env`, the token WRITE) is NOT a leak and is
+	// excluded. `EnvironmentFile=` / `--env-file <path>` load without printing
+	// and are excluded (they carry no reader command before the path).
+	catEnvFile := regexp.MustCompile(`\b(cat|tee|less|more|head|tail|xxd|od|hexdump)\b[^\n>]*signals\.env`)
+	substEnvFile := regexp.MustCompile(`\$\([^)]*\bcat\b[^)]*signals\.env`)
+
+	// A token VALUE placed on a docker command line (`-e SIGNALS_API_TOKEN=...`
+	// or `--env SIGNALS_API_TOKEN=...`) — the by-reference forms `-e NAME` (no
+	// `=`) and `--env-file` are safe. The RHS here is a concrete value/interp.
+	tokenValueOnCmdline := regexp.MustCompile(`--?e(nv)?[= ]SIGNALS_API_TOKEN=\S`)
+
+	for _, tc := range ec2RunPaths {
+		body := readArtifact(t, tc.path)
+
+		for i, line := range strings.Split(body, "\n") {
+			// Comments document behaviour; they carry no runtime secret.
+			trimmed := strings.TrimLeft(line, " \t")
+			if strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			if catEnvFile.MatchString(line) || substEnvFile.MatchString(line) {
+				t.Errorf("%s:%d prints signals.env to a log stream (R-AMI-06): %q",
+					tc.name, i+1, strings.TrimSpace(line))
+			}
+			if tokenValueOnCmdline.MatchString(line) {
+				t.Errorf("%s:%d puts a SIGNALS_API_TOKEN value on the docker command "+
+					"line (visible in the journal / ps); pass by reference (R-AMI-06): %q",
+					tc.name, i+1, strings.TrimSpace(line))
+			}
+		}
+
+		// A `set -x` anywhere in the AMI component's shell steps would echo every
+		// subsequent command (and its expanded token) to the journal. Guard it in
+		// the component (its shell is baked into the unit/build). Terraform's
+		// user_data intentionally uses `set -euo pipefail` (no -x); assert no -x.
+		if strings.Contains(body, "set -x") ||
+			regexp.MustCompile(`set -[a-wyz]*x`).MatchString(body) {
+			t.Errorf("%s: enables shell tracing (set -x) — would echo expanded "+
+				"token values to the journal (R-AMI-06)", tc.name)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The baked AMI `signals.service` unit
(`deploy/aws/imagebuilder/signals-collector-component.yaml`) forwarded only
`-e SIGNALS_API_TOKEN` to the container. Any other `SIGNALS_*` var a buyer
placed in `/etc/signals/signals.env` was silently dropped. Found in the #235
AMI launch-test: the dev-only `SIGNALS_ALLOW_INSECURE_PG_TLS` never reached the
collector, which failed closed and crash-looped. Production RDS use over
`verify-full` (config in `signals.yaml`) was unaffected.

## Decision (recorded)

**Forward-all** (vs document-only), chosen by Frank. The collector reads its
full runtime config from `SIGNALS_*` env, so a buyer tuning any of those must be
able to set it in `signals.env` without editing the baked unit. Recorded in
`specifications/marketplace-ami-image-builder.md` as R-AMI-05 with a dated
rationale, plus the security rule R-AMI-06, invariant INV-AMI-04, failure
conditions FC-AMI-04/05, and acceptance cases TC-AMI-06/07.

## Change

- **Env forwarding:** the AMI component **and** both IaC run paths
  (`deploy/aws/terraform`, `deploy/aws/cloudformation`) now docker-run with
  `--env-file /etc/signals/signals.env`, forwarding the whole file. The
  component keeps `EnvironmentFile=` so systemd fails cleanly if the file is
  absent. All three EC2 paths now forward env identically (INV-AMI-03 parity).
  CloudFormation was included because it is the third EC2 run path with the
  identical defect; leaving it token-only would create doc-vs-reality drift.
- **Security (R-AMI-06 / INV-AMI-04):** the token is passed **by reference
  only**. The IaC paths previously put the token *value* on the docker command
  line (`-e SIGNALS_API_TOKEN="$SIGNALS_API_TOKEN"`), visible in the journal and
  `ps`. They now write it to a **root-only (0600)** `signals.env` and pass
  `--env-file`; the value is never on the command line and never echoed/cat'd to
  a log. `/root/signals-api-token` is still produced for the operator verify
  step.

## Proving secrets are never logged

`tests/signals_ami_env_forwarding_test.go` asserts, across all three EC2 paths,
that no line `cat`/`echo`/`tee`s `signals.env` to a log stream, no
`SIGNALS_API_TOKEN=<value>` appears on a docker command line, and no `set -x` is
enabled. Verified **non-vacuous**: injecting a `cat /etc/signals/signals.env`
into terraform and cloudformation each makes the test fail; reverting makes it
pass.

## Tests / gates run locally

- `go test ./... -count=1` -> all packages pass (tests pkg 16.8s).
- `go test ./tests -run TestAMI_ -v` -> 3/3 pass.
- `bash scripts/preflight.sh gofmt|vet|imagebuilder` -> clean.
- `terraform fmt -check` + `terraform validate` -> clean / valid.
- `shellcheck` (default severity) on the added shell + the extracted user-data:
  the only findings are pre-existing SC2154/SC2086 on the Terraform `${var.*}`
  interpolation (not real shell); my added lines are clean.
- `gitleaks protect --staged` (repo `.gitleaks.toml`) -> no leaks (the token is
  minted at runtime via `openssl`, no literal committed).

Note: this repo has no `yamllint` gate; the component's guard is
`scripts/check-imagebuilder-component.sh`, which still passes.

## Acceptance criteria

- [x] Decision recorded (forward-all); component + terraform (+ cloudformation)
  in parity (INV-AMI-03).
- [x] A buyer-supplied `SIGNALS_*` var in `signals.env` reaches the collector
  (`--env-file` forwards the whole file).

Closes #292