### PR TITLE
docs(changelog): fold char-type fix + output-contract tests into [1.1.0] (closes #317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
-
-- Collector output-contract verification against a live PostgreSQL: an
-  `integration`-tagged test seeds representative schema (parent + child
-  with an unindexed FK), runs the full collection, exports a snapshot ZIP
-  via the production export path, and asserts the per-collector output
-  contract — internal-`"char"` columns serialize as single-char strings
-  (the `contype == "f"` regression lock for #312), spec-declared columns
-  are present, and the status↔payload invariant holds end-to-end. Runs in
-  a new CI job matrixed across PG 14/15/16/17/18 (#314).
-
-### Fixed
-
-- `pg_class_storage_v1` emitted `relpersistence` uncast, so pgx scanned
-  the internal `"char"` as a byte integer (`112`/`117`/`116`) instead of
-  `p`/`u`/`t` — a residual of the #312 class the new #314 harness caught.
-  Now cast `::text` like the other char columns (#314).
-
-## [1.1.0] - 2026-07-22
+## [1.1.0] - 2026-07-28
 
 ### Added
 
@@ -32,15 +14,42 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#295).
 - Partitioned-index and relation-kind evidence in `index_health_summary_v2`
   (#298).
+- Collector output-contract verification against a live PostgreSQL: an
+  `integration`-tagged test seeds representative schema (parent + child
+  with an unindexed FK), runs the full collection, exports a snapshot ZIP
+  via the production export path, and asserts the per-collector output
+  contract — internal-`"char"` columns serialize as single-char strings
+  (the `contype == "f"` regression lock for #312), spec-declared columns
+  are present, and the status↔payload invariant holds end-to-end. Runs in
+  a new CI job matrixed across PG 14/15/16/17/18 (#314). Closes the STDD
+  gap where a specification's declared output was never asserted in the
+  exported ZIP end-to-end.
 
 ### Fixed
 
+- Snapshot char-type columns (`contype`, `relkind`, `relpersistence`,
+  `provolatile`, `prokind`) are now emitted as text via `::text` casts
+  instead of the PostgreSQL internal `"char"` type, which pgx decodes as an
+  integer byte value. Previously e.g. `contype` serialized as `102` rather
+  than `"f"`, so a consumer reading the value as a string silently skipped
+  every foreign-key constraint — the root cause of the Analyzer
+  missing-FK-index miss (Elevarq/Analyzer#1871). A collector run is also
+  never marked `success` before its payload is persisted, so
+  `query_runs`/`collector_status` can no longer claim rows the export does
+  not carry (#312, #313).
+- `pg_class_storage_v1` emitted `relpersistence` uncast, so pgx scanned
+  the internal `"char"` as a byte integer (`112`/`117`/`116`) instead of
+  `p`/`u`/`t` — a residual of the #312 class the new #314 harness caught.
+  Now cast `::text` like the other char columns (#314).
 - AWS EC2 deploy paths now forward the whole `signals.env` to the collector,
   not a partial subset (#299).
 
 ### Changed
 
+- Weekly security scan scheduled on the Monday-night cleanup window (#308).
+- Corrected the scheduled-scan timezone to `America/Los_Angeles` (#311).
 - Bump `google.golang.org/api` 0.288.0 -> 0.289.0 (#296).
+- Dependency group bumps: go-minor and actions-minor updates (#309, #310).
 
 ### Security
 


### PR DESCRIPTION
Closes #317.

The v1.1.0 release was prepared in #303 (Chart.yaml + appVersion bumped to 1.1.0, `## [1.1.0]` section written) but never tagged (latest tag is v1.0.3). Correctness-critical work merged since then had no `[1.1.0]` coverage:

- **#312 / #313** — snapshot char-type columns emitted as text (`::text` casts) instead of the internal `"char"` pgx decodes as an integer byte value; `contype` was serializing as `102` not `"f"`, silently skipping every FK constraint (root cause of Elevarq/Analyzer#1871). Plus the status/payload persistence invariant.
- **#314 / #315** — live-PG collector output-contract test layer (CI matrix 14-18); caught a residual uncast `relpersistence`.
- **#308 / #311 / #309 / #310** — CI schedule + timezone + dependency bumps.

Because 1.1.0 was never released, these are folded into the existing `## [1.1.0]` section (re-dated 2026-07-28) rather than a new version — the section now reflects what actually ships. This unblocks the v1.1.0 tag (the release workflow greps for `## [1.1.0]`).

Docs-only; gofmt/vet/test gates are no-ops for a `*.md` change.