### PR TITLE
Bump grpc to v1.82.1 for HIGH advisory GHSA-hrxh-6v49-42gf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800 // indirect
-	google.golang.org/grpc v1.82.0 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	modernc.org/libc v1.74.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7/go.mod h1:KqHwBx2upmfa1XSi1WuRvC+2VGCLtooKkfmyvRbUmqA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800 h1:qEHAMpSaUhtD0p3NbEEI83HwNGFxEwaSJ1G9PLnCBZE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary
The Nightly Security workflow (grype source vuln scan, run 29902736140) failed on a HIGH-severity advisory published 2026-07-21:

- **GHSA-hrxh-6v49-42gf** — "gRPC-Go: xDS RBAC and HTTP/2 Vulnerabilities" (HIGH)
- `google.golang.org/grpc` v1.82.0 (indirect); vulnerable range < 1.82.1

The advisory landed under a pinned transitive dependency, so the next nightly flagged it — nothing regressed in Signals. This bumps grpc to the patched **v1.82.1**.

## Change
- `google.golang.org/grpc` v1.82.0 -> v1.82.1 (remains indirect; patch release, no API change)
- Only `go.mod`/`go.sum` touched

## Verification
- `go build ./...`, `go vet ./...`, tests: pass
- Full `scripts/preflight.sh all`: pass (gitleaks, govulncheck, semgrep, osv-scanner, kube-lint, golangci-lint)
- **osv-scanner reports 0 vulnerabilities** after the bump (version-range based, same as the failing grype gate)

## Out of scope
The nightly also emits an inconsistent STDD fingerprint annotation on `go.mod:1`; that is unrelated to this CVE and left for separate handling.

closes #300