### PR TITLE
fix(ci): schedule timezone is America/Los_Angeles (revert wrong Amsterdam change)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
       interval: weekly
       day: monday
       time: "02:00"
-      timezone: "Europe/Amsterdam"
+      timezone: "America/Los_Angeles"
     open-pull-requests-limit: 5
     labels:
       - area:tooling
@@ -48,7 +48,7 @@ updates:
       interval: weekly
       day: monday
       time: "02:00"
-      timezone: "Europe/Amsterdam"
+      timezone: "America/Los_Angeles"
     open-pull-requests-limit: 5
     labels:
       - area:tooling

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -34,8 +34,9 @@ on:
     # Weekly, Monday 05:09 UTC — portfolio scheme: all repos run their
     # deep scan Monday early UTC, staggered 6 minutes apart (Analyzer
     # 05:03, Signals 05:09, Workbench 05:15, pgAgroal-Enterprise 05:21)
-    # so results are ready before the Monday-morning cleanup
-    # (Europe/Amsterdam) and simultaneous Grype DB pulls don't collide.
+    # (Sunday ~22:09 America/Los_Angeles) so results are ready before
+    # the Pacific Monday-morning cleanup and simultaneous Grype DB
+    # pulls don't collide.
     # Daily cadence dropped to conserve Actions minutes.
     - cron: "9 5 * * 1"
   workflow_dispatch: {}


### PR DESCRIPTION
The Dependabot schedule timezone was incorrectly changed from America/Los_Angeles to Europe/Amsterdam earlier this week. The team is in LA; the original Pacific timezone was correct. This reverts it.

- `.github/dependabot.yml`: both `timezone` entries back to `America/Los_Angeles`.
- `.github/workflows/nightly-security.yml`: cron `"9 5 * * 1"` unchanged (Mon 05:09 UTC = Sunday ~22:09 PT; the weekly cadence stays). Comment updated to reference the Pacific Monday-morning cleanup instead of Amsterdam.

Verified locally: `grep -rn Amsterdam .github/` returns nothing, both files parse as YAML, and `actionlint` is clean.