### PR TITLE
ci: weekly security scan on the Monday-night cleanup window (drop daily cadence)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
       interval: weekly
       day: monday
       time: "02:00"
-      timezone: America/Los_Angeles
+      timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 5
     labels:
       - area:tooling
@@ -48,7 +48,7 @@ updates:
       interval: weekly
       day: monday
       time: "02:00"
-      timezone: America/Los_Angeles
+      timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 5
     labels:
       - area:tooling

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -31,10 +31,13 @@ name: Nightly Security
 
 on:
   schedule:
-    # 07:23 UTC daily — off the hour to avoid scheduler hot-minute
-    # contention. Elevarq's nightly runs at 07:17 — keep them 5 minutes
-    # apart so simultaneous Anchore/Grype DB pulls don't collide.
-    - cron: "23 7 * * *"
+    # Weekly, Monday 05:09 UTC — portfolio scheme: all repos run their
+    # deep scan Monday early UTC, staggered 6 minutes apart (Analyzer
+    # 05:03, Signals 05:09, Workbench 05:15, pgAgroal-Enterprise 05:21)
+    # so results are ready before the Monday-morning cleanup
+    # (Europe/Amsterdam) and simultaneous Grype DB pulls don't collide.
+    # Daily cadence dropped to conserve Actions minutes.
+    - cron: "9 5 * * 1"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
closes #307

## What

- `.github/workflows/nightly-security.yml`: cron `"23 7 * * *"` (daily 07:23 UTC) -> `"9 5 * * 1"` (weekly, Monday 05:09 UTC), with the adjacent comment updated to document the portfolio scheme: all repos run their deep scan Monday early UTC staggered 6 minutes apart (Analyzer 05:03, Signals 05:09, Workbench 05:15, pgAgroal-Enterprise 05:21) so results are ready before the Monday-morning cleanup (Europe/Amsterdam) and simultaneous Grype DB pulls don't collide. Daily cadence dropped to conserve Actions minutes (~30 runs/month).
- `.github/dependabot.yml`: both update schedules' `timezone` set to `Europe/Amsterdam` (weekly monday 02:00 kept), so Dependabot PRs also land in the Monday-morning cleanup window.

## Verification (local)

- `actionlint .github/workflows/nightly-security.yml`: clean
- Python YAML parse of both files: OK; parsed cron = `9 5 * * 1`, timezones = `Europe/Amsterdam` x2
- `yamllint`: only pre-existing findings (80-char SHA-pin comment lines, missing `---` doc start) — none on changed lines