### PR TITLE
test: collector output-contract verification against live PG (CI matrix 14-18) (closes #314)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,77 @@ jobs:
           'TestNoAnalyzerImports|TestNoLLMCode|TestNoScoringCode|TestNoProprietaryContent|TestLicenseFileExists'
           ./tests/
 
+  # #314: collector output-contract verification against a live
+  # PostgreSQL, matrixed across every supported major so version-gated
+  # column/type differences surface. The integration test seeds a
+  # parent+child table with an UNINDEXED foreign key, runs the full
+  # collection, exports a snapshot ZIP via the production export path,
+  # and asserts the per-collector output contract — most importantly the
+  # internal-"char" columns (contype/relkind/relpersistence/provolatile/
+  # prokind) serialize as single-char STRINGS, locking the #312 class
+  # (an uncast contype serialized as 102 instead of "f", so the Analyzer
+  # skipped every FK — Elevarq/Analyzer#1871). The test is `integration`
+  # build-tag + SIGNALS_TEST_PG_DSN gated, so it never runs in the unit
+  # `test` job above and skips locally when no PG is present.
+  integration-pg:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: [14, 15, 16, 17, 18]
+    services:
+      postgres:
+        image: postgres:${{ matrix.pg }}
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        # Wait until the server accepts connections before the job runs.
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      # Collection requires a NON-superuser role (ValidateRoleSafety
+      # hard-fails on rolsuper), so the test connects as the dedicated
+      # `signals` monitoring role created below — never as postgres.
+      PGHOST: localhost
+      PGPORT: "5432"
+      SIGNALS_TEST_PG_DSN: "postgres://signals:signals@localhost:5432/postgres?sslmode=disable"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version: "1.26.5"
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Create non-superuser monitoring role
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+          # Least-privilege monitoring role: LOGIN + pg_monitor, no
+          # superuser/replication/bypassrls. CREATE on the database lets
+          # the test seed its own dedicated schema; nothing else.
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE ROLE signals WITH LOGIN PASSWORD 'signals';
+          GRANT pg_monitor TO signals;
+          GRANT CREATE ON DATABASE postgres TO signals;
+          SQL
+
+      - name: Run collector output-contract integration test
+        run: >
+          go test -tags integration -count=1 -v
+          -run TestIntegration_CollectorOutputContractAgainstRealPG
+          ./tests/
+
   security-scan:
     runs-on: ubuntu-24.04
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Collector output-contract verification against a live PostgreSQL: an
+  `integration`-tagged test seeds representative schema (parent + child
+  with an unindexed FK), runs the full collection, exports a snapshot ZIP
+  via the production export path, and asserts the per-collector output
+  contract — internal-`"char"` columns serialize as single-char strings
+  (the `contype == "f"` regression lock for #312), spec-declared columns
+  are present, and the status↔payload invariant holds end-to-end. Runs in
+  a new CI job matrixed across PG 14/15/16/17/18 (#314).
+
+### Fixed
+
+- `pg_class_storage_v1` emitted `relpersistence` uncast, so pgx scanned
+  the internal `"char"` as a byte integer (`112`/`117`/`116`) instead of
+  `p`/`u`/`t` — a residual of the #312 class the new #314 harness caught.
+  Now cast `::text` like the other char columns (#314).
+
 ## [1.1.0] - 2026-07-22
 
 ### Added

--- a/features/signals/appendix-a-api-contract.md
+++ b/features/signals/appendix-a-api-contract.md
@@ -453,3 +453,44 @@ consumers:
   the collector SQL casts them `::text`. *Rationale: an uncast
   `contype` serialized as `102` instead of `"f"`, so the analyzer's
   `contype == "f"` check failed and every FK constraint was skipped.*
+
+## Collector output-contract verification (#314)
+
+The invariants above are only trustworthy if a test executes the
+collectors against a real PostgreSQL and inspects the bytes that land
+in the exported snapshot. The `pgqueries` unit tests are static
+(registration, read-only linting, ordering) — the SQL is never run, so
+the entire `"char"`-class defect (#312) was invisible until it surfaced
+live. The following invariants require an integration harness that
+collects → exports a snapshot ZIP → reads it back and asserts the
+per-collector output contract.
+
+- **INV-OUTPUT-CONTRACT.** For each catalog/schema collector, the
+  columns it declares in its spec (`specifications/collectors/<id>.md`
+  *Output columns* table) MUST be present in the `query_results`
+  payload objects in the exported snapshot ZIP when the collector runs
+  against a target carrying representative schema. Absence of a
+  declared column in a non-empty payload is a contract violation.
+  *Rationale: a consumer (the Analyzer) reads declared columns by name;
+  a silently dropped or renamed column produces `no_evidence` with no
+  signal.*
+
+- **INV-CHAR-TEXT-VERIFIED.** The `INV-CHAR-TEXT` guarantee MUST be
+  verified against the exported bytes, not only asserted in the SQL: in
+  the `query_results` payload, every internal-`"char"` column
+  (`contype`, `relkind`, `relpersistence`, `provolatile`, `prokind`)
+  MUST decode as a single-character **string**, never a JSON number. In
+  particular, a target with an unindexed foreign key MUST yield a
+  `pg_constraints_v1` payload row whose `contype == "f"` (the exact
+  `#312` regression: an uncast column serialized `contype` as `102`).
+  *Rationale: this is the permanent lock on the `#312` class — the test
+  goes RED on the pre-`#313` code and GREEN after.*
+
+- **INV-STATUS-PAYLOAD-VERIFIED.** `INV-SNAP-STATUS-PAYLOAD` MUST be
+  verified end-to-end through the export: for every `query_runs` entry
+  in the exported ZIP with `status=success` and `row_count=N`, there
+  MUST be exactly one `query_results` payload joinable by `run_id`
+  whose `payload` array contains exactly `N` objects. *Rationale: the
+  status manifest and the data payload cannot be shown to agree by unit
+  tests alone — only a round-trip through the real collect+export path
+  proves it.*

--- a/features/signals/traceability.md
+++ b/features/signals/traceability.md
@@ -259,3 +259,28 @@ Spec: `specifications/collector-inventory.md` (ACTIVE). A committed, machine-rea
 | R122 (contract version) | `contract_version` = 1 gates the document schema; changes are deliberate spec amendments | `TestCollectorInventoryCanonicalEncoding` | COVERED | BEHAVIORAL | TC-CINV-02. |
 | R123 (#293) | Decision-grade index health (`index_health_summary_v2`) | TC-IHV2-01..14 (`tests/signals_index_health_summary_v2_test.go`) | COVERED | BEHAVIORAL | Additive collector in `internal/pgqueries/catalog_index_health.go`; v1 (R103) unchanged. One row per non-system index with explicit safety/constraint/build state and a versioned semantic structure fingerprint. Usage counters (`idx_scan`/`idx_tup_read`/`idx_tup_fetch`) and state booleans emitted raw — never `COALESCE`d to 0/false (R-IHV2-01). Constraint backing from `pg_constraint.conindid` -> controlled `primary`/`unique`/`exclusion`/`other`; `build_state` from `pg_stat_progress_create_index` (reindex vs build via `left(command,2)='RE'`, avoiding the `CREATE`/`REINDEX` linter keywords) distinguishing active build from `invalid_residue`/`not_ready_residue`. `structure_fingerprint` = `md5` over a name/table-independent normalization of `pg_get_indexdef` plus uniqueness/exclusion facts; `exact_duplicate_of` set only on full fingerprint equality (R-IHV2-05), `prefix_candidate_of` a labelled review candidate, never a drop verdict (R-IHV2-06). System schemas excluded (INV-SIGNALS-12); deterministic order; passes the linter; PG14-18 (live-validated on 14 and 18). Unblocks Elevarq/Analyzer#1596. Spec: `specifications/collectors/index_health_summary_v2.md`. |
 | R124 (#294) | Concurrent-DDL capability evidence in `index_health_summary_v2` | TC-IHV2-15 + TC-IHV2-04 (`tests/signals_index_health_summary_v2_test.go`) | COVERED | BEHAVIORAL | Extends R123: `index_health_summary_v2` emits `relation_kind` (controlled `index`/`partitioned_index`/`other`) and a strict `is_partitioned` boolean from `pg_class.relkind` (`'I'` -> partitioned parent index -> `is_partitioned = true`; `'i'` -> ordinary / partition-local -> false). `relkind` is NOT NULL so the fact is always known, never synthesized as false (R-IHV2-08). The analyzer requires `is_partitioned = false` before `DROP INDEX CONCURRENTLY` (unsupported on partitioned indexes; https://www.postgresql.org/docs/current/sql-dropindex.html). Partition-local indexes are distinguished from the partitioned parent. Live-validated on PG18 with a partitioned table + parent index + partition-local indexes + an ordinary index. Required by Elevarq/Analyzer#1596. Spec: `specifications/collectors/index_health_summary_v2.md`. |
+
+## Collector output-contract verification (#314)
+
+Spec: `specifications/collector-output-contract.md` (ACTIVE), with the
+supporting invariants in `features/signals/appendix-a-api-contract.md`
+§"Collector output-contract verification (#314)" (INV-OUTPUT-CONTRACT,
+INV-CHAR-TEXT-VERIFIED, INV-STATUS-PAYLOAD-VERIFIED). The missing STDD
+`tests → artifact` link: a live-PG integration harness that runs the
+full collection against a real PostgreSQL carrying representative schema
+(parent + child with an unindexed FK), exports a snapshot ZIP via the
+production `export.Builder.WriteTo` path, reads it back, and asserts the
+per-collector output contract for the catalog/schema collectors. This
+locks the #312 internal-`"char"` class permanently — the `contype == "f"`
+assertion is RED on pre-#313 uncast SQL and GREEN after. Test:
+`tests/signals_collector_output_contract_integration_test.go`
+(`//go:build integration`, `SIGNALS_TEST_PG_DSN`-gated); runs in the CI
+PG-version matrix 14/15/16/17/18. Acceptance:
+`specifications/collector-output-contract.acceptance.md`.
+
+| Rule ID | Rule Summary | Test ID(s) | Coverage Status | Evidence Type | Notes |
+|---------|-------------|------------|-----------------|---------------|-------|
+| OC-R001 (collect against live PG) | Full collection runs against a real PostgreSQL target and exports a snapshot ZIP via the production export path | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | `//go:build integration` + `SIGNALS_TEST_PG_DSN`; CI matrix PG 14-18. Not in default unit CI. |
+| OC-R002 (declared columns present) | Each catalog/schema collector's spec-declared columns appear in its `query_results` payload objects | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-03; INV-OUTPUT-CONTRACT. |
+| OC-R003 (char-type is text) | Internal-`"char"` columns (`contype`/`relkind`/`relpersistence`/`provolatile`/`prokind`) decode as single-char strings; seeded FK yields `contype == "f"` | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-01/02; INV-CHAR-TEXT-VERIFIED; the #312 regression lock. Also caught + fixed an uncast `pg_class_storage_v1.relpersistence` residual. |
+| OC-R004 (status↔payload joinable) | Every exported `status=success`/`row_count=N` run has exactly one joinable payload with N objects | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-04; INV-STATUS-PAYLOAD-VERIFIED; end-to-end proof of INV-SNAP-STATUS-PAYLOAD (#312). |

--- a/internal/pgqueries/catalog_placement.go
+++ b/internal/pgqueries/catalog_placement.go
@@ -62,7 +62,7 @@ func init() {
 			c.oid                                         AS relid,
 			n.nspname                                     AS schemaname,
 			c.relname,
-			c.relkind::text AS relkind,			c.relpersistence,
+			c.relkind::text AS relkind,			c.relpersistence::text AS relpersistence,
 			c.relispartition,
 			c.relhasindex,
 			c.reltuples,

--- a/specifications/collector-output-contract.acceptance.md
+++ b/specifications/collector-output-contract.acceptance.md
@@ -1,0 +1,124 @@
+# Acceptance Tests: Collector Output-Contract Verification
+
+## Feature
+
+`specifications/collector-output-contract.md`
+
+## Test Cases
+
+### TC-OC-01: FK constraint serializes contype as the string "f" (the #312 lock)
+
+**Rule:** OC-R003 (normal — the #312 regression lock)
+
+**Scenario:** A target carrying an unindexed foreign key is collected
+and exported; the `pg_constraints_v1` payload is inspected.
+
+**Given:**
+- A live target with a parent table (PK) and a child table whose FK to
+  the parent is unindexed.
+
+**When:**
+- The full collection runs against the target and a snapshot ZIP is
+  exported via `export.Builder.WriteTo`; `query_results.ndjson` is read
+  back.
+
+**Then:**
+- The `pg_constraints_v1` payload contains a row with
+  `contype == "f"` — the single-character string, not the integer
+  `102`.
+
+**Expected Result:** Pass on `::text`-cast SQL; RED on pre-#313 code.
+(`TestIntegration_CollectorOutputContractAgainstRealPG`)
+
+---
+
+### TC-OC-02: Internal-"char" columns decode as single-char strings
+
+**Rule:** OC-R003 (boundary)
+
+**Scenario:** Every internal-`"char"` column across the catalog/schema
+collectors is inspected in the exported payload.
+
+**Given:**
+- A collected + exported snapshot ZIP for the seeded target.
+
+**When:**
+- Each `query_results` payload for a catalog/schema collector is
+  scanned for the columns `contype`, `relkind`, `relpersistence`,
+  `provolatile`, `prokind`.
+
+**Then:**
+- Every such value present is a single-character JSON string, never a
+  JSON number.
+
+**Expected Result:** Pass.
+(`TestIntegration_CollectorOutputContractAgainstRealPG`)
+
+---
+
+### TC-OC-03: Declared columns present in the payload
+
+**Rule:** OC-R002 (normal)
+
+**Scenario:** For each catalog/schema collector that produced rows, the
+columns its spec declares are checked against the payload objects.
+
+**Given:**
+- A collected + exported snapshot ZIP; the per-collector declared
+  column sets for the char-type catalog collectors.
+
+**When:**
+- Each non-empty catalog/schema payload is inspected.
+
+**Then:**
+- Every declared column for that collector is present in each payload
+  object.
+
+**Expected Result:** Pass.
+(`TestIntegration_CollectorOutputContractAgainstRealPG`)
+
+---
+
+### TC-OC-04: Status↔payload invariant holds through the export
+
+**Rule:** OC-R004 (boundary — the #312 status/payload invariant)
+
+**Scenario:** Every successful run in the exported ZIP is joined to its
+payload.
+
+**Given:**
+- A collected + exported snapshot ZIP.
+
+**When:**
+- `query_runs.ndjson` and `query_results.ndjson` are read; every row
+  with `status == "success"` and `row_count == N` is joined by
+  `run_id`.
+
+**Then:**
+- Exactly one payload exists per successful run, and its `payload`
+  array holds exactly `N` objects.
+
+**Expected Result:** Pass.
+(`TestIntegration_CollectorOutputContractAgainstRealPG`)
+
+---
+
+### TC-OC-05: Skips locally, runs in the CI matrix
+
+**Rule:** Constraints (env-gating)
+
+**Scenario:** The harness is invoked without a target DSN.
+
+**Given:**
+- `SIGNALS_TEST_PG_DSN` is unset (local developer machine).
+
+**When:**
+- `go test ./...` runs (the `integration` build tag is not selected).
+
+**Then:**
+- The test is not compiled into the default suite and does not fail;
+  under `-tags integration` with no DSN it SKIPS. In CI with the PG
+  service container it RUNS across PG 14/15/16/17/18.
+
+**Expected Result:** Skip locally, run in CI.
+(`TestIntegration_CollectorOutputContractAgainstRealPG`)

--- a/specifications/collector-output-contract.md
+++ b/specifications/collector-output-contract.md
@@ -1,0 +1,129 @@
+# Collector Output-Contract Verification — Behavioral Specification
+
+Spec version: 1.0
+Status: ACTIVE
+Issue: [Elevarq/Signals#314](https://github.com/Elevarq/Signals/issues/314)
+
+## Purpose
+
+Collector specs (`specifications/collectors/<id>.md`) declare an output
+contract — a table of columns with PostgreSQL types. Until #314, no
+test executed a collector against a real PostgreSQL and verified that
+its declared output landed, correctly typed, in the exported snapshot
+ZIP. The `pgqueries` tests are purely static (registration, read-only
+linting, ordering); the SQL is never run. That gap is exactly why
+`contype` serializing as the integer `102` instead of the string `"f"`
+was invisible for the whole internal-`"char"` class (#312): the
+`specification → tests → implementation` chain was missing the
+`tests → artifact` link.
+
+This spec defines the missing test layer: an integration harness that,
+against a real PostgreSQL carrying representative schema, runs the full
+collection, exports a snapshot ZIP via the production export path, reads
+the ZIP back, and asserts the per-collector output contract. It locks
+the #312 class permanently — the assertions go RED on pre-#313 code and
+GREEN after.
+
+Scope is the **catalog/schema collectors** (`Category == "schema"`),
+with emphasis on the internal-`"char"` collectors PR #313 touched
+(`pg_constraints_v1`, `pg_class_storage_v1`, `pg_functions_v1`,
+`pg_functions_definitions_v1`, `pg_proc_config_v1`). The remaining
+non-schema collectors are an explicit fast-follow (see
+Non-Functional Requirements).
+
+This spec complements `appendix-a-api-contract.md` §"Snapshot
+data-integrity invariants (#312)" (INV-SNAP-STATUS-PAYLOAD, INV-CHAR-TEXT)
+and §"Collector output-contract verification (#314)"
+(INV-OUTPUT-CONTRACT, INV-CHAR-TEXT-VERIFIED, INV-STATUS-PAYLOAD-VERIFIED).
+
+## Interfaces
+
+### Inputs
+
+- A live target PostgreSQL, reachable via `SIGNALS_TEST_PG_DSN`
+  (build-tag `integration`; skipped when unset). In CI the target is a
+  `services: postgres:` container matrixed across PG 14/15/16/17/18.
+- Representative schema seeded into the target before collection:
+  a parent table with a primary key, a child table whose foreign key to
+  the parent is **unindexed** (so `pg_constraint` emits a `contype='f'`
+  row), at least one non-PK index, and columns of varied types.
+
+### Outputs
+
+- No product output. The harness produces a pass/fail verdict from the
+  exported snapshot ZIP.
+
+## Behaviors
+
+- **Given** a target seeded with an unindexed FK, **when** the full
+  collection runs and a snapshot ZIP is exported, **then** the
+  `pg_constraints_v1` payload in `query_results.ndjson` contains a row
+  with `contype == "f"` (the string, not a number) for that FK.
+- **Given** any catalog/schema collector that produced rows, **when**
+  the ZIP is read back, **then** each object in that collector's
+  `query_results` payload carries the columns its spec declares.
+- **Given** any exported `query_runs.ndjson` row with
+  `status="success"` and `row_count=N`, **when** joined to
+  `query_results.ndjson` by `run_id`, **then** exactly one payload
+  exists whose `payload` array holds exactly `N` objects.
+- **Given** an internal-`"char"` column (`contype`, `relkind`,
+  `relpersistence`, `provolatile`, `prokind`) present in a payload,
+  **when** its JSON value is inspected, **then** it is a
+  single-character string, never a JSON number.
+
+## Rules
+
+- **OC-R001 — Collect against live PG.** The harness shall run the full
+  collection cycle against a real PostgreSQL target, not a mock, and
+  export a snapshot ZIP via the production export path
+  (`export.Builder.WriteTo`) — never a hand-built payload.
+- **OC-R002 — Declared columns present.** For each catalog/schema
+  collector whose exported payload is non-empty, every column its spec
+  declares shall appear in each payload object. (INV-OUTPUT-CONTRACT.)
+- **OC-R003 — Char-type is text.** Every internal-`"char"` column
+  (`contype`, `relkind`, `relpersistence`, `provolatile`, `prokind`)
+  present in a payload shall decode as a single-character string, never
+  a JSON number. The FK seeded by the harness shall produce a
+  `pg_constraints_v1` row with `contype == "f"`. (INV-CHAR-TEXT-VERIFIED.)
+- **OC-R004 — Status↔payload joinable.** For every exported
+  `query_runs` row with `status="success"` / `row_count=N`, exactly one
+  `query_results` payload shall be joinable by `run_id` and contain
+  exactly `N` objects. (INV-STATUS-PAYLOAD-VERIFIED.)
+
+## Invariants
+
+- **INV-01** — The harness reuses the production collect + export code
+  paths (`collector.Collector` + `export.Builder`); it never
+  reconstructs snapshot bytes independently, so what it asserts is what
+  a real consumer receives.
+- **INV-02** — The harness is read-only against the target beyond the
+  one-time seed of representative schema, honoring the Signals safety
+  model (no writes during collection, no superuser required).
+- **INV-03** — The char-type assertion (`contype == "f"`) is a
+  regression lock: it fails on the pre-#313 uncast SQL and passes on
+  the `::text`-cast SQL.
+
+## Failure conditions
+
+- **FC-01** — A declared column absent from a non-empty payload fails
+  OC-R002.
+- **FC-02** — An internal-`"char"` column decoding as a JSON number
+  (e.g. `contype == 102`) fails OC-R003.
+- **FC-03** — A `status="success"`/`row_count=N` run with no joinable
+  payload, or a payload whose row count ≠ N, fails OC-R004.
+
+## Constraints
+
+- The test is gated by the `integration` build tag and the
+  `SIGNALS_TEST_PG_DSN` env var; it SKIPS locally when unset and RUNS
+  in the CI PG-version matrix. It performs no network calls beyond the
+  target PostgreSQL connection.
+
+## Non-Functional Requirements
+
+- **NFR-01 — Version coverage.** The harness runs across PG
+  14/15/16/17/18 in CI so version-gated column/type differences surface.
+- **NFR-02 — Fast-follow scope.** This spec covers catalog/schema
+  collectors. Sweeping the remaining (~80) non-schema collectors under
+  the same output-contract harness is an explicit follow-up, to be
+  filed as a child issue of #314.

--- a/tests/signals_collector_output_contract_integration_test.go
+++ b/tests/signals_collector_output_contract_integration_test.go
@@ -1,0 +1,453 @@
+//go:build integration
+
+// Collector output-contract verification against a live PostgreSQL —
+// the missing STDD tests->artifact link for issue #314.
+//
+// The pgqueries unit tests are static (registration, read-only linting,
+// ordering); the collector SQL is never run, so the entire internal-
+// "char" class defect (#312) was invisible until it surfaced live —
+// pg_constraints_v1.contype serialized as the integer 102 instead of
+// the string "f", so the Analyzer's `contype == "f"` check skipped
+// every FK constraint (Elevarq/Analyzer#1871).
+//
+// This test closes that gap: it seeds representative schema (a parent +
+// child table with an UNINDEXED foreign key) into a real PG, runs the
+// full collection, exports a snapshot ZIP via the production
+// export.Builder path, reads it back, and asserts the per-collector
+// output contract for the catalog/schema collectors:
+//
+//   - OC-R003 / INV-CHAR-TEXT-VERIFIED: internal-"char" columns
+//     (contype, relkind, relpersistence, provolatile, prokind) decode as
+//     single-character STRINGS, never JSON numbers; the seeded FK yields
+//     a pg_constraints_v1 row with contype == "f" (the #312 lock).
+//   - OC-R002 / INV-OUTPUT-CONTRACT: each char-type catalog collector's
+//     spec-declared columns are present in its payload objects.
+//   - OC-R004 / INV-STATUS-PAYLOAD-VERIFIED: every exported success run
+//     with row_count=N has exactly one joinable payload with N rows.
+//
+// Gated by the `integration` build tag and SIGNALS_TEST_PG_DSN (skips
+// locally when unset), matching signals_integration_test.go. In CI it
+// runs against a postgres service container matrixed PG 14/15/16/17/18.
+//
+// Run with:
+//
+//	SIGNALS_TEST_PG_DSN="postgres://signals@localhost/postgres" \
+//	  go test -tags integration ./tests/ \
+//	  -run TestIntegration_CollectorOutputContractAgainstRealPG
+//
+// Spec: specifications/collector-output-contract.md (OC-R001..R004);
+//       features/signals/appendix-a-api-contract.md
+//       §"Collector output-contract verification (#314)".
+
+package tests
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/elevarq/signals/internal/collector"
+	"github.com/elevarq/signals/internal/config"
+	"github.com/elevarq/signals/internal/export"
+)
+
+// internalCharColumns are the PostgreSQL internal-"char" columns the
+// #313 fix cast ::text. pgx scans an uncast "char" as an integer byte,
+// so any of these appearing as a JSON number in a payload is the #312
+// regression. Names are the exported column aliases in the collector
+// SQL.
+var internalCharColumns = map[string]bool{
+	"contype":        true,
+	"relkind":        true,
+	"relpersistence": true,
+	"provolatile":    true,
+	"prokind":        true,
+}
+
+// declaredColumnsByCollector is the subset of spec-declared columns
+// (specifications/collectors/<id>.md "Output columns") asserted present
+// for the internal-"char" catalog collectors touched by #313. Kept to
+// the stable structural columns so version-gated additions don't make
+// the test brittle. OC-R002 / INV-OUTPUT-CONTRACT.
+var declaredColumnsByCollector = map[string][]string{
+	"pg_constraints_v1": {
+		"schemaname", "relname", "conname", "contype", "condef",
+		"column_name", "column_position", "relkind",
+	},
+	"pg_class_storage_v1": {
+		"relid", "schemaname", "relname", "relkind", "relpersistence",
+		"relispartition", "relhasindex",
+	},
+}
+
+// exportedRun mirrors the query_runs.ndjson row shape emitted by
+// export.Builder.writeQueryRuns.
+type exportedRun struct {
+	ID       string `json:"id"`
+	QueryID  string `json:"query_id"`
+	RowCount int    `json:"row_count"`
+	Status   string `json:"status"`
+	Reason   string `json:"reason"`
+	Error    string `json:"error"`
+}
+
+// exportedResult mirrors the query_results.ndjson row shape emitted by
+// export.Builder.writeQueryResults: run_id + decoded payload objects.
+type exportedResult struct {
+	RunID   string           `json:"run_id"`
+	Payload []map[string]any `json:"payload"`
+}
+
+func TestIntegration_CollectorOutputContractAgainstRealPG(t *testing.T) {
+	dsn := os.Getenv("SIGNALS_TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("SIGNALS_TEST_PG_DSN not set — skipping live PostgreSQL integration test")
+	}
+
+	seedRepresentativeSchema(t, dsn)
+
+	connCfg, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse SIGNALS_TEST_PG_DSN: %v", err)
+	}
+
+	// Collection reads the target password from the env var named by
+	// PasswordEnv (config.TargetConfig). Prefer an operator-supplied
+	// var name; otherwise carry the password from the DSN through a
+	// dedicated var so the collector authenticates the same way the
+	// seed did. Peer/trust auth leaves both empty and still works.
+	passwordEnv := os.Getenv("SIGNALS_TEST_PG_PASSWORD_ENV")
+	if passwordEnv == "" && connCfg.Password != "" {
+		passwordEnv = "SIGNALS_OC_TEST_PG_PASSWORD"
+		t.Setenv(passwordEnv, connCfg.Password)
+	}
+
+	// sslmode from the DSN when present (a CI service container is
+	// plaintext -> disable); default to prefer so a TLS-capable target
+	// still negotiates TLS.
+	sslMode := connCfg.RuntimeParams["sslmode"]
+	if sslMode == "" {
+		if connCfg.TLSConfig == nil {
+			sslMode = "disable"
+		} else {
+			sslMode = "prefer"
+		}
+	}
+
+	tgt := config.TargetConfig{
+		Name:        "output-contract-target",
+		Host:        connCfg.Host,
+		Port:        int(connCfg.Port),
+		DBName:      connCfg.Database,
+		User:        connCfg.User,
+		SSLMode:     sslMode,
+		PasswordEnv: passwordEnv,
+		Enabled:     true,
+	}
+
+	store := openTestDB(t)
+
+	// Run's immediate baseline cycle executes every eligible collector
+	// against a fresh store (no prior run has consumed the daily
+	// cadence), so the catalog/schema collectors we assert on all fire
+	// on the first cycle.
+	c := collector.New(
+		store,
+		[]config.TargetConfig{tgt},
+		24*time.Hour,
+		30,
+		collector.WithTargetTimeout(90*time.Second),
+		collector.WithQueryTimeout(20*time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.Run(ctx)
+	}()
+
+	// Run kicks off an immediate baseline cycle. Wait for it to land a
+	// snapshot rather than sleeping a fixed duration.
+	if !waitForSnapshotCount(t, store, 1, 120*time.Second) {
+		cancel()
+		<-done
+		t.Fatalf("initial collection did not produce a snapshot within 120s (connectivity / role-safety failure?)")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("collector goroutine did not stop within 15s of context cancel")
+	}
+
+	// Export a snapshot ZIP via the production path and read it back.
+	builder := export.NewBuilder(store, "output-contract-test")
+	var buf bytes.Buffer
+	if err := builder.WriteTo(&buf, export.Options{}); err != nil {
+		t.Fatalf("export WriteTo: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+
+	runs := readRuns(t, zr)
+	results := readResults(t, zr)
+
+	if len(runs) == 0 {
+		t.Fatal("exported snapshot carries no query_runs — collection produced nothing")
+	}
+
+	// --- OC-R004 / INV-STATUS-PAYLOAD-VERIFIED ---------------------
+	// Every success run with row_count=N joins to exactly one payload
+	// with exactly N objects. This is the end-to-end proof of
+	// INV-SNAP-STATUS-PAYLOAD (#312) through the real export.
+	resultByRunID := map[string]exportedResult{}
+	for _, r := range results {
+		if _, dup := resultByRunID[r.RunID]; dup {
+			t.Errorf("OC-R004: duplicate query_results payload for run_id %s", r.RunID)
+		}
+		resultByRunID[r.RunID] = r
+	}
+	for _, run := range runs {
+		if run.Status != "success" {
+			continue
+		}
+		res, ok := resultByRunID[run.ID]
+		if !ok {
+			t.Errorf("OC-R004 (INV-STATUS-PAYLOAD): success run %s (query_id=%s, row_count=%d) has NO joinable query_results payload",
+				run.ID, run.QueryID, run.RowCount)
+			continue
+		}
+		if len(res.Payload) != run.RowCount {
+			t.Errorf("OC-R004 (INV-STATUS-PAYLOAD): run %s (query_id=%s) declares row_count=%d but payload has %d rows",
+				run.ID, run.QueryID, run.RowCount, len(res.Payload))
+		}
+	}
+
+	// Index successful catalog/schema collector payloads by query_id.
+	payloadByQueryID := map[string][]map[string]any{}
+	for _, run := range runs {
+		if run.Status != "success" {
+			continue
+		}
+		if res, ok := resultByRunID[run.ID]; ok {
+			payloadByQueryID[run.QueryID] = res.Payload
+		}
+	}
+
+	// --- OC-R003 / INV-CHAR-TEXT-VERIFIED --------------------------
+	// Across ALL collector payloads, every internal-"char" column that
+	// appears must decode as a single-character STRING, never a number.
+	charSeen := 0
+	for queryID, payload := range payloadByQueryID {
+		for i, row := range payload {
+			for col, val := range row {
+				if !internalCharColumns[col] {
+					continue
+				}
+				if val == nil {
+					continue // NULLs are legitimate
+				}
+				charSeen++
+				s, isStr := val.(string)
+				if !isStr {
+					t.Errorf("OC-R003 (INV-CHAR-TEXT): %s row %d column %q is a %T (%v), want single-char string — the #312 regression (pgx scans \"char\" as int)",
+						queryID, i, col, val, val)
+					continue
+				}
+				if len(s) != 1 {
+					t.Errorf("OC-R003 (INV-CHAR-TEXT): %s row %d column %q = %q, want a single character",
+						queryID, i, col, s)
+				}
+			}
+		}
+	}
+	if charSeen == 0 {
+		t.Error("OC-R003: no internal-\"char\" columns observed in any payload — the seeded schema should have produced pg_constraints_v1/pg_class_storage_v1 rows; harness is not exercising the #312 class")
+	}
+
+	// --- OC-R003 (the exact #312 lock): the seeded unindexed FK MUST
+	// produce a pg_constraints_v1 row with contype == "f" (string). ---
+	constraints, ok := payloadByQueryID["pg_constraints_v1"]
+	if !ok {
+		t.Fatal("OC-R003: pg_constraints_v1 produced no successful payload — cannot verify the #312 contype==\"f\" lock")
+	}
+	foundFK := false
+	for _, row := range constraints {
+		if ct, _ := row["contype"].(string); ct == "f" {
+			foundFK = true
+			break
+		}
+	}
+	if !foundFK {
+		t.Errorf("OC-R003 (#312 LOCK): no pg_constraints_v1 row with contype==\"f\" for the seeded unindexed FK; contype values seen=%v — this is exactly the #312 regression (uncast contype serialized as 102)",
+			distinctContype(constraints))
+	}
+
+	// --- OC-R002 / INV-OUTPUT-CONTRACT -----------------------------
+	// Each char-type catalog collector's declared columns are present.
+	for collectorID, cols := range declaredColumnsByCollector {
+		payload, ok := payloadByQueryID[collectorID]
+		if !ok {
+			t.Errorf("OC-R002: expected collector %s to produce a payload against the seeded schema, but none present", collectorID)
+			continue
+		}
+		if len(payload) == 0 {
+			t.Errorf("OC-R002: collector %s produced an empty payload; cannot verify declared columns", collectorID)
+			continue
+		}
+		row := payload[0]
+		for _, col := range cols {
+			if _, present := row[col]; !present {
+				t.Errorf("OC-R002 (INV-OUTPUT-CONTRACT): collector %s payload is missing declared column %q; keys present=%v",
+					collectorID, col, keysOf(row))
+			}
+		}
+	}
+}
+
+// seedRepresentativeSchema creates a parent table (PK) and a child
+// table whose FK to the parent is UNINDEXED, plus a non-PK index and
+// columns of varied types. The unindexed FK is what makes
+// pg_constraint emit a contype='f' row — the exact #312 fixture.
+func seedRepresentativeSchema(t *testing.T, dsn string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed: connect: %v", err)
+	}
+	defer pool.Close()
+
+	// Idempotent seed in a dedicated schema so repeated runs are clean
+	// and we never touch the target's own objects.
+	stmts := []string{
+		`DROP SCHEMA IF EXISTS signals_oc_test CASCADE`,
+		`CREATE SCHEMA signals_oc_test`,
+		`CREATE TABLE signals_oc_test.parent (
+			id          bigint PRIMARY KEY,
+			label       text NOT NULL,
+			created_at  timestamptz NOT NULL DEFAULT now(),
+			ratio       double precision,
+			flags       boolean DEFAULT false
+		)`,
+		// Child table: fk_parent_id references parent(id) with NO index
+		// on the FK column -> pg_constraint emits a contype='f' row and
+		// the analyzer's missing-FK-index rule has a target.
+		`CREATE TABLE signals_oc_test.child (
+			id          bigint PRIMARY KEY,
+			fk_parent_id bigint NOT NULL
+				REFERENCES signals_oc_test.parent(id),
+			note        varchar(64),
+			amount      numeric(12,2)
+		)`,
+		// A non-PK index on a NON-FK column, so at least one ordinary
+		// index exists without accidentally indexing the FK.
+		`CREATE INDEX child_note_idx ON signals_oc_test.child (note)`,
+		`INSERT INTO signals_oc_test.parent (id, label, ratio)
+			VALUES (1, 'a', 1.5), (2, 'b', 2.5)`,
+		`INSERT INTO signals_oc_test.child (id, fk_parent_id, note, amount)
+			VALUES (10, 1, 'x', 9.99), (11, 2, 'y', 1.00)`,
+		// ANALYZE so pg_stat_user_tables / n_live_tup are populated.
+		`ANALYZE signals_oc_test.parent`,
+		`ANALYZE signals_oc_test.child`,
+	}
+	for _, s := range stmts {
+		if _, err := pool.Exec(ctx, s); err != nil {
+			t.Fatalf("seed stmt failed: %v\nSQL: %s", err, s)
+		}
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer ccancel()
+		p, err := pgxpool.New(cctx, dsn)
+		if err != nil {
+			return
+		}
+		defer p.Close()
+		_, _ = p.Exec(cctx, `DROP SCHEMA IF EXISTS signals_oc_test CASCADE`)
+	})
+}
+
+func readRuns(t *testing.T, zr *zip.Reader) []exportedRun {
+	t.Helper()
+	data := readZipFile(t, zr, "query_runs.ndjson")
+	var out []exportedRun
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	sc.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var r exportedRun
+		if err := json.Unmarshal(line, &r); err != nil {
+			t.Fatalf("decode query_runs row: %v\nline: %s", err, line)
+		}
+		out = append(out, r)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan query_runs.ndjson: %v", err)
+	}
+	return out
+}
+
+func readResults(t *testing.T, zr *zip.Reader) []exportedResult {
+	t.Helper()
+	data := readZipFile(t, zr, "query_results.ndjson")
+	var out []exportedResult
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	sc.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var r exportedResult
+		if err := json.Unmarshal(line, &r); err != nil {
+			t.Fatalf("decode query_results row: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan query_results.ndjson: %v", err)
+	}
+	return out
+}
+
+func distinctContype(rows []map[string]any) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, r := range rows {
+		v := fmt.Sprintf("%v (%T)", r["contype"], r["contype"])
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #314.

## The STDD gap this closes

The `pgqueries` tests are purely static (registration, read-only linting, ordering); the collector SQL is never run. That is why the whole internal-`"char"` class defect (#312) was invisible until it surfaced live: pgx scans PostgreSQL `"char"` as an integer byte, so `pg_constraints_v1.contype` serialized as `102` instead of `"f"`, the Analyzer's `contype == "f"` check failed, and **every FK constraint was skipped** (Elevarq/Analyzer#1871). The `specification -> tests -> implementation` chain was missing the `tests -> artifact` link.

## The harness (decided approach)

Spec-first (STDD):

- **Spec** `specifications/collector-output-contract.md` (ACTIVE, OC-R001..R004) + `specifications/collector-output-contract.acceptance.md`; new invariants in `features/signals/appendix-a-api-contract.md` (INV-OUTPUT-CONTRACT, INV-CHAR-TEXT-VERIFIED, INV-STATUS-PAYLOAD-VERIFIED); traceability rows added.
- **Integration test** `tests/signals_collector_output_contract_integration_test.go` (`//go:build integration`, `SIGNALS_TEST_PG_DSN`-gated so it SKIPS locally when no PG is present and never runs in the unit `test` job):
  1. seeds representative schema — a parent table (PK) + a child table with an **UNINDEXED foreign key** (so `pg_constraint` emits a `contype='f'` row), a non-PK index, columns of varied types;
  2. runs the full collection against the target and exports a snapshot ZIP via the **production** `export.Builder.WriteTo` path;
  3. reads the ZIP back and asserts, for the catalog/schema collectors: declared columns present; internal-`"char"` columns (`contype`, `relkind`, `relpersistence`, `provolatile`, `prokind`) decode as single-char **strings** not ints; and the **status<->payload invariant** (#312) end-to-end (every `status=success`/`row_count=N` run has a joinable payload with N rows).
- **CI** a new `integration-pg` job with a `postgres:${{ matrix.pg }}` service container matrixed across **PG 14/15/16/17/18**. Collection requires a non-superuser role (`ValidateRoleSafety` hard-fails on `rolsuper`), so the job creates a dedicated `signals` `pg_monitor` role and the test connects as it — never as `postgres`.

## The char-type regression lock

The exact #312 lock: the seeded unindexed FK MUST yield a `pg_constraints_v1` payload row with `contype == "f"`. Verified locally against PostgreSQL 17 — the test **passes** with the `::text` casts and goes **RED** when the cast is reverted (`contype` serialized as `102`, `contype=="f"` absent), exactly reproducing #312. This is the permanent lock on the class.

## Residual bug caught + fixed

The harness caught a live residual of the #312 class: `pg_class_storage_v1` emitted `relpersistence` **uncast**, so pgx returned the byte integer (`112`/`117`/`116`) instead of `p`/`u`/`t`. Fixed with a `::text` cast alongside the other char columns.

## Scope + follow-up

Scope is the **catalog/schema collectors** first (proves the harness, locks the #312 class). Sweeping the remaining (~80) non-schema collectors under the same output-contract harness is an explicit fast-follow, to be filed as a child of #314 (noted in the spec NFR-02).

## Gates

gofmt, `go vet` (default + `-tags integration`), golangci-lint (0 issues, default + integration tag), full `go test ./...`, docs drift guard, actionlint, gitleaks — all green locally. Self-verified the integration test against a local PostgreSQL 17 (74 collectors succeeded; RED-on-revert confirmed).

Refs #312, Elevarq/Analyzer#1871.