### PR TITLE
export: per-call local scope + strict per-collector regrouping (#322, #323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,32 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Concurrent exports can no longer cross-contaminate each other's
+  archives. The daemon shares one long-lived `export.Builder` across
+  every `GET /export` request, and request-specific scope (resolved
+  snapshots, resolved run set, snapshot-ID membership, run-scope label)
+  was stored on that shared Builder — so two overlapping exports with
+  different selectors raced on those fields and one archive could report
+  the other's scope (a data race under `go test -race`). Request scope
+  is now local and immutable for a single `WriteTo` call, carried in a
+  per-call value threaded through every writer; the Builder holds only
+  set-once construction-time config. Two concurrent exports with
+  different `--snapshot-id`/`--target-id` vs `--all`/default selectors
+  now each contain only their own data (#323, SIGNALS-R110).
+- The per-collector export directory is now a strict regrouping of the
+  export's already-resolved in-scope run set instead of a fresh, more
+  permissive re-query. Previously `writePerCollectorFiles` re-queried by
+  `target_id` + time range only, so a snapshot-scoped archive could
+  carry a payload from another snapshot, the default scope could pull
+  disabled-target and history runs absent from `query_runs.ndjson`, and
+  an unscoped multi-target export grouped only by `query_id` — one
+  target silently won and attribution was lost. Files are now grouped by
+  `(target_id, query_id)` under `per-collector/<target_id>/`, so every
+  per-collector run also appears in canonical `query_runs.ndjson` and
+  target attribution is preserved. A missing or corrupt payload for a
+  successful in-scope run now fails the export (same guard as
+  `query_results.ndjson`) instead of emitting a zero-row success stub
+  (#322, SIGNALS-R080).
 - Retention cleanup now deletes a run's `query_results` payload and its
   `query_runs` row inside a single SQLite transaction, so both commit
   together or roll back together (#327). Previously the two deletes ran as

--- a/features/signals/specification.md
+++ b/features/signals/specification.md
@@ -597,6 +597,25 @@ A future revision MAY upgrade this to a per-export SQLite read
 transaction (true WAL MVCC snapshot) without changing the externally
 observable invariant.
 
+**Concurrency model — per-call local scope (issue #323).** Because
+multiple exports run concurrently (shared read lock, above), the
+request-specific scope of a single `WriteTo` call **shall be local and
+immutable for that call**. The resolved scope — the in-scope snapshot
+rows, the snapshot-ID membership set, the resolved query-run set, and
+the `run_scope` label — is carried in a per-call value threaded through
+every file writer, **never stored on the shared exporter**. The daemon
+constructs one long-lived exporter and dispatches every `GET /export`
+request through it; the only mutable state that exporter may hold is
+set-once construction-time configuration (store handle, instance ID,
+unsafe-mode flag, collector-status file, the per-collector-files
+toggle), which is read-only for the daemon lifetime and identical for
+every request. Consequently two concurrent `WriteTo` calls with
+different selectors (`--snapshot-id`/`--target-id` versus
+`--all`/default) cannot alias each other's scope: each produced archive
+contains only its own metadata, snapshots, `query_runs`,
+`query_results`, `collector_status`, and optional per-collector data.
+This invariant holds under the Go race detector.
+
 **SIGNALS-R073**: The system shall support target-scoped export.
 When exporting for a specific target, query_runs, query_results, and
 collector_status shall contain only data for that target. The
@@ -2314,22 +2333,45 @@ The view is **off by default** to keep the ZIP small. It is enabled
 by `signals.export_per_collector_files: true` (or the equivalent
 `SIGNALS_EXPORT_PER_COLLECTOR_FILES=true` environment variable).
 
-When enabled, the export ZIP contains a `per-collector/` directory
-with one JSON file per collector that has at least one entry in
-`collector_status.json` for the export's scope:
+The per-collector view is a **strict regrouping of the export's
+already-resolved in-scope run set** — the same set that produced
+`query_runs.ndjson` and `query_results.ndjson`. It shall be derived
+**exclusively** from that resolved set and shall **never** re-query the
+store with a narrower or different selector. Consequently every scope
+selector (`--snapshot-id`, `--target-id`, `--all`, `--since`/`--until`,
+and the R084 default of the latest run per collector across active
+targets only, excluding disabled targets and orphan runs) yields
+per-collector files whose runs match the canonical files exactly.
 
-- File name: `per-collector/<query_id>.json`. The `query_id` is the
-  stable logical collector ID (e.g. `pg_stat_database_v1`); it is
-  the same value already used in `collector_status.json` and
-  `query_runs.ndjson`.
+**Invariant (issue #322):** no per-collector `run_id` or payload may
+appear unless that same run is present in `query_runs.ndjson`. A
+per-collector file is never a superset of, and never scoped
+differently from, the canonical bundle.
+
+When enabled, the export ZIP contains a `per-collector/` directory
+keyed by `(target_id, query_id)` drawn from the resolved run set:
+
+- File name: `per-collector/<target_id>/<query_id>.json`. The
+  `query_id` is the stable logical collector ID (e.g.
+  `pg_stat_database_v1`); it is the same value used in
+  `collector_status.json` and `query_runs.ndjson`. Grouping by
+  `(target_id, query_id)` — with `target_id` as a subdirectory —
+  preserves target attribution: a multi-target export keeps each
+  target's run for a collector as its own file instead of one target
+  silently winning a `query_id`-only grouping.
 - File content: a JSON object with the latest run's status, run
-  metadata (target name, collected_at, duration_ms, row_count, pg
-  version), and — for successful runs — the row payload as a JSON
-  array. For skipped or failed runs the row payload is omitted and
-  the reason / detail are included.
-- Latest-run-wins ordering: when the export covers multiple cycles,
-  the per-collector file reflects the most recent run for that
-  collector within the export's scope.
+  metadata (target_id, target name, collected_at, duration_ms,
+  row_count, pg version), and — for successful runs — the row payload
+  as a JSON array. For skipped or failed runs the row payload is
+  omitted and the reason / detail are included.
+- Latest-run-wins ordering: when the resolved scope contains multiple
+  runs for the same `(target_id, query_id)`, the per-collector file
+  reflects the most recent run for that pair within the scope.
+
+**Failure condition (issue #322):** when a successful in-scope run has
+a missing or corrupt result payload, the export **fails** with the same
+guard `query_results.ndjson` applies — it shall not emit a
+zero-row success stub that masks the data-integrity failure.
 
 The per-collector files do not introduce any new field beyond what
 already exists in the canonical NDJSON bundle. They are a regrouping

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/elevarq/signals/internal/collector"
@@ -56,6 +57,16 @@ type Options struct {
 const CollectorStatusSchemaVersion = "1"
 
 // Builder creates a ZIP export of collected data.
+//
+// R110 concurrency model (issue #323): a Builder holds ONLY set-once
+// construction-time configuration (store handle, instance ID,
+// unsafe-mode flag, collector-status file, the per-collector-files
+// toggle). Every field below is written before the daemon starts
+// serving and is read-only for its lifetime, so the single long-lived
+// Builder the daemon shares across concurrent GET /export requests is
+// safe to call concurrently. Per-request scope is NOT stored here — it
+// lives in a per-call exportScope value threaded through the writers,
+// so two concurrent WriteTo calls cannot alias each other's scope.
 type Builder struct {
 	store                            *db.DB
 	instanceID                       string
@@ -64,26 +75,27 @@ type Builder struct {
 	collectorStatus                  *collector.CollectorStatusFile
 	highSensitivityCollectorsEnabled bool
 	perCollectorFiles                bool
+}
 
-	// Per-call snapshot scope, resolved at the top of WriteTo from
-	// Options and used by every writer below it. R084/R085: holding
-	// the resolved set on the Builder keeps the writer signatures
-	// unchanged while ensuring snapshots, query_runs, and
-	// query_results can never disagree about which cycles are in
-	// scope.
-	scopedSnapshots   []db.Snapshot
-	scopedSnapshotIDs map[string]bool
-
-	// scopedRunSet is the resolved set of query_runs for the export.
-	// For selector scopes it is every run in scopedSnapshots; for the
-	// R084 default scope it is the latest run per (target_id, query_id)
-	// — which may reference more snapshots than the selector path. Held
-	// on the builder so collector_status, query_runs, and query_results
-	// all draw from the same set.
-	scopedRunSet []db.QueryRun
-	// runScope labels the scope in metadata.json (R086):
-	// "latest-per-collector" for the default, "snapshot" for selectors.
-	runScope string
+// exportScope is the request-specific scope of a single WriteTo call.
+// It is resolved once at the top of WriteTo and passed by value/pointer
+// to every writer, so it is local and immutable for that call (issue
+// #323). Nothing here is ever stored on the shared Builder.
+//
+//   - snapshots      — the snapshot rows in scope (R084/R085).
+//   - snapshotIDs    — membership set for the scoped snapshots.
+//   - runSet         — the resolved query_runs. For selector scopes it
+//     is every run in the scoped snapshots; for the R084 default scope
+//     it is the latest run per (target_id, query_id). collector_status,
+//     query_runs, query_results, and the per-collector view all draw
+//     from this one set so they can never disagree (issue #322).
+//   - runScope       — metadata.json label (R086): "latest-per-collector"
+//     for the default, "snapshot" for selectors.
+type exportScope struct {
+	snapshots   []db.Snapshot
+	snapshotIDs map[string]bool
+	runSet      []db.QueryRun
+	runScope    string
 }
 
 // NewBuilder creates a new export Builder.
@@ -133,26 +145,28 @@ func (b *Builder) WriteTo(w io.Writer, opts Options) error {
 	release := b.store.LockExports()
 	defer release()
 
-	// Resolve the snapshot scope once, up front. Every writer below
-	// reads from b.scopedSnapshots / b.scopedSnapshotIDs so the six
-	// files in the ZIP can never disagree about which cycles are
-	// in scope (R084/R085).
-	if err := b.resolveScope(opts); err != nil {
+	// Resolve the snapshot scope once, up front, into a per-call value.
+	// Every writer below reads from this local scope so the six files
+	// in the ZIP can never disagree about which cycles are in scope
+	// (R084/R085) and two concurrent WriteTo calls cannot alias each
+	// other's scope (R110, issue #323).
+	scope, err := b.resolveScope(opts)
+	if err != nil {
 		return err
 	}
 
 	zw := zip.NewWriter(w)
 	defer func() { _ = zw.Close() }()
 
-	if err := b.writeMetadata(zw, opts); err != nil {
+	if err := b.writeMetadata(zw, opts, scope); err != nil {
 		return fmt.Errorf("write metadata.json: %w", err)
 	}
 
-	if err := b.writeCollectorStatus(zw, opts); err != nil {
+	if err := b.writeCollectorStatus(zw, opts, scope); err != nil {
 		return fmt.Errorf("write collector_status.json: %w", err)
 	}
 
-	if err := b.writeSnapshots(zw, opts); err != nil {
+	if err := b.writeSnapshots(zw, opts, scope); err != nil {
 		return fmt.Errorf("write snapshots.ndjson: %w", err)
 	}
 
@@ -160,16 +174,16 @@ func (b *Builder) WriteTo(w io.Writer, opts Options) error {
 		return fmt.Errorf("write query_catalog.json: %w", err)
 	}
 
-	if err := b.writeQueryRuns(zw, opts); err != nil {
+	if err := b.writeQueryRuns(zw, scope); err != nil {
 		return fmt.Errorf("write query_runs.ndjson: %w", err)
 	}
 
-	if err := b.writeQueryResults(zw, opts); err != nil {
+	if err := b.writeQueryResults(zw, scope); err != nil {
 		return fmt.Errorf("write query_results.ndjson: %w", err)
 	}
 
 	if b.perCollectorFiles {
-		if err := b.writePerCollectorFiles(zw, opts); err != nil {
+		if err := b.writePerCollectorFiles(zw, opts, scope); err != nil {
 			return fmt.Errorf("write per-collector files: %w", err)
 		}
 	}
@@ -178,8 +192,10 @@ func (b *Builder) WriteTo(w io.Writer, opts Options) error {
 }
 
 // resolveScope selects the snapshot rows that belong in the export
-// according to R084/R085 semantics. The result is cached on the
-// builder so the individual file writers all see the same set.
+// according to R084/R085 semantics and returns them in a per-call
+// exportScope value (issue #323: never stored on the shared Builder).
+// The individual file writers all read from the returned scope, so the
+// files in the ZIP cannot disagree.
 //
 //   - All && SnapshotID         → ErrConflictingSelectors.
 //   - SnapshotID set            → that one snapshot, or
@@ -190,14 +206,16 @@ func (b *Builder) WriteTo(w io.Writer, opts Options) error {
 //   - default                   → R084: latest completed snapshot
 //     per active target, optionally
 //     narrowed by target_id.
-func (b *Builder) resolveScope(opts Options) error {
+func (b *Builder) resolveScope(opts Options) (*exportScope, error) {
 	if opts.All && opts.SnapshotID != "" {
-		return ErrConflictingSelectors
+		return nil, ErrConflictingSelectors
 	}
 
-	// Selector scopes are snapshot-based; the default scope overrides
-	// this to "latest-per-collector" below (R086).
-	b.runScope = "snapshot"
+	scope := &exportScope{
+		// Selector scopes are snapshot-based; the default scope
+		// overrides this to "latest-per-collector" below (R086).
+		runScope: "snapshot",
+	}
 
 	var snaps []db.Snapshot
 
@@ -205,16 +223,16 @@ func (b *Builder) resolveScope(opts Options) error {
 	case opts.SnapshotID != "":
 		s, err := b.store.GetSnapshotByID(opts.SnapshotID)
 		if err != nil {
-			return fmt.Errorf("lookup snapshot %q: %w", opts.SnapshotID, err)
+			return nil, fmt.Errorf("lookup snapshot %q: %w", opts.SnapshotID, err)
 		}
 		if s == nil {
-			return fmt.Errorf("%w: %s", ErrSnapshotNotFound, opts.SnapshotID)
+			return nil, fmt.Errorf("%w: %s", ErrSnapshotNotFound, opts.SnapshotID)
 		}
 		// Honour TargetID as a guard: requesting a snapshot that
 		// belongs to a different target is treated as not found, so
 		// an HTTP caller can't probe across targets via this path.
 		if opts.TargetID > 0 && s.TargetID != opts.TargetID {
-			return fmt.Errorf("%w: %s (target_id mismatch)", ErrSnapshotNotFound, opts.SnapshotID)
+			return nil, fmt.Errorf("%w: %s (target_id mismatch)", ErrSnapshotNotFound, opts.SnapshotID)
 		}
 		snaps = []db.Snapshot{*s}
 
@@ -226,7 +244,7 @@ func (b *Builder) resolveScope(opts Options) error {
 			snaps, err = b.store.GetAllSnapshots(opts.Since, opts.Until)
 		}
 		if err != nil {
-			return fmt.Errorf("scan snapshots in scope: %w", err)
+			return nil, fmt.Errorf("scan snapshots in scope: %w", err)
 		}
 
 	default:
@@ -236,10 +254,10 @@ func (b *Builder) resolveScope(opts Options) error {
 		// every collector, not only those due in its newest cycle.
 		runs, err := b.store.GetLatestRunsPerCollector(opts.TargetID)
 		if err != nil {
-			return fmt.Errorf("latest runs per collector: %w", err)
+			return nil, fmt.Errorf("latest runs per collector: %w", err)
 		}
-		b.runScope = "latest-per-collector"
-		b.scopedRunSet = runs
+		scope.runScope = "latest-per-collector"
+		scope.runSet = runs
 
 		// Materialise the snapshots those runs belong to so
 		// snapshots.ndjson and per-snapshot identity stay consistent.
@@ -254,33 +272,33 @@ func (b *Builder) resolveScope(opts Options) error {
 		}
 		snaps, err = b.store.GetSnapshotsByIDs(snapIDs)
 		if err != nil {
-			return fmt.Errorf("snapshots for latest runs: %w", err)
+			return nil, fmt.Errorf("snapshots for latest runs: %w", err)
 		}
 	}
 
-	b.scopedSnapshots = snaps
-	b.scopedSnapshotIDs = make(map[string]bool, len(snaps))
+	scope.snapshots = snaps
+	scope.snapshotIDs = make(map[string]bool, len(snaps))
 	for _, s := range snaps {
-		b.scopedSnapshotIDs[s.ID] = true
+		scope.snapshotIDs[s.ID] = true
 	}
 
 	// Selector scopes draw their run set from the resolved snapshots;
-	// the default scope already set scopedRunSet at the run level above.
-	if b.runScope == "snapshot" {
+	// the default scope already set runSet at the run level above.
+	if scope.runScope == "snapshot" {
 		ids := make([]string, 0, len(snaps))
 		for _, s := range snaps {
 			ids = append(ids, s.ID)
 		}
 		runs, err := b.store.GetQueryRunsBySnapshotIDs(ids)
 		if err != nil {
-			return fmt.Errorf("runs for scoped snapshots: %w", err)
+			return nil, fmt.Errorf("runs for scoped snapshots: %w", err)
 		}
-		b.scopedRunSet = runs
+		scope.runSet = runs
 	}
-	return nil
+	return scope, nil
 }
 
-func (b *Builder) writeMetadata(zw *zip.Writer, opts Options) error {
+func (b *Builder) writeMetadata(zw *zip.Writer, opts Options, scope *exportScope) error {
 	f, err := zw.Create("metadata.json")
 	if err != nil {
 		return err
@@ -306,12 +324,12 @@ func (b *Builder) writeMetadata(zw *zip.Writer, opts Options) error {
 		// every operator-driven export; "history_only" is reserved
 		// for R087 backlog-replay traffic and is set only by the
 		// (future) replay path.
-		"snapshot_count": len(b.scopedSnapshots),
+		"snapshot_count": len(scope.snapshots),
 		"ingest_mode":    "analyze",
 		// R086: marks how runs were assembled — "latest-per-collector"
 		// for the R084 default (runs may carry differing collected_at)
 		// or "snapshot" for selector scopes.
-		"run_scope": b.runScope,
+		"run_scope": scope.runScope,
 	}
 	if opts.TargetID > 0 {
 		if name, err := b.store.GetTargetName(opts.TargetID); err == nil && name != "" {
@@ -346,7 +364,7 @@ func (b *Builder) writeMetadata(zw *zip.Writer, opts Options) error {
 	return json.NewEncoder(f).Encode(data)
 }
 
-func (b *Builder) writeCollectorStatus(zw *zip.Writer, opts Options) error {
+func (b *Builder) writeCollectorStatus(zw *zip.Writer, opts Options, scope *exportScope) error {
 	f, err := zw.Create("collector_status.json")
 	if err != nil {
 		return err
@@ -358,15 +376,12 @@ func (b *Builder) writeCollectorStatus(zw *zip.Writer, opts Options) error {
 	// land in this ZIP — a fresh-install / latest-only export
 	// reports just one cycle's collectors per target instead of the
 	// daemon's accumulated history.
-	scopedRuns, err := b.scopedRuns()
-	if err != nil {
-		return err
-	}
+	scopedRuns := scope.runSet
 
 	// Target-scoped: build status from query runs for that target (MTE-R004).
 	if opts.TargetID > 0 {
 		targetName := b.resolveTargetName(opts.TargetID)
-		statuses := b.applyFreshness(collector.BuildStatusFromRuns(scopedRuns), scopedRuns, true)
+		statuses := b.applyFreshness(collector.BuildStatusFromRuns(scopedRuns), scopedRuns, true, scope)
 
 		file := collector.CollectorStatusFile{
 			SchemaVersion: CollectorStatusSchemaVersion,
@@ -399,7 +414,7 @@ func (b *Builder) writeCollectorStatus(zw *zip.Writer, opts Options) error {
 	file := collector.CollectorStatusFile{
 		SchemaVersion: CollectorStatusSchemaVersion,
 		CollectedAt:   time.Now().UTC().Format(time.RFC3339),
-		Collectors:    b.applyFreshness(collector.BuildStatusFromRuns(scopedRuns), scopedRuns, false),
+		Collectors:    b.applyFreshness(collector.BuildStatusFromRuns(scopedRuns), scopedRuns, false, scope),
 	}
 	if file.Collectors == nil {
 		file.Collectors = []collector.CollectorStatus{}
@@ -427,8 +442,8 @@ func (b *Builder) writeCollectorStatus(zw *zip.Writer, opts Options) error {
 // instance-level collector_status.json carries no target field, so a
 // per-target `never_run` entry there would be ambiguous. Cadence and
 // fresh/stale enrichment is unambiguous and applies to both.
-func (b *Builder) applyFreshness(statuses []collector.CollectorStatus, runs []db.QueryRun, withNeverRun bool) []collector.CollectorStatus {
-	if b.runScope != "latest-per-collector" {
+func (b *Builder) applyFreshness(statuses []collector.CollectorStatus, runs []db.QueryRun, withNeverRun bool, scope *exportScope) []collector.CollectorStatus {
+	if scope.runScope != "latest-per-collector" {
 		return statuses
 	}
 	now := time.Now().UTC()
@@ -513,16 +528,13 @@ func (b *Builder) writeQueryCatalog(zw *zip.Writer) error {
 // snapshot_id is in the resolved scope (R084/R085). The set is
 // computed once by resolveScope and applies uniformly to runs and
 // results so the two files cannot disagree.
-func (b *Builder) writeQueryRuns(zw *zip.Writer, opts Options) error {
+func (b *Builder) writeQueryRuns(zw *zip.Writer, scope *exportScope) error {
 	f, err := zw.Create("query_runs.ndjson")
 	if err != nil {
 		return err
 	}
 
-	runs, err := b.scopedRuns()
-	if err != nil {
-		return err
-	}
+	runs := scope.runSet
 
 	enc := json.NewEncoder(f)
 	for _, r := range runs {
@@ -552,16 +564,13 @@ func (b *Builder) writeQueryRuns(zw *zip.Writer, opts Options) error {
 
 // writeQueryResults emits one NDJSON row per successful run in the
 // resolved scope (R084/R085).
-func (b *Builder) writeQueryResults(zw *zip.Writer, opts Options) error {
+func (b *Builder) writeQueryResults(zw *zip.Writer, scope *exportScope) error {
 	f, err := zw.Create("query_results.ndjson")
 	if err != nil {
 		return err
 	}
 
-	runs, err := b.scopedRuns()
-	if err != nil {
-		return err
-	}
+	runs := scope.runSet
 
 	enc := json.NewEncoder(f)
 	for _, r := range runs {
@@ -603,7 +612,7 @@ func (b *Builder) writeQueryResults(zw *zip.Writer, opts Options) error {
 	return nil
 }
 
-func (b *Builder) writeSnapshots(zw *zip.Writer, opts Options) error {
+func (b *Builder) writeSnapshots(zw *zip.Writer, opts Options, scope *exportScope) error {
 	f, err := zw.Create("snapshots.ndjson")
 	if err != nil {
 		return err
@@ -622,7 +631,7 @@ func (b *Builder) writeSnapshots(zw *zip.Writer, opts Options) error {
 	identityCache := make(map[int64]cachedIdent)
 
 	enc := json.NewEncoder(f)
-	for _, s := range b.scopedSnapshots {
+	for _, s := range scope.snapshots {
 		row := map[string]any{
 			"id":           s.ID,
 			"target_id":    s.TargetID,
@@ -667,55 +676,62 @@ func (b *Builder) writeSnapshots(zw *zip.Writer, opts Options) error {
 	return nil
 }
 
-// scopedRuns returns every query_run whose snapshot_id is in the
-// resolved scope. Used by writeQueryRuns and writeQueryResults so
-// both files draw from the same set.
-// scopedRuns returns the run set resolved by resolveScope (R084/R085).
-// For the default scope this is the latest run per (target_id,
-// query_id); for selector scopes it is every run in the scoped
-// snapshots. Both are computed once in resolveScope so the files in
-// the ZIP cannot disagree.
-func (b *Builder) scopedRuns() ([]db.QueryRun, error) {
-	return b.scopedRunSet, nil
-}
-
-// writePerCollectorFiles regroups the latest run per collector into one
-// JSON file per query_id under `per-collector/`. R080: the canonical
-// NDJSON layout remains authoritative; this directory is a derivative
-// view for human browsing.
-func (b *Builder) writePerCollectorFiles(zw *zip.Writer, opts Options) error {
-	var runs []db.QueryRun
-	var err error
-	if opts.TargetID > 0 {
-		runs, err = b.store.GetQueryRunsByTarget(opts.TargetID, opts.Since, opts.Until)
-	} else {
-		runs, err = b.store.GetAllQueryRuns(opts.Since, opts.Until)
+// writePerCollectorFiles regroups the export's already-resolved
+// in-scope run set into one JSON file per (target_id, query_id) under
+// `per-collector/<target_id>/`. R080: the canonical NDJSON layout
+// remains authoritative; this directory is a derivative view for human
+// browsing.
+//
+// Issue #322: the view is a STRICT regrouping of scope.runSet — the
+// same runs that produced query_runs.ndjson / query_results.ndjson. It
+// never re-queries the store with a different or narrower selector, so
+// no per-collector run_id or payload can appear that is absent from the
+// canonical files. Grouping by (target_id, query_id) preserves target
+// attribution: a multi-target export keeps each target's run instead of
+// one target silently winning a query_id-only grouping. A missing or
+// corrupt payload for a successful in-scope run FAILS the export (same
+// guard as writeQueryResults) rather than emitting a zero-row stub.
+func (b *Builder) writePerCollectorFiles(zw *zip.Writer, opts Options, scope *exportScope) error {
+	// Latest-run-wins per (target_id, query_id) from the resolved
+	// scope. collected_at is RFC 3339 so a lexical compare matches time
+	// order.
+	type key struct {
+		targetID int64
+		queryID  string
 	}
-	if err != nil {
-		return err
-	}
-
-	// Latest-run-wins: collected_at is RFC 3339, lex sort matches time
-	// order. Iterate runs and keep the row whose collected_at is the
-	// largest seen for each query_id.
-	latest := make(map[string]db.QueryRun, len(runs))
-	for _, r := range runs {
-		if cur, ok := latest[r.QueryID]; !ok || r.CollectedAt > cur.CollectedAt {
-			latest[r.QueryID] = r
+	latest := make(map[key]db.QueryRun, len(scope.runSet))
+	for _, r := range scope.runSet {
+		k := key{targetID: r.TargetID, queryID: r.QueryID}
+		if cur, ok := latest[k]; !ok || r.CollectedAt > cur.CollectedAt {
+			latest[k] = r
 		}
 	}
 
 	// Stable file ordering inside the ZIP for deterministic output.
-	ids := make([]string, 0, len(latest))
-	for id := range latest {
-		ids = append(ids, id)
+	keys := make([]key, 0, len(latest))
+	for k := range latest {
+		keys = append(keys, k)
 	}
-	sort.Strings(ids)
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].targetID != keys[j].targetID {
+			return keys[i].targetID < keys[j].targetID
+		}
+		return keys[i].queryID < keys[j].queryID
+	})
 
-	for _, id := range ids {
-		r := latest[id]
+	// Cache target-name lookups so a multi-collector target resolves
+	// its name once.
+	nameCache := make(map[int64]string)
+
+	for _, k := range keys {
+		r := latest[k]
 
 		entry := map[string]any{
+			// run_id ties this file back to the canonical
+			// query_runs.ndjson so consumers (and the #322 tests) can
+			// verify the strict-regrouping invariant.
+			"run_id":       r.ID,
+			"target_id":    r.TargetID,
 			"query_id":     r.QueryID,
 			"collected_at": r.CollectedAt,
 			"pg_version":   r.PGVersion,
@@ -740,22 +756,36 @@ func (b *Builder) writePerCollectorFiles(zw *zip.Writer, opts Options) error {
 		if r.Error != "" {
 			entry["detail"] = r.Error
 		}
-		if opts.TargetID > 0 {
-			entry["target_name"] = b.resolveTargetName(opts.TargetID)
+
+		name, ok := nameCache[r.TargetID]
+		if !ok {
+			name = b.resolveTargetName(r.TargetID)
+			nameCache[r.TargetID] = name
 		}
+		entry["target_name"] = name
 
 		// Row payload only for successful runs. Skipped/failed runs
 		// describe themselves with status + reason/detail.
+		//
+		// Issue #322: for a successful in-scope run a missing or corrupt
+		// payload is a data-integrity failure — fail the export with the
+		// same guard writeQueryResults applies, never a zero-row stub.
 		if status == "success" {
 			res, err := b.store.GetQueryResultByRunID(r.ID)
-			if err == nil && res != nil {
-				if rows, decErr := db.DecodeNDJSON(res.Payload, res.Compressed); decErr == nil {
-					entry["rows"] = rows
-				}
+			if err != nil {
+				return fmt.Errorf("read result for run %s (query_id=%s): %w", r.ID, r.QueryID, err)
 			}
+			if res == nil {
+				return fmt.Errorf("missing result payload for successful run %s (query_id=%s)", r.ID, r.QueryID)
+			}
+			rows, err := db.DecodeNDJSON(res.Payload, res.Compressed)
+			if err != nil {
+				return fmt.Errorf("decode result for run %s (query_id=%s): %w", r.ID, r.QueryID, err)
+			}
+			entry["rows"] = rows
 		}
 
-		f, err := zw.Create("per-collector/" + r.QueryID + ".json")
+		f, err := zw.Create("per-collector/" + strconv.FormatInt(r.TargetID, 10) + "/" + r.QueryID + ".json")
 		if err != nil {
 			return err
 		}

--- a/tests/signals_export_concurrency_test.go
+++ b/tests/signals_export_concurrency_test.go
@@ -1,0 +1,165 @@
+// Tests for R110 concurrency safety (issue #323): a single long-lived
+// export.Builder is shared across concurrent GET /export requests (as
+// the daemon does), so the request-specific scope of one WriteTo call
+// must be local and immutable for that call. Two concurrent WriteTo
+// calls with different selectors must each produce an archive that
+// contains ONLY its own scope, and must be clean under `go test -race`.
+//
+// These tests exercise the PRODUCTION shared-Builder path: one Builder,
+// many concurrent WriteTo calls.
+
+package tests
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elevarq/signals/internal/db"
+	"github.com/elevarq/signals/internal/export"
+)
+
+// seedTwoSnapshotFixture inserts one target with two distinguishable
+// snapshots, each carrying a run for a distinct collector so a
+// snapshot-scoped export and an all-history export are trivially
+// distinguishable by their query_runs.ndjson contents.
+//
+// Returns the two snapshot IDs and the query_ids that identify each.
+func seedTwoSnapshotFixture(t *testing.T, store *db.DB) (snapA, snapB, qidA, qidB string, targetID int64) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	var err error
+	targetID, err = store.UpsertTarget("target-A", "hostA", 5432, "dbA", "u", "disable", "NONE", "", true)
+	if err != nil {
+		t.Fatalf("UpsertTarget: %v", err)
+	}
+
+	snapA, snapB = "snap-A", "snap-B"
+	qidA, qidB = "collector_a_v1", "collector_b_v1"
+
+	for _, s := range []db.Snapshot{
+		{ID: snapA, TargetID: targetID, CollectedAt: "2026-01-01T00:00:00Z", PGVersion: "16", Payload: []byte(`{"which":"A"}`), SizeBytes: 13},
+		{ID: snapB, TargetID: targetID, CollectedAt: "2026-02-01T00:00:00Z", PGVersion: "16", Payload: []byte(`{"which":"B"}`), SizeBytes: 13},
+	} {
+		if err := store.InsertSnapshot(s); err != nil {
+			t.Fatalf("InsertSnapshot %s: %v", s.ID, err)
+		}
+	}
+
+	rowsA := []map[string]any{{"which": "A"}}
+	payA, compA, sizeA, _ := db.EncodeNDJSON(rowsA)
+	rowsB := []map[string]any{{"which": "B"}}
+	payB, compB, sizeB, _ := db.EncodeNDJSON(rowsB)
+
+	runs := []db.QueryRun{
+		{ID: "run-A", TargetID: targetID, SnapshotID: snapA, QueryID: qidA, CollectedAt: "2026-01-01T00:00:00Z", PGVersion: "16", RowCount: 1, Status: "success", CreatedAt: now},
+		{ID: "run-B", TargetID: targetID, SnapshotID: snapB, QueryID: qidB, CollectedAt: "2026-02-01T00:00:00Z", PGVersion: "16", RowCount: 1, Status: "success", CreatedAt: now},
+	}
+	results := []db.QueryResult{
+		{RunID: "run-A", Payload: payA, Compressed: compA, SizeBytes: sizeA},
+		{RunID: "run-B", Payload: payB, Compressed: compB, SizeBytes: sizeB},
+	}
+	if err := store.InsertQueryRunBatch(runs, results); err != nil {
+		t.Fatalf("InsertQueryRunBatch: %v", err)
+	}
+	return snapA, snapB, qidA, qidB, targetID
+}
+
+// runIDsInArchive returns the set of run ids emitted in query_runs.ndjson.
+func runIDsInArchive(t *testing.T, data []byte) map[string]bool {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+	out := map[string]bool{}
+	for _, f := range zr.File {
+		if f.Name != "query_runs.ndjson" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open query_runs.ndjson: %v", err)
+		}
+		raw, _ := io.ReadAll(rc)
+		rc.Close()
+		for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+			if line == "" {
+				continue
+			}
+			var row map[string]any
+			if err := json.Unmarshal([]byte(line), &row); err != nil {
+				t.Fatalf("decode run row: %v", err)
+			}
+			if id, ok := row["id"].(string); ok {
+				out[id] = true
+			}
+		}
+	}
+	return out
+}
+
+// TestConcurrentExportsDoNotCrossContaminate runs many concurrent
+// WriteTo calls on ONE shared Builder — exactly the daemon topology —
+// with two different selectors: a snapshot-scoped export (only snap-A →
+// run-A) and an all-history export (run-A + run-B). Each archive must
+// contain ONLY its own scope. This fails before the fix (shared mutable
+// Builder fields race and cross-contaminate) and passes after (per-call
+// local scope). Run under `go test -race`.
+// Traces: SIGNALS-R110 (issue #323)
+func TestConcurrentExportsDoNotCrossContaminate(t *testing.T) {
+	store := openTestDB(t)
+	snapA, _, _, _, _ := seedTwoSnapshotFixture(t, store)
+
+	// ONE shared Builder — the production topology (cmd/signals/main.go
+	// builds one and api.Deps shares it across every request).
+	builder := export.NewBuilder(store, "shared-instance")
+
+	const iterations = 40
+	var wg sync.WaitGroup
+	errCh := make(chan error, iterations*2)
+
+	for i := 0; i < iterations; i++ {
+		wg.Add(2)
+
+		// Selector 1: snapshot-scoped → expect exactly {run-A}.
+		go func() {
+			defer wg.Done()
+			var buf bytes.Buffer
+			if err := builder.WriteTo(&buf, export.Options{SnapshotID: snapA}); err != nil {
+				errCh <- err
+				return
+			}
+			ids := runIDsInArchive(t, buf.Bytes())
+			if !ids["run-A"] || ids["run-B"] || len(ids) != 1 {
+				t.Errorf("snapshot-scoped archive leaked scope: got run ids %v, want only {run-A}", ids)
+			}
+		}()
+
+		// Selector 2: all-history → expect exactly {run-A, run-B}.
+		go func() {
+			defer wg.Done()
+			var buf bytes.Buffer
+			if err := builder.WriteTo(&buf, export.Options{All: true}); err != nil {
+				errCh <- err
+				return
+			}
+			ids := runIDsInArchive(t, buf.Bytes())
+			if !ids["run-A"] || !ids["run-B"] || len(ids) != 2 {
+				t.Errorf("all-history archive leaked scope: got run ids %v, want {run-A, run-B}", ids)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("concurrent WriteTo: %v", err)
+	}
+}

--- a/tests/signals_per_collector_export_test.go
+++ b/tests/signals_per_collector_export_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -96,8 +97,11 @@ func TestPerCollectorExportEnabled(t *testing.T) {
 	if len(names) != 1 {
 		t.Fatalf("expected 1 per-collector file (one collector ran), got %d: %v", len(names), names)
 	}
-	if names[0] != "per-collector/pg_settings_v1.json" {
-		t.Errorf("unexpected file name: %q", names[0])
+	// Grouped by (target_id, query_id): file lives under the target
+	// subdirectory (issue #322 attribution).
+	if !strings.HasSuffix(names[0], "/pg_settings_v1.json") ||
+		!strings.HasPrefix(names[0], "per-collector/") {
+		t.Errorf("unexpected file name: %q (want per-collector/<target_id>/pg_settings_v1.json)", names[0])
 	}
 
 	// Content shape: latest run metadata + payload rows.
@@ -157,7 +161,7 @@ func TestPerCollectorExportSkippedRunHasStub(t *testing.T) {
 	builder.SetExportPerCollectorFiles(true)
 	zr := buildExportZIPWithBuilder(t, builder)
 
-	raw := readZipFile(t, zr, "per-collector/pg_views_definitions_v1.json")
+	raw := readZipFile(t, zr, "per-collector/"+tgtDir(targetID)+"/pg_views_definitions_v1.json")
 	var entry map[string]any
 	if err := json.Unmarshal(raw, &entry); err != nil {
 		t.Fatalf("decode skipped entry: %v", err)
@@ -214,7 +218,9 @@ func TestPerCollectorExportLatestRunWins(t *testing.T) {
 	builder.SetExportPerCollectorFiles(true)
 	zr := buildExportZIPWithBuilder(t, builder)
 
-	raw := readZipFile(t, zr, "per-collector/demo_v1.json")
+	// Grouping is by (target_id, query_id): the file lives under the
+	// target subdirectory (issue #322 attribution).
+	raw := readZipFile(t, zr, "per-collector/"+tgtDir(targetID)+"/demo_v1.json")
 	var entry map[string]any
 	if err := json.Unmarshal(raw, &entry); err != nil {
 		t.Fatalf("decode entry: %v", err)
@@ -225,5 +231,378 @@ func TestPerCollectorExportLatestRunWins(t *testing.T) {
 	rows := entry["rows"].([]any)
 	if rows[0].(map[string]any)["value"] != "new" {
 		t.Errorf("payload mismatch: expected new, got %v", rows[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// R080 scope-fidelity tests (issue #322): the per-collector directory
+// is a STRICT regrouping of the resolved in-scope run set. Every
+// per-collector run must also appear in canonical query_runs.ndjson,
+// and scope selectors must match the canonical files exactly.
+// ---------------------------------------------------------------------------
+
+// tgtDir builds the per-collector target subdirectory path segment for
+// a target id.
+func tgtDir(n int64) string {
+	return strconv.FormatInt(n, 10)
+}
+
+// canonicalRunIDs returns the set of run ids from query_runs.ndjson.
+func canonicalRunIDs(t *testing.T, zr *zip.Reader) map[string]bool {
+	t.Helper()
+	raw := readZipFile(t, zr, "query_runs.ndjson")
+	out := map[string]bool{}
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line == "" {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			t.Fatalf("decode canonical run: %v", err)
+		}
+		if id, ok := row["id"].(string); ok {
+			out[id] = true
+		}
+	}
+	return out
+}
+
+// perCollectorRunIDs returns the run_id embedded in every per-collector
+// file. Each file must carry the run_id it was regrouped from so the
+// canonical cross-check (issue #322) is possible.
+func perCollectorRunIDs(t *testing.T, zr *zip.Reader) []string {
+	t.Helper()
+	var out []string
+	for _, name := range listPerCollectorFiles(zr) {
+		var entry map[string]any
+		if err := json.Unmarshal(readZipFile(t, zr, name), &entry); err != nil {
+			t.Fatalf("decode %s: %v", name, err)
+		}
+		id, ok := entry["run_id"].(string)
+		if !ok || id == "" {
+			t.Fatalf("per-collector file %s missing run_id (needed for canonical cross-check)", name)
+		}
+		out = append(out, id)
+	}
+	return out
+}
+
+// assertPerCollectorSubsetOfCanonical asserts every per-collector run_id
+// is present in canonical query_runs.ndjson (the core issue #322
+// invariant: no per-collector payload outside the resolved scope).
+func assertPerCollectorSubsetOfCanonical(t *testing.T, zr *zip.Reader) {
+	t.Helper()
+	canonical := canonicalRunIDs(t, zr)
+	for _, id := range perCollectorRunIDs(t, zr) {
+		if !canonical[id] {
+			t.Errorf("per-collector run_id %q is NOT in canonical query_runs.ndjson (scope leak)", id)
+		}
+	}
+}
+
+// buildScopedExportZIP builds an export with the given options and
+// per-collector files enabled, returning the parsed reader.
+func buildScopedPerCollectorZIP(t *testing.T, store *db.DB, opts export.Options) *zip.Reader {
+	t.Helper()
+	b := export.NewBuilder(store, "test-instance-id")
+	b.SetExportPerCollectorFiles(true)
+	var buf bytes.Buffer
+	if err := b.WriteTo(&buf, opts); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+	return zr
+}
+
+// seedMultiTargetHistory inserts two enabled targets and one disabled
+// target, each with two cycles of runs for the same collector, so scope
+// selectors (snapshot, target, all, since/until, default, disabled) are
+// all distinguishable. Returns the two enabled target ids, the disabled
+// target id, and the snapshot ids for target1.
+func seedMultiTargetHistory(t *testing.T, store *db.DB) (t1, t2, tDisabled int64, snap1Old, snap1New string) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	var err error
+	t1, err = store.UpsertTarget("t1", "h1", 5432, "d", "u", "disable", "NONE", "", true)
+	if err != nil {
+		t.Fatalf("UpsertTarget t1: %v", err)
+	}
+	t2, err = store.UpsertTarget("t2", "h2", 5432, "d", "u", "disable", "NONE", "", true)
+	if err != nil {
+		t.Fatalf("UpsertTarget t2: %v", err)
+	}
+	tDisabled, err = store.UpsertTarget("t3-disabled", "h3", 5432, "d", "u", "disable", "NONE", "", false)
+	if err != nil {
+		t.Fatalf("UpsertTarget t3: %v", err)
+	}
+
+	snap1Old, snap1New = "snap-t1-old", "snap-t1-new"
+	type snapSpec struct {
+		id     string
+		target int64
+		at     string
+	}
+	snaps := []snapSpec{
+		{snap1Old, t1, "2026-01-01T00:00:00Z"},
+		{snap1New, t1, "2026-03-01T00:00:00Z"},
+		{"snap-t2", t2, "2026-02-01T00:00:00Z"},
+		{"snap-t3", tDisabled, "2026-02-15T00:00:00Z"},
+	}
+	for _, s := range snaps {
+		if err := store.InsertSnapshot(db.Snapshot{
+			ID: s.id, TargetID: s.target, CollectedAt: s.at,
+			PGVersion: "16", Payload: []byte(`{}`), SizeBytes: 2,
+		}); err != nil {
+			t.Fatalf("InsertSnapshot %s: %v", s.id, err)
+		}
+	}
+
+	mkRun := func(id string, target int64, snap, at, val string) (db.QueryRun, db.QueryResult) {
+		rows := []map[string]any{{"v": val}}
+		p, c, sz, _ := db.EncodeNDJSON(rows)
+		return db.QueryRun{
+				ID: id, TargetID: target, SnapshotID: snap, QueryID: "demo_v1",
+				CollectedAt: at, PGVersion: "16", RowCount: 1, Status: "success", CreatedAt: now,
+			},
+			db.QueryResult{RunID: id, Payload: p, Compressed: c, SizeBytes: sz}
+	}
+
+	var runs []db.QueryRun
+	var results []db.QueryResult
+	for _, spec := range []struct {
+		id, snap, at, val string
+		target            int64
+	}{
+		{"r-t1-old", snap1Old, "2026-01-01T00:00:00Z", "t1-old", t1},
+		{"r-t1-new", snap1New, "2026-03-01T00:00:00Z", "t1-new", t1},
+		{"r-t2", "snap-t2", "2026-02-01T00:00:00Z", "t2", t2},
+		{"r-t3", "snap-t3", "2026-02-15T00:00:00Z", "t3", tDisabled},
+	} {
+		run, res := mkRun(spec.id, spec.target, spec.snap, spec.at, spec.val)
+		runs = append(runs, run)
+		results = append(results, res)
+	}
+	if err := store.InsertQueryRunBatch(runs, results); err != nil {
+		t.Fatalf("InsertQueryRunBatch: %v", err)
+	}
+	return t1, t2, tDisabled, snap1Old, snap1New
+}
+
+// TestPerCollectorSnapshotScope: a snapshot-scoped export's
+// per-collector files contain ONLY the run from that snapshot, and
+// every per-collector run appears in canonical query_runs.ndjson.
+// Traces: SIGNALS-R080 (issue #322)
+func TestPerCollectorSnapshotScope(t *testing.T) {
+	store := openTestDB(t)
+	t1, _, _, snap1Old, _ := seedMultiTargetHistory(t, store)
+
+	zr := buildScopedPerCollectorZIP(t, store, export.Options{SnapshotID: snap1Old})
+	assertPerCollectorSubsetOfCanonical(t, zr)
+
+	ids := perCollectorRunIDs(t, zr)
+	if len(ids) != 1 || ids[0] != "r-t1-old" {
+		t.Fatalf("snapshot scope: per-collector run ids = %v, want [r-t1-old]", ids)
+	}
+	// The old snapshot's run must be the one exported, not the newer one.
+	if _, err := zr.Open("per-collector/" + tgtDir(t1) + "/demo_v1.json"); err != nil {
+		t.Fatalf("expected per-collector/%d/demo_v1.json: %v", t1, err)
+	}
+}
+
+// TestPerCollectorTargetScope: a target-scoped export contains only
+// that target's latest run and nothing from other targets.
+// Traces: SIGNALS-R080 (issue #322)
+func TestPerCollectorTargetScope(t *testing.T) {
+	store := openTestDB(t)
+	_, t2, _, _, _ := seedMultiTargetHistory(t, store)
+
+	zr := buildScopedPerCollectorZIP(t, store, export.Options{TargetID: t2, All: true})
+	assertPerCollectorSubsetOfCanonical(t, zr)
+
+	ids := perCollectorRunIDs(t, zr)
+	if len(ids) != 1 || ids[0] != "r-t2" {
+		t.Fatalf("target scope: per-collector run ids = %v, want [r-t2]", ids)
+	}
+}
+
+// TestPerCollectorAllScopeMultiTargetAttribution: --all across two
+// targets keeps BOTH targets' latest run as distinct files under their
+// own target subdirectory — no target silently wins a query_id-only
+// grouping.
+// Traces: SIGNALS-R080 (issue #322)
+func TestPerCollectorAllScopeMultiTargetAttribution(t *testing.T) {
+	store := openTestDB(t)
+	t1, t2, tDisabled, _, _ := seedMultiTargetHistory(t, store)
+
+	zr := buildScopedPerCollectorZIP(t, store, export.Options{All: true})
+	assertPerCollectorSubsetOfCanonical(t, zr)
+
+	names := listPerCollectorFiles(zr)
+	// --all is full history INCLUDING disabled targets (only the R084
+	// default excludes them). Each of the three targets keeps its own
+	// (target_id, query_id) file — attribution is preserved, no target
+	// silently wins a query_id-only grouping.
+	want := map[string]bool{
+		"per-collector/" + tgtDir(t1) + "/demo_v1.json":        true,
+		"per-collector/" + tgtDir(t2) + "/demo_v1.json":        true,
+		"per-collector/" + tgtDir(tDisabled) + "/demo_v1.json": true,
+	}
+	got := map[string]bool{}
+	for _, n := range names {
+		got[n] = true
+	}
+	for w := range want {
+		if !got[w] {
+			t.Errorf("multi-target: missing %s (attribution collapsed); got %v", w, names)
+		}
+	}
+	// t1 has two runs but latest-run-wins keeps one file per (target,
+	// query). Three distinct targets → three files.
+	if len(names) != 3 {
+		t.Fatalf("multi-target --all: expected 3 per-collector files, got %d: %v", len(names), names)
+	}
+	// Latest-run-wins for t1: the exported run is the newer one.
+	var entry map[string]any
+	if err := json.Unmarshal(readZipFile(t, zr, "per-collector/"+tgtDir(t1)+"/demo_v1.json"), &entry); err != nil {
+		t.Fatalf("decode t1 entry: %v", err)
+	}
+	if entry["run_id"] != "r-t1-new" {
+		t.Errorf("t1 per-collector run_id = %v, want r-t1-new (latest-run-wins)", entry["run_id"])
+	}
+}
+
+// TestPerCollectorSinceUntilScope: a time-window export includes only
+// the runs inside the window, matching the canonical files.
+// Traces: SIGNALS-R080 (issue #322)
+func TestPerCollectorSinceUntilScope(t *testing.T) {
+	store := openTestDB(t)
+	seedMultiTargetHistory(t, store)
+
+	// Window covers only Feb → only t2's run (2026-02-01) qualifies.
+	zr := buildScopedPerCollectorZIP(t, store, export.Options{
+		Since: "2026-01-15T00:00:00Z",
+		Until: "2026-02-10T00:00:00Z",
+	})
+	assertPerCollectorSubsetOfCanonical(t, zr)
+
+	ids := perCollectorRunIDs(t, zr)
+	if len(ids) != 1 || ids[0] != "r-t2" {
+		t.Fatalf("since/until scope: per-collector run ids = %v, want [r-t2]", ids)
+	}
+}
+
+// TestPerCollectorDefaultActiveTargetExcludesDisabled: the R084 default
+// scope (no selectors) exports the latest run per collector for ACTIVE
+// targets only — the disabled target's run must not appear in the
+// per-collector directory (nor in canonical runs).
+// Traces: SIGNALS-R080 (issue #322)
+func TestPerCollectorDefaultActiveTargetExcludesDisabled(t *testing.T) {
+	store := openTestDB(t)
+	seedMultiTargetHistory(t, store)
+
+	zr := buildScopedPerCollectorZIP(t, store, export.Options{})
+	assertPerCollectorSubsetOfCanonical(t, zr)
+
+	for _, id := range perCollectorRunIDs(t, zr) {
+		if id == "r-t3" {
+			t.Errorf("default scope leaked disabled-target run r-t3 into per-collector files")
+		}
+	}
+	// Default keeps t1's LATEST run (r-t1-new), not the old one.
+	ids := map[string]bool{}
+	for _, id := range perCollectorRunIDs(t, zr) {
+		ids[id] = true
+	}
+	if ids["r-t1-old"] {
+		t.Errorf("default scope should carry t1's latest run, not r-t1-old")
+	}
+	if !ids["r-t1-new"] || !ids["r-t2"] {
+		t.Errorf("default scope missing expected latest runs: got %v", ids)
+	}
+}
+
+// TestPerCollectorMissingPayloadFailsExport: a successful in-scope run
+// whose result payload is missing must FAIL the export (issue #322 —
+// no zero-row success stub), consistent with query_results.ndjson.
+// Traces: SIGNALS-R080 (issue #322)
+func TestPerCollectorMissingPayloadFailsExport(t *testing.T) {
+	store := openTestDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	targetID, err := store.UpsertTarget("t", "h", 5432, "d", "u", "disable", "NONE", "", true)
+	if err != nil {
+		t.Fatalf("UpsertTarget: %v", err)
+	}
+	if err := store.InsertSnapshot(db.Snapshot{
+		ID: "snap-x", TargetID: targetID, CollectedAt: now,
+		PGVersion: "16", Payload: []byte(`{}`), SizeBytes: 2,
+	}); err != nil {
+		t.Fatalf("InsertSnapshot: %v", err)
+	}
+	// Successful run with NO accompanying result payload (nil results).
+	run := db.QueryRun{
+		ID: "run-nopayload", TargetID: targetID, SnapshotID: "snap-x",
+		QueryID: "demo_v1", CollectedAt: now, PGVersion: "16",
+		RowCount: 1, Status: "success", CreatedAt: now,
+	}
+	if err := store.InsertQueryRunBatch([]db.QueryRun{run}, nil); err != nil {
+		t.Fatalf("InsertQueryRunBatch: %v", err)
+	}
+
+	b := export.NewBuilder(store, "test-instance-id")
+	b.SetExportPerCollectorFiles(true)
+	var buf bytes.Buffer
+	err = b.WriteTo(&buf, export.Options{All: true})
+	if err == nil {
+		t.Fatal("expected export to FAIL on missing payload for successful in-scope run, got nil (success stub)")
+	}
+	if !strings.Contains(err.Error(), "run-nopayload") {
+		t.Errorf("error should name the offending run: %v", err)
+	}
+}
+
+// TestPerCollectorCorruptPayloadFailsExport: a successful in-scope run
+// whose payload cannot be decoded must FAIL the export, not emit a
+// zero-row stub.
+// Traces: SIGNALS-R080 (issue #322)
+func TestPerCollectorCorruptPayloadFailsExport(t *testing.T) {
+	store := openTestDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	targetID, err := store.UpsertTarget("t", "h", 5432, "d", "u", "disable", "NONE", "", true)
+	if err != nil {
+		t.Fatalf("UpsertTarget: %v", err)
+	}
+	if err := store.InsertSnapshot(db.Snapshot{
+		ID: "snap-x", TargetID: targetID, CollectedAt: now,
+		PGVersion: "16", Payload: []byte(`{}`), SizeBytes: 2,
+	}); err != nil {
+		t.Fatalf("InsertSnapshot: %v", err)
+	}
+	run := db.QueryRun{
+		ID: "run-corrupt", TargetID: targetID, SnapshotID: "snap-x",
+		QueryID: "demo_v1", CollectedAt: now, PGVersion: "16",
+		RowCount: 1, Status: "success", CreatedAt: now,
+	}
+	// Corrupt payload: claims uncompressed but is not valid NDJSON JSON.
+	corrupt := db.QueryResult{
+		RunID: "run-corrupt", Payload: []byte("\xff\xfe not json"),
+		Compressed: false, SizeBytes: 10,
+	}
+	if err := store.InsertQueryRunBatch([]db.QueryRun{run}, []db.QueryResult{corrupt}); err != nil {
+		t.Fatalf("InsertQueryRunBatch: %v", err)
+	}
+
+	b := export.NewBuilder(store, "test-instance-id")
+	b.SetExportPerCollectorFiles(true)
+	var buf bytes.Buffer
+	err = b.WriteTo(&buf, export.Options{All: true})
+	if err == nil {
+		t.Fatal("expected export to FAIL on corrupt payload for successful in-scope run, got nil")
+	}
+	if !strings.Contains(err.Error(), "run-corrupt") {
+		t.Errorf("error should name the offending run: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #322.
Closes #323.

One combined fix for two bugs in the export subsystem that share a root cause: the daemon shares one long-lived `export.Builder` across concurrent `GET /export` requests, and per-request scope was stored on that shared Builder.

## #323 — shared mutable Builder races concurrent requests

`WriteTo` stored request-specific scope (`scopedSnapshots`, `scopedSnapshotIDs`, `scopedRunSet`, `runScope`) on the Builder. Two overlapping exports with different selectors raced on those fields and could cross-contaminate archives — a data race under `go test -race`, and one archive could report the other's scope.

Fix: the four fields move off the Builder into a per-call `exportScope` value, resolved once at the top of `WriteTo` and threaded through every writer. The Builder now holds only set-once construction-time config (store, instance ID, unsafe-mode, collector-status, per-collector toggle), read-only for the daemon lifetime. Concurrent `WriteTo` calls can no longer alias each other's scope.

## #322 — per-collector export ignores resolved scope

`writePerCollectorFiles` discarded the resolved run set and re-queried by `TargetID` + time range only. Consequences: `SnapshotID` ignored, disabled/out-of-scope runs pulled, multi-target attribution collapsed to a `query_id`-only grouping, and result read/decode errors suppressed into empty success stubs.

Fix: it now derives exclusively from the resolved `scope.runSet` (the same set behind `query_runs.ndjson` / `query_results.ndjson`), groups by `(target_id, query_id)` under `per-collector/<target_id>/`, and fails the export on a missing/corrupt payload for an in-scope successful run — the same guard `query_results.ndjson` applies — instead of a zero-row stub. Each per-collector file carries its `run_id` so the strict-regrouping invariant is verifiable against the canonical file.

## STDD

- Spec: `SIGNALS-R110` now states the per-call-local concurrency model explicitly; `SIGNALS-R080` states the per-collector view is a strict regrouping of the resolved in-scope run set keyed by `(target_id, query_id)`, with the missing/corrupt-payload failure condition. Traceability rows already described this design.
- Tests (RED before, GREEN after):
  - `TestConcurrentExportsDoNotCrossContaminate` — concurrent `WriteTo` on the production shared Builder with two different selectors against distinguishable fixtures; each archive contains only its own scope; passes under `-race` (was: data race + scope leak).
  - Per-collector scope coverage: SnapshotID, TargetID, All, Since/Until, default active-target, disabled-target, multi-target attribution, and missing/corrupt payload fails the export. Every per-collector `run_id` is cross-checked against canonical `query_runs.ndjson`.

## Gates

Local `preflight.sh` gofmt / vet / lint / test (with `-race`) all green.