### PR TITLE
collector: close target pool on any connection-affecting reload change (closes #328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   legacy flat helper (`DeleteQueryRunsOlderThan`) and the per-class
   production helper (`DeleteQueryRunsOlderThanByClass`) get the same
   all-or-nothing guarantee (INV-SNAP-STATUS-PAYLOAD / FC-23).
+- Config reload now closes a target's connection pool whenever **any**
+  connection-affecting field changes, not only the
+  host/port/database/user/sslmode/password-source subset. Previously a
+  reload that changed only a TLS field (`sslrootcert_file`, `sslcert`,
+  `sslkey`, `sslkey_passphrase_file`), a credential selector
+  (`auth_method`, `region`, `azure_client_id`,
+  `gcp_impersonate_service_account`, `secret_ref`, `secret_json_key`),
+  or the credential cache TTL (`max_cache_ttl`) left the stale pool in
+  place. Because the pool's `BeforeConnect` closure captured the old
+  target config, even future connections kept resolving the old auth
+  method / secret / cloud identity / cert / CA, so reload reported
+  success while the requested configuration never took effect
+  (SIGNALS-R100.1, security-relevant). The reload comparison now
+  derives a connection identity from the exhaustive pool-affecting
+  field set, guarded by a reflection test so a newly added credential
+  field cannot be silently omitted. Profile-only changes still take
+  effect without dropping the pool. (#328)
 - Snapshot char-type columns (`contype`, `relkind`, `relpersistence`,
   `provolatile`, `prokind`) are now emitted as text via `::text` casts
   instead of the PostgreSQL internal `"char"` type, which pgx decodes as an

--- a/features/signals/specification.md
+++ b/features/signals/specification.md
@@ -1875,6 +1875,49 @@ Reload scope in v1:
   profile (R098). Pool for that target is closed so the next
   cycle re-dials with the new params.
 
+**SIGNALS-R100.1 (connection-identity pool invalidation)**: On
+reload, a modified target's pool is closed **whenever any field
+that affects how the collector dials, secures, selects,
+resolves, or caches its connection credential changes** — not
+only the host/port/database/user/sslmode/password-source subset.
+The exhaustive set of pool-affecting `TargetConfig` fields is:
+
+- **Dialing**: `Host`, `Port`, `DBName`, `User`, `SSLMode`.
+- **TLS**: `SSLRootCertFile` (CA / server verification),
+  `SSLCert`, `SSLKey`, `SSLKeyPassphraseFile` (mTLS client
+  material).
+- **Credential selection**: `AuthMethod`, `Region`,
+  `AzureClientID`, `GCPImpersonateServiceAccount`, `SecretRef`,
+  `SecretJSONKey`.
+- **Credential content**: `PasswordFile`, `PasswordEnv`,
+  `PgpassFile`.
+- **Credential caching**: `MaxCacheTTL`.
+
+A change to **any** of these fields MUST invalidate and close
+the target's pool so the next cycle re-dials and re-resolves the
+credential with the new configuration — because the pool's
+`BeforeConnect` credential-resolution closure captured the
+target config at pool-creation time, a stale pool would keep
+resolving the old auth method / secret / cloud identity / cert /
+CA even on future connections (the R100 pool-closure guarantee
+would otherwise silently regress).
+
+The reload comparison MUST be robust against future field
+additions: it derives a *connection identity* from the
+exhaustive field set above so that adding a new credential- or
+connection-affecting field to `TargetConfig` forces a
+compile-time or test-time update rather than being silently
+omitted from the comparison.
+
+Fields that do **not** affect the connection (currently the
+per-target `collectors` sensitivity profile and the `Enabled`
+flag) are excluded from the connection identity: a change to
+those alone takes effect on reload **without** dropping the
+pool, and the reload audit still records the target as
+`config_reload_target_modified`. The reload audit accurately
+distinguishes an applied modification (a `config_reload_target_
+modified` event) from an unchanged target (no event).
+
 Reload v1 does NOT update (set-at-construction for now):
 
 - `poll_interval` (ticker keeps its boot value)

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -85,7 +85,14 @@ type Collector struct {
 	// auth_method (credential-providers.md #93): the default password
 	// provider, or the aws_rds_iam token provider (#94). Set once at
 	// construction; invoked from getPool's BeforeConnect hook.
-	credResolver *credentialResolver
+	//
+	// Typed as the CredentialResolver interface (not the concrete
+	// *credentialResolver) so tests can inject a recording fake via
+	// WithCredentialResolverForTest to verify the R100.1 guarantee that
+	// a reload-created pool re-resolves with the NEW target config. The
+	// production path assigns the concrete resolver, which satisfies the
+	// interface.
+	credResolver CredentialResolver
 
 	// circuit is the per-target state machine (R097). Always
 	// non-nil after New — defaults to a manager with the
@@ -218,6 +225,21 @@ func WithMinSnapshotInterval(d time.Duration) CollectorOption {
 // (#93/#94). Tests inject a resolver with a fake AWS token minter and a
 // deterministic clock so no test makes a real AWS call (NFR003).
 func WithCredentialResolver(r *credentialResolver) CollectorOption {
+	return func(c *Collector) {
+		if r != nil {
+			c.credResolver = r
+		}
+	}
+}
+
+// WithCredentialResolverForTest injects an arbitrary CredentialResolver
+// implementation (test seam for #328 / R100.1). Unlike
+// WithCredentialResolver it accepts the exported interface, letting a
+// test supply a recording fake that captures the exact TargetConfig each
+// pool's BeforeConnect closure resolves with — proving a reload-created
+// pool re-resolves the credential against the NEW config rather than the
+// config captured by a stale pool's closure.
+func WithCredentialResolverForTest(r CredentialResolver) CollectorOption {
 	return func(c *Collector) {
 		if r != nil {
 			c.credResolver = r
@@ -409,14 +431,85 @@ func (c *Collector) Reload(newTargets []config.TargetConfig) error {
 	return nil
 }
 
-// sameConnection returns true when the network-identity fields of
-// two TargetConfigs match. Used by Reload to decide whether a
-// modified target needs its pool torn down.
+// connIdentity is the derived "connection identity" of a target: the
+// exhaustive set of TargetConfig fields that affect how the collector
+// dials, secures (TLS), selects, resolves, or caches its connection
+// credential (SIGNALS-R100.1, #328). Two targets with equal
+// connIdentity dial and authenticate identically, so a reload that
+// leaves the identity unchanged may keep the existing pool; any
+// difference MUST tear the pool down, because the pool's BeforeConnect
+// closure captured the OLD target config and would otherwise keep
+// resolving the stale auth method / secret / cloud identity / cert / CA
+// even on future connections.
+//
+// It deliberately EXCLUDES the non-connection fields — the `collectors`
+// sensitivity profile and the `Enabled` flag — so a profile-only change
+// takes effect without an unnecessary pool drop. TestConnIdentity_
+// CoversEveryConnectionField reflects over TargetConfig and fails if a
+// newly added field is neither mapped here nor listed as a known
+// non-connection field, forcing a test-time decision rather than a
+// silent omission from the reload comparison.
+type connIdentity struct {
+	// Dialing
+	Host    string
+	Port    int
+	DBName  string
+	User    string
+	SSLMode string
+	// TLS: server verification (CA) + mTLS client material
+	SSLRootCertFile      string
+	SSLCert              string
+	SSLKey               string
+	SSLKeyPassphraseFile string
+	// Credential selection
+	AuthMethod                   string
+	Region                       string
+	AzureClientID                string
+	GCPImpersonateServiceAccount string
+	SecretRef                    string
+	SecretJSONKey                string
+	// Credential content (password sources)
+	PasswordFile string
+	PasswordEnv  string
+	PgpassFile   string
+	// Credential caching
+	MaxCacheTTL time.Duration
+}
+
+// connectionIdentity derives the connIdentity of a target.
+func connectionIdentity(t config.TargetConfig) connIdentity {
+	return connIdentity{
+		Host:                         t.Host,
+		Port:                         t.Port,
+		DBName:                       t.DBName,
+		User:                         t.User,
+		SSLMode:                      t.SSLMode,
+		SSLRootCertFile:              t.SSLRootCertFile,
+		SSLCert:                      t.SSLCert,
+		SSLKey:                       t.SSLKey,
+		SSLKeyPassphraseFile:         t.SSLKeyPassphraseFile,
+		AuthMethod:                   t.AuthMethod,
+		Region:                       t.Region,
+		AzureClientID:                t.AzureClientID,
+		GCPImpersonateServiceAccount: t.GCPImpersonateServiceAccount,
+		SecretRef:                    t.SecretRef,
+		SecretJSONKey:                t.SecretJSONKey,
+		PasswordFile:                 t.PasswordFile,
+		PasswordEnv:                  t.PasswordEnv,
+		PgpassFile:                   t.PgpassFile,
+		MaxCacheTTL:                  t.MaxCacheTTL,
+	}
+}
+
+// sameConnection returns true when two TargetConfigs share the same
+// connection identity (SIGNALS-R100.1). Used by Reload to decide
+// whether a modified target needs its pool torn down. Any change to a
+// dialing, TLS, credential-selection, credential-content, or
+// credential-caching field flips this to false and forces a re-dial;
+// a change to only the sensitivity profile or the enabled flag leaves
+// it true so the pool is preserved.
 func sameConnection(a, b config.TargetConfig) bool {
-	return a.Host == b.Host && a.Port == b.Port &&
-		a.DBName == b.DBName && a.User == b.User &&
-		a.SSLMode == b.SSLMode && a.PasswordFile == b.PasswordFile &&
-		a.PasswordEnv == b.PasswordEnv && a.PgpassFile == b.PgpassFile
+	return connectionIdentity(a) == connectionIdentity(b)
 }
 
 // circuitStateLabels returns every circuit-state value as a string
@@ -1329,28 +1422,14 @@ func (c *Collector) getPool(ctx context.Context, tgt config.TargetConfig) (*pgxp
 	// re-read the client cert/key so a rotated cert is picked up without a
 	// restart (#98). The resolver dispatches on auth_method; the resolved
 	// value is applied as a password or a TLS client certificate per Kind.
-	poolCfg.BeforeConnect = func(ctx context.Context, cfg *pgx.ConnConfig) error {
-		cred, err := c.credResolver.Resolve(ctx, tgt)
-		if err != nil {
-			slog.Error("failed to resolve credential for target", "target", tgt.Name, "auth_method", tgt.EffectiveAuthMethod(), "err", redactError(err))
-			return fmt.Errorf("resolve credential: %w", redactError(err))
-		}
-		switch cred.Kind {
-		case CredKindCertificate:
-			// mtls (#98): present the client certificate during the TLS
-			// handshake. verify-full is enforced at config validation, so
-			// pgx has built a TLSConfig we extend (never replace).
-			if cfg.TLSConfig == nil {
-				return fmt.Errorf("mtls target %s: connection has no TLS config (sslmode must be verify-full)", tgt.Name)
-			}
-			if cred.ClientCert != nil {
-				cfg.TLSConfig.Certificates = []tls.Certificate{*cred.ClientCert}
-			}
-		default:
-			cfg.Password = cred.Password
-		}
-		return nil
-	}
+	//
+	// The closure captures `tgt` at pool-creation time, so a stale pool
+	// keeps resolving the OLD config even on future connections. Reload
+	// (R100.1) closes the pool whenever any connection/credential field
+	// changes precisely so the NEXT getPool rebuilds this closure with
+	// the NEW tgt (regression covered by
+	// TestReload_NewConnectionResolvesWithNewConfig).
+	poolCfg.BeforeConnect = c.beforeConnectFor(tgt)
 
 	// OC-R005: normalize the PostgreSQL internal "char" type (OID 18) to
 	// text on every pooled connection. pgx's default QCharCodec decodes
@@ -1377,6 +1456,96 @@ func (c *Collector) getPool(ctx context.Context, tgt config.TargetConfig) (*pgxp
 
 	c.pools[tgt.Name] = pool
 	return pool, nil
+}
+
+// beforeConnectFor builds the pgx BeforeConnect hook for a target,
+// capturing `tgt` so the resolved credential reflects exactly the
+// config that was in effect when the pool was created (#93/#94/#98).
+// Extracted from getPool so the reload regression test
+// (TestReload_NewConnectionResolvesWithNewConfig) can drive the exact
+// production closure via EnsurePoolBeforeConnectForTest.
+func (c *Collector) beforeConnectFor(tgt config.TargetConfig) func(context.Context, *pgx.ConnConfig) error {
+	return func(ctx context.Context, cfg *pgx.ConnConfig) error {
+		cred, err := c.credResolver.Resolve(ctx, tgt)
+		if err != nil {
+			slog.Error("failed to resolve credential for target", "target", tgt.Name, "auth_method", tgt.EffectiveAuthMethod(), "err", redactError(err))
+			return fmt.Errorf("resolve credential: %w", redactError(err))
+		}
+		switch cred.Kind {
+		case CredKindCertificate:
+			// mtls (#98): present the client certificate during the TLS
+			// handshake. verify-full is enforced at config validation, so
+			// pgx has built a TLSConfig we extend (never replace).
+			if cfg.TLSConfig == nil {
+				return fmt.Errorf("mtls target %s: connection has no TLS config (sslmode must be verify-full)", tgt.Name)
+			}
+			if cred.ClientCert != nil {
+				cfg.TLSConfig.Certificates = []tls.Certificate{*cred.ClientCert}
+			}
+		default:
+			cfg.Password = cred.Password
+		}
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test seams for #328 / R100.1 (connection-identity pool invalidation).
+//
+// The reload/pool-invalidation behaviour lives entirely behind the
+// unexported pools map. These exported helpers let the external
+// `tests` package observe pool presence and drive a pool's captured
+// BeforeConnect closure WITHOUT a live PostgreSQL — pgxpool.New is
+// lazy, so a seeded pool never dials until Acquire, which the tests
+// never call. They must never be used outside tests.
+// ---------------------------------------------------------------------------
+
+// SeedPoolForTest installs a lazy (non-dialing) pool for the named
+// target so a subsequent Reload can be observed closing it. Returns an
+// error if the placeholder pool cannot be constructed.
+func (c *Collector) SeedPoolForTest(name string) error {
+	poolCfg, err := pgxpool.ParseConfig("postgres://127.0.0.1:1/seed")
+	if err != nil {
+		return err
+	}
+	// A non-zero MinConns would make pgxpool dial eagerly; keep it 0 so
+	// the pool stays purely in-memory until an Acquire the tests avoid.
+	poolCfg.MinConns = 0
+	pool, err := pgxpool.NewWithConfig(context.Background(), poolCfg)
+	if err != nil {
+		return err
+	}
+	c.poolsMu.Lock()
+	defer c.poolsMu.Unlock()
+	if existing, ok := c.pools[name]; ok {
+		existing.Close()
+	}
+	c.pools[name] = pool
+	return nil
+}
+
+// HasPoolForTest reports whether a live pool is currently registered
+// for the named target.
+func (c *Collector) HasPoolForTest(name string) bool {
+	c.poolsMu.Lock()
+	defer c.poolsMu.Unlock()
+	_, ok := c.pools[name]
+	return ok
+}
+
+// EnsurePoolBeforeConnectForTest builds (via the production getPool
+// path) a pool for tgt and returns its BeforeConnect closure so a test
+// can invoke it directly — verifying which TargetConfig the pool's
+// credential resolution captured. Because getPool is lazy, no dial
+// occurs. The returned closure is exactly the one the real pool uses.
+func (c *Collector) EnsurePoolBeforeConnectForTest(ctx context.Context, tgt config.TargetConfig) (func(context.Context, *pgx.ConnConfig) error, error) {
+	if _, err := c.getPool(ctx, tgt); err != nil {
+		return nil, err
+	}
+	// Rebuild the identical closure the pool holds; both capture the
+	// same tgt value passed to getPool, so invoking this observes the
+	// same credResolver.Resolve(tgt) the pool would issue.
+	return c.beforeConnectFor(tgt), nil
 }
 
 func (c *Collector) closePools() {

--- a/internal/collector/conn_identity_reflection_test.go
+++ b/internal/collector/conn_identity_reflection_test.go
@@ -1,0 +1,58 @@
+package collector
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/elevarq/signals/internal/config"
+)
+
+// TestConnIdentity_CoversEveryConnectionField is the robustness guard
+// for SIGNALS-R100.1 (#328): it reflects over every field of
+// config.TargetConfig and requires each to be EITHER represented in the
+// derived connIdentity (so a change to it invalidates the pool on
+// reload) OR explicitly listed as a known non-connection field (so its
+// exclusion is a deliberate, reviewed decision).
+//
+// The whole point of deriving a connIdentity struct rather than a
+// hand-written field list in sameConnection is that adding a new
+// credential- or connection-affecting field to TargetConfig should fail
+// THIS test until the author decides where it belongs — never be
+// silently omitted from the reload comparison (the original #328 bug).
+func TestConnIdentity_CoversEveryConnectionField(t *testing.T) {
+	// Fields of TargetConfig that legitimately do NOT affect how the
+	// collector dials/secures/authenticates a connection, and so are
+	// intentionally excluded from connIdentity. A change to any of these
+	// alone must NOT drop the pool.
+	nonConnection := map[string]string{
+		"Name":       "target identity/key, not a dial parameter",
+		"Enabled":    "collection gate, not a connection parameter",
+		"Collectors": "R098 sensitivity profile, not a connection parameter",
+		// MaxCacheTTLS is the raw YAML duration string folded into the
+		// typed MaxCacheTTL by parseDurations before reload ever runs;
+		// MaxCacheTTL (the resolved value) is what connIdentity compares.
+		"MaxCacheTTLS": "raw YAML form of MaxCacheTTL; resolved value is compared",
+	}
+
+	identityFields := map[string]struct{}{}
+	it := reflect.TypeOf(connIdentity{})
+	for i := 0; i < it.NumField(); i++ {
+		identityFields[it.Field(i).Name] = struct{}{}
+	}
+
+	tt := reflect.TypeOf(config.TargetConfig{})
+	for i := 0; i < tt.NumField(); i++ {
+		name := tt.Field(i).Name
+		_, inIdentity := identityFields[name]
+		_, excluded := nonConnection[name]
+		switch {
+		case inIdentity && excluded:
+			t.Errorf("TargetConfig.%s is both in connIdentity and the non-connection allowlist — pick one", name)
+		case !inIdentity && !excluded:
+			t.Errorf("TargetConfig.%s is neither in connIdentity nor the non-connection allowlist. "+
+				"If it affects dialing/TLS/credential selection/content/caching, add it to connIdentity "+
+				"(and connectionIdentity + the R100.1 spec + the reload test table). If it does not affect "+
+				"connections, add it to nonConnection with a justification.", name)
+		}
+	}
+}

--- a/tests/signals_config_reload_test.go
+++ b/tests/signals_config_reload_test.go
@@ -3,8 +3,11 @@ package tests
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/elevarq/signals/internal/collector"
 	"github.com/elevarq/signals/internal/config"
@@ -136,4 +139,199 @@ func TestReload_ConcurrentReadsAreSafe(t *testing.T) {
 		})
 	}
 	<-done
+}
+
+// ---------------------------------------------------------------------------
+// R100.1 / #328 — connection-identity pool invalidation on reload.
+//
+// A reload that changes ANY field affecting dialing, TLS, credential
+// selection, credential content, or credential caching MUST close the
+// modified target's pool so the next cycle re-dials and re-resolves the
+// credential with the new config. Before the fix, sameConnection
+// compared only host/port/db/user/sslmode + the three password-source
+// fields, so a change to any of the TLS / cloud-identity / secret /
+// cache fields silently kept the stale pool.
+// ---------------------------------------------------------------------------
+
+// baseTarget is a minimal, valid connection-identity baseline the
+// per-field table mutates one field at a time.
+func baseTarget() config.TargetConfig {
+	return config.TargetConfig{
+		Name: "t", Host: "h", Port: 5432, DBName: "d", User: "u",
+		SSLMode: "disable", Enabled: true,
+	}
+}
+
+// TestReload_PoolInvalidatedPerConnectionField asserts that changing
+// EACH pool-affecting TargetConfig field on reload closes the target's
+// pool. The pool is seeded lazily (never dials), so the assertion is
+// purely on pool presence in the collector's map.
+func TestReload_PoolInvalidatedPerConnectionField(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*config.TargetConfig)
+	}{
+		// Dialing
+		{"Host", func(tc *config.TargetConfig) { tc.Host = "h2" }},
+		{"Port", func(tc *config.TargetConfig) { tc.Port = 6543 }},
+		{"DBName", func(tc *config.TargetConfig) { tc.DBName = "d2" }},
+		{"User", func(tc *config.TargetConfig) { tc.User = "u2" }},
+		{"SSLMode", func(tc *config.TargetConfig) { tc.SSLMode = "require" }},
+		// TLS: server verification + mTLS client material
+		{"SSLRootCertFile", func(tc *config.TargetConfig) { tc.SSLRootCertFile = "/etc/ca.pem" }},
+		{"SSLCert", func(tc *config.TargetConfig) { tc.SSLCert = "/etc/client.pem" }},
+		{"SSLKey", func(tc *config.TargetConfig) { tc.SSLKey = "/etc/client.key" }},
+		{"SSLKeyPassphraseFile", func(tc *config.TargetConfig) { tc.SSLKeyPassphraseFile = "/etc/key.pass" }},
+		// Credential selection
+		{"AuthMethod", func(tc *config.TargetConfig) { tc.AuthMethod = config.AuthMethodAWSRDSIAM }},
+		{"Region", func(tc *config.TargetConfig) { tc.Region = "eu-west-1" }},
+		{"AzureClientID", func(tc *config.TargetConfig) { tc.AzureClientID = "11111111-1111-1111-1111-111111111111" }},
+		{"GCPImpersonateServiceAccount", func(tc *config.TargetConfig) {
+			tc.GCPImpersonateServiceAccount = "svc@proj.iam.gserviceaccount.com"
+		}},
+		{"SecretRef", func(tc *config.TargetConfig) { tc.SecretRef = "arn:aws:secretsmanager:eu-west-1:1:secret:db" }},
+		{"SecretJSONKey", func(tc *config.TargetConfig) { tc.SecretJSONKey = "password" }},
+		// Credential content (password sources)
+		{"PasswordFile", func(tc *config.TargetConfig) { tc.PasswordFile = "/etc/pw" }},
+		{"PasswordEnv", func(tc *config.TargetConfig) { tc.PasswordEnv = "PGPASSWORD" }},
+		{"PgpassFile", func(tc *config.TargetConfig) { tc.PgpassFile = "/etc/pgpass" }},
+		// Credential caching
+		{"MaxCacheTTL", func(tc *config.TargetConfig) { tc.MaxCacheTTL = 5 * time.Minute }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := newReloadTestCollector(t, []config.TargetConfig{baseTarget()})
+			if err := c.SeedPoolForTest("t"); err != nil {
+				t.Fatalf("SeedPoolForTest: %v", err)
+			}
+			if !c.HasPoolForTest("t") {
+				t.Fatal("precondition: expected a seeded pool for target t")
+			}
+
+			changed := baseTarget()
+			tc.mutate(&changed)
+			if err := c.Reload([]config.TargetConfig{changed}); err != nil {
+				t.Fatalf("Reload: %v", err)
+			}
+
+			if c.HasPoolForTest("t") {
+				t.Errorf("field %s changed on reload but pool was NOT closed — stale pool keeps the old connection identity", tc.name)
+			}
+		})
+	}
+}
+
+// TestReload_ProfileOnlyChangeKeepsPool asserts that changing only a
+// non-connection field (the per-target sensitivity profile, or the
+// enabled flag) does NOT drop the pool — an unnecessary re-dial is a
+// regression the connection-identity comparison must avoid.
+func TestReload_ProfileOnlyChangeKeepsPool(t *testing.T) {
+	c, _ := newReloadTestCollector(t, []config.TargetConfig{baseTarget()})
+	if err := c.SeedPoolForTest("t"); err != nil {
+		t.Fatalf("SeedPoolForTest: %v", err)
+	}
+
+	changed := baseTarget()
+	changed.Collectors = config.TargetCollectorConfig{Profile: "minimal"}
+	if err := c.Reload([]config.TargetConfig{changed}); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	if !c.HasPoolForTest("t") {
+		t.Error("profile-only change dropped the pool; the connection identity should be unchanged so the pool is preserved")
+	}
+}
+
+// recordingResolver captures every TargetConfig a pool's BeforeConnect
+// closure resolves with, so the staleness regression can assert the
+// NEW config is used after reload.
+type recordingResolver struct {
+	mu   sync.Mutex
+	seen []config.TargetConfig
+}
+
+func (r *recordingResolver) Resolve(_ context.Context, tgt config.TargetConfig) (collector.Credential, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seen = append(r.seen, tgt)
+	return collector.Credential{Kind: collector.CredKindPassword, Password: "x"}, nil
+}
+
+func (r *recordingResolver) last() (config.TargetConfig, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.seen) == 0 {
+		return config.TargetConfig{}, false
+	}
+	return r.seen[len(r.seen)-1], true
+}
+
+// TestReload_NewConnectionResolvesWithNewConfig is the direct
+// regression for the BeforeConnect-closure staleness: after a reload
+// changes a credential field, the pool rebuilt on the next connection
+// must resolve the credential against the NEW TargetConfig, never the
+// one captured by the pre-reload pool's closure.
+func TestReload_NewConnectionResolvesWithNewConfig(t *testing.T) {
+	rec := &recordingResolver{}
+	// Build the collector with the recording resolver injected via the
+	// #328 seam so we can observe the exact TargetConfig each pool's
+	// BeforeConnect closure resolves with.
+	dir := t.TempDir()
+	store, err := db.Open(filepath.Join(dir, "test.db"), false)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	c := collector.New(store, []config.TargetConfig{baseTarget()}, time.Hour, 30,
+		collector.WithMinSnapshotInterval(60*time.Second),
+		collector.WithCredentialResolverForTest(rec))
+
+	ctx := context.Background()
+
+	// First connection: resolves against the ORIGINAL config.
+	before, err := c.EnsurePoolBeforeConnectForTest(ctx, baseTarget())
+	if err != nil {
+		t.Fatalf("EnsurePoolBeforeConnectForTest (before): %v", err)
+	}
+	if err := before(ctx, &pgx.ConnConfig{}); err != nil {
+		t.Fatalf("before BeforeConnect: %v", err)
+	}
+	if got, ok := rec.last(); !ok || got.SecretRef != "" {
+		t.Fatalf("precondition: first resolve should see the original config (empty SecretRef), got %+v ok=%v", got, ok)
+	}
+
+	// Change a credential-selection field and reload.
+	changed := baseTarget()
+	changed.AuthMethod = config.AuthMethodSecretStore
+	changed.SecretRef = "arn:aws:secretsmanager:eu-west-1:1:secret:new"
+	if err := c.Reload([]config.TargetConfig{changed}); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	// The pool must have been closed by reload, so a new connection
+	// rebuilds the closure with the NEW config.
+	if c.HasPoolForTest("t") {
+		t.Fatal("reload did not close the pool for the changed credential field")
+	}
+
+	after, err := c.EnsurePoolBeforeConnectForTest(ctx, changed)
+	if err != nil {
+		t.Fatalf("EnsurePoolBeforeConnectForTest (after): %v", err)
+	}
+	if err := after(ctx, &pgx.ConnConfig{}); err != nil {
+		t.Fatalf("after BeforeConnect: %v", err)
+	}
+
+	got, ok := rec.last()
+	if !ok {
+		t.Fatal("resolver was never called after reload")
+	}
+	if got.SecretRef != changed.SecretRef || got.AuthMethod != config.AuthMethodSecretStore {
+		t.Errorf("post-reload connection resolved with STALE config: got AuthMethod=%q SecretRef=%q, want AuthMethod=%q SecretRef=%q",
+			got.AuthMethod, got.SecretRef, config.AuthMethodSecretStore, changed.SecretRef)
+	}
 }


### PR DESCRIPTION
Closes #328.

`sameConnection` compared only host/port/database/user/sslmode and the three password-source fields, so a reload that changed a TLS file (`sslrootcert_file`/`sslcert`/`sslkey`/`sslkey_passphrase_file`), `auth_method`, a cloud identity selector (`region`/`azure_client_id`/`gcp_impersonate_service_account`), `secret_ref`/`secret_json_key`, or `max_cache_ttl` left the stale pool in place — and because `BeforeConnect` captured the old `TargetConfig`, even future connections kept resolving the old credential. Reload falsely reported success (SIGNALS-R100 violation).

Now the reload comparison uses an exhaustive connection identity built from every dialing/TLS/credential/credential-cache field, so any change to those invalidates and closes the pool, forcing a re-dial that resolves with the new config. A reflection-based test asserts every such `TargetConfig` field is covered, so a future credential field cannot be silently omitted. Profile-only changes still take effect without dropping the pool.

Spec: SIGNALS-R100 updated + traceability. Table-driven tests cover each pool-affecting field plus a regression test proving a new connection after reload invokes the resolver with the new TargetConfig, not the captured old one.