### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-22
+
+### Added
+
+- `index_health_summary_v2` collector: decision-grade index health evidence
+  (#295).
+- Partitioned-index and relation-kind evidence in `index_health_summary_v2`
+  (#298).
+
+### Fixed
+
+- AWS EC2 deploy paths now forward the whole `signals.env` to the collector,
+  not a partial subset (#299).
+
+### Changed
+
+- Bump `google.golang.org/api` 0.288.0 -> 0.289.0 (#296).
+
+### Security
+
+- Bump `google.golang.org/grpc` v1.82.0 -> v1.82.1 to remediate
+  GHSA-hrxh-6v49-42gf ("gRPC-Go: xDS RBAC and HTTP/2 Vulnerabilities", HIGH).
+  grpc is an indirect dependency; patch release, no API change (#301).
+
 ## [1.0.3] - 2026-07-19
 
 ### Fixed

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 1.0.3
-appVersion: "1.0.3"
+version: 1.1.0
+appVersion: "1.1.0"
 keywords:
   - postgresql
   - monitoring

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "1.0.3"
+  tag: "1.1.0"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration. Rendered into the mounted


### PR DESCRIPTION
Version-bump PR for the **v1.1.0** release. Five commits have landed on `main` since v1.0.3 (2026-07-19), including a HIGH-severity security fix and two backward-compatible collector features, so per SemVer this is a **minor** release (not a patch).

## Release contents (since v1.0.3)
- **Security:** `google.golang.org/grpc` v1.82.0 -> v1.82.1 — GHSA-hrxh-6v49-42gf (HIGH) (#301)
- **Added:** `index_health_summary_v2` decision-grade index health (#295)
- **Added:** partitioned-index / relation-kind evidence in `index_health_summary_v2` (#298)
- **Fixed:** forward the whole `signals.env` to the collector across EC2 paths (#299)
- **Changed:** `google.golang.org/api` 0.288.0 -> 0.289.0 (#296)

## This PR
- `Chart.yaml`: `version` + `appVersion` 1.0.3 -> 1.1.0
- `values.yaml`: `image.tag` 1.0.3 -> 1.1.0
- `CHANGELOG.md`: new `## [1.1.0]` section

All three version references are in lockstep (consistency gate).

## Verification
- `helm lint` + `helm template` (defaults): pass
- Full `scripts/preflight.sh all`: pass (gitleaks, govulncheck, semgrep, osv-scanner 0 vulns, kube-lint, golangci-lint)

## Human gate
The GA tag `v1.1.0` is cut by a maintainer **after this merges** and `main` is verified to carry the bump. Tagging is not part of this PR; CI STOPs if the chart version does not match the tag.

closes #302