### PR TITLE
test(output-contract): cover remaining internal-"char" schema collectors (#326)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,27 @@ jobs:
           # Least-privilege monitoring role: LOGIN + pg_monitor, no
           # superuser/replication/bypassrls. CREATE on the database lets
           # the test seed its own dedicated schema; nothing else.
+          #
+          # #326: the postgres_fdw extension is created here (it needs
+          # superuser) so the harness's FDW leg (OC-R007) is exercised
+          # in the matrix — the test then provisions a foreign server +
+          # grants USAGE via SIGNALS_TEST_PG_SUPERUSER_DSN and seeds a
+          # foreign table as the `signals` role. Without this the FDW
+          # assertion is a documented skip.
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 <<'SQL'
           CREATE ROLE signals WITH LOGIN PASSWORD 'signals';
           GRANT pg_monitor TO signals;
           GRANT CREATE ON DATABASE postgres TO signals;
+          CREATE EXTENSION IF NOT EXISTS postgres_fdw;
           SQL
 
       - name: Run collector output-contract integration test
+        env:
+          # #326: optional superuser DSN the harness uses ONLY to
+          # provision the FDW capability (foreign server + USAGE grant)
+          # that a pg_monitor role cannot create itself. Collection still
+          # runs as the non-superuser `signals` role (SIGNALS_TEST_PG_DSN).
+          SIGNALS_TEST_PG_SUPERUSER_DSN: "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
         run: >
           go test -tags integration -count=1 -v
           -run TestIntegration_CollectorOutputContractAgainstRealPG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   a new CI job matrixed across PG 14/15/16/17/18 (#314). Closes the STDD
   gap where a specification's declared output was never asserted in the
   exported ZIP end-to-end.
+- Output-contract harness coverage for the remaining internal-`"char"`
+  schema collectors #314 missed: the sweep now seeds a partitioned table,
+  a trigger, and a SQL function and asserts
+  `pg_partitions_v1.partition_strategy`,
+  `pg_triggers_v1`/`pg_triggers_definitions_v1.tg_enabled`, and
+  `pg_functions_v1`/`pg_functions_definitions_v1.volatility` decode as
+  single-char strings (never JSON numbers), regression-locking #319's
+  central OID-18 normalization across the whole char family. When a
+  superuser DSN provisions the FDW capability the harness also seeds a
+  foreign table and asserts `fdw_foreign_tables_v1.relkind == "f"`;
+  without the capability that leg is a documented skip. Test-only — the
+  production normalization already landed in #319 (#326).
 
 ### Fixed
 

--- a/features/signals/traceability.md
+++ b/features/signals/traceability.md
@@ -280,6 +280,17 @@ assertion is RED on pre-#313 uncast SQL and GREEN after. Test:
 PG-version matrix 14/15/16/17/18. Acceptance:
 `specifications/collector-output-contract.acceptance.md`.
 
+#326 extends the harness to the remaining internal-`"char"` schema
+collectors #314 left unexercised: it seeds a partitioned table, a
+trigger, and a SQL function and asserts `pg_partitions_v1.partition_strategy`,
+`pg_triggers_v1`/`pg_triggers_definitions_v1.tg_enabled`, and
+`pg_functions_v1`/`pg_functions_definitions_v1.volatility` decode as
+single-char strings (OC-R006). When a superuser DSN
+(`SIGNALS_TEST_PG_SUPERUSER_DSN`) provisions the FDW capability it also
+seeds a foreign table and asserts `fdw_foreign_tables_v1.relkind == "f"`;
+without the capability that leg is a documented skip (OC-R007). This is
+test-only — the production normalization already landed in #319/#321.
+
 | Rule ID | Rule Summary | Test ID(s) | Coverage Status | Evidence Type | Notes |
 |---------|-------------|------------|-----------------|---------------|-------|
 | OC-R001 (collect against live PG) | Full collection runs against a real PostgreSQL target and exports a snapshot ZIP via the production export path | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | `//go:build integration` + `SIGNALS_TEST_PG_DSN`; CI matrix PG 14-18. Not in default unit CI. |
@@ -288,3 +299,5 @@ PG-version matrix 14/15/16/17/18. Acceptance:
 | OC-R004 (status↔payload joinable) | Every exported `status=success`/`row_count=N` run has exactly one joinable payload with N objects | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-04; INV-STATUS-PAYLOAD-VERIFIED; end-to-end proof of INV-SNAP-STATUS-PAYLOAD (#312). |
 | INV-SNAP-STATUS-PAYLOAD (retention producer, #327) | Retention cleanup deletes a run's payload + its run row atomically; a failure after the payload delete leaves BOTH tables intact, so no `success` run is ever stripped of its joinable payload | `internal/db/retention_atomic_test.go` (`TestDeleteQueryRunsOlderThan_AtomicOnSecondStepFailure`, `TestDeleteQueryRunsOlderThanByClass_AtomicOnSecondStepFailure`, `TestDeleteQueryRuns*_InvariantHoldsAfterCleanup`) | COVERED | BEHAVIORAL | FC-23; failure-injection proving the transaction rolls back both deletes on a second-step failure; post-cleanup asserts every remaining `success` run has exactly one joinable payload with `row_count` rows. Covers both the legacy flat helper and the per-class production helper. |
 | OC-R005 (char-type normalized at connection boundary) | OID 18 decodes as text for ALL collectors via a pooled-connection type registration; the columns #313 missed — `relkind` (`catalog_bloat_v1`/`catalog_index_bloat_v1`/`fdw_*_v1`), `provolatile`/`volatility` (functions), `attidentity` (identity, `""` when non-set) — decode as strings, never JSON numbers | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-06; INV-04; the #319 central-fix regression lock (root cause of Elevarq/Analyzer#1871). |
+| OC-R006 (char sweep covers remaining schema collectors) | The char whitelist includes the aliases `partition_strategy` (`pg_partitions_v1`), `tg_enabled` (`pg_triggers_v1`/`pg_triggers_definitions_v1`), `volatility` (the **output alias** of `provolatile` in `pg_functions_v1`/`pg_functions_definitions_v1`), and `attidentity`; a seeded partitioned table, trigger, and function make each collector emit a single-char string for its aliased char column, never a JSON number | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-07; INV-05; regression-locks #319 across the schema collectors #314 missed (#326). |
+| OC-R007 (FDW char capability-gated) | When a superuser DSN provisions `postgres_fdw` + a foreign server + `GRANT USAGE`, a seeded foreign table makes `fdw_foreign_tables_v1` emit `relkind == "f"` (single-char string, never a number); absent the capability the FDW fixture + assertion are skipped with a documented reason and every other assertion still runs | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-08; INV-05/INV-06; capability-gated FDW leg of #326. |

--- a/specifications/collector-output-contract.acceptance.md
+++ b/specifications/collector-output-contract.acceptance.md
@@ -136,6 +136,74 @@ removed; GREEN with it in place.
 
 ---
 
+### TC-OC-07: Remaining schema collectors decode their aliased char columns as strings
+
+**Rule:** OC-R006 (normal — the #326 schema-family regression lock)
+
+**Scenario:** A target is seeded so the schema collectors #314 missed
+emit rows: a partitioned table (so `pg_partitions_v1` emits
+`partition_strategy`), a user trigger (so `pg_triggers_v1` /
+`pg_triggers_definitions_v1` emit `tg_enabled`), and a SQL function (so
+`pg_functions_v1` / `pg_functions_definitions_v1` emit `volatility`).
+The exported payloads are inspected.
+
+**Given:**
+- A live target carrying a `PARTITION BY RANGE` table with a child
+  partition, a `BEFORE INSERT` row trigger, and a SQL function.
+
+**When:**
+- The full collection runs and a snapshot ZIP is exported via
+  `export.Builder.WriteTo`; `query_results.ndjson` is read back.
+
+**Then:**
+- `pg_partitions_v1.partition_strategy` is a single-character string
+  (e.g. `"r"` for RANGE), never a number.
+- `pg_triggers_v1.tg_enabled` and `pg_triggers_definitions_v1.tg_enabled`
+  are single-character strings (e.g. `"O"`), never a number.
+- `pg_functions_v1.volatility` and `pg_functions_definitions_v1.volatility`
+  are single-character strings (e.g. `"i"`), never a number.
+- Each of these collectors emits at least one such value (the sweep is
+  not vacuously satisfied).
+
+**Expected Result:** RED with the OID-18 `AfterConnect` registration
+removed; GREEN with it in place.
+(`TestIntegration_CollectorOutputContractAgainstRealPG`)
+
+---
+
+### TC-OC-08: FDW foreign-table relkind is a string (capability-gated)
+
+**Rule:** OC-R007 (normal / capability-gated — the #326 FDW leg)
+
+**Scenario:** When the environment provides the FDW capability (a
+superuser DSN provisions `postgres_fdw` + a foreign server + grants
+USAGE to the collector role), a foreign table is seeded so
+`fdw_foreign_tables_v1` emits a row; otherwise the FDW fixture and
+assertion are skipped with a documented reason.
+
+**Given:**
+- `SIGNALS_TEST_PG_SUPERUSER_DSN` present and the `postgres_fdw`
+  extension available (CI provisions both).
+
+**When:**
+- The full collection runs and a snapshot ZIP is exported; the
+  `fdw_foreign_tables_v1` payload is read back.
+
+**Then:**
+- `fdw_foreign_tables_v1.relkind` is the single-character string `"f"`,
+  never a number.
+
+**And (capability absent):**
+- With no superuser DSN / no `postgres_fdw`, the FDW fixture is not
+  created and the assertion is skipped with a logged reason; every other
+  assertion still runs.
+
+**Expected Result:** Pass when the capability is present; documented
+skip otherwise.
+(`TestIntegration_CollectorOutputContractAgainstRealPG`)
+
+---
+
 ### TC-OC-05: Skips locally, runs in the CI matrix
 
 **Rule:** Constraints (env-gating)

--- a/specifications/collector-output-contract.md
+++ b/specifications/collector-output-contract.md
@@ -27,7 +27,11 @@ GREEN after.
 Scope is the **catalog/schema collectors** (`Category == "schema"`),
 with emphasis on the internal-`"char"` collectors PR #313 touched
 (`pg_constraints_v1`, `pg_class_storage_v1`, `pg_functions_v1`,
-`pg_functions_definitions_v1`, `pg_proc_config_v1`). The remaining
+`pg_functions_definitions_v1`, `pg_proc_config_v1`) **and the remaining
+schema collectors that alias an internal-`"char"` column** but were not
+exercised by the #314 fixtures (#326): `pg_partitions_v1`
+(`partition_strategy`), `pg_triggers_v1` / `pg_triggers_definitions_v1`
+(`tg_enabled`), and `fdw_foreign_tables_v1` (`relkind`). The remaining
 non-schema collectors are an explicit fast-follow (see
 Non-Functional Requirements).
 
@@ -46,7 +50,19 @@ and §"Collector output-contract verification (#314)"
 - Representative schema seeded into the target before collection:
   a parent table with a primary key, a child table whose foreign key to
   the parent is **unindexed** (so `pg_constraint` emits a `contype='f'`
-  row), at least one non-PK index, and columns of varied types.
+  row), at least one non-PK index, and columns of varied types; plus a
+  **partitioned table**, a user-defined **trigger**, a SQL **function**,
+  and an **identity column** so the remaining internal-`"char"` schema
+  collectors (`pg_partitions_v1`, `pg_triggers_v1` /
+  `pg_triggers_definitions_v1`, `pg_functions_v1` /
+  `pg_functions_definitions_v1`, `pg_identity_columns_v1`) each emit a
+  row. The seed runs as the non-superuser collector role.
+- An optional superuser DSN (`SIGNALS_TEST_PG_SUPERUSER_DSN`) used ONLY
+  to provision the FDW capability that a `pg_monitor` role cannot create
+  itself (`CREATE EXTENSION postgres_fdw` + a foreign `SERVER` +
+  `GRANT USAGE` to the collector role). When absent, the FDW fixture and
+  its `fdw_foreign_tables_v1.relkind` assertion are capability-gated and
+  skipped (OC-R007); every other assertion still runs.
 
 ### Outputs
 
@@ -78,6 +94,23 @@ and §"Collector output-contract verification (#314)"
   `attidentity` the empty string for the non-set case), never a JSON
   number — because the connection boundary decodes OID 18 as text for
   every collector, not just the columns hand-cast with `::text`.
+- **Given** a target seeded with a **partitioned table**, a
+  user-defined **trigger**, and a SQL **function**, **when** the ZIP is
+  read back, **then** `pg_partitions_v1.partition_strategy` (from
+  `pg_partitioned_table.partstrat`), `pg_triggers_v1.tg_enabled` /
+  `pg_triggers_definitions_v1.tg_enabled` (from `pg_trigger.tgenabled`),
+  and `pg_functions_v1.volatility` / `pg_functions_definitions_v1.volatility`
+  (from `pg_proc.provolatile`) each decode as a single-character string,
+  never a JSON number — extending the OID-18 boundary lock across the
+  remaining schema collectors that alias an internal-`"char"` column.
+- **Given** the target additionally exposes the FDW capability (a
+  `postgres_fdw` foreign server the collector role may create a foreign
+  table against), **when** the ZIP is read back, **then**
+  `fdw_foreign_tables_v1.relkind` (from `pg_class.relkind`) decodes as
+  the single-character string `"f"`, never a JSON number. When the
+  environment cannot provide the FDW capability the FDW assertion is
+  capability-gated and skipped with a documented reason — the remaining
+  schema-collector char assertions still run.
 
 ## Rules
 
@@ -112,6 +145,31 @@ and §"Collector output-contract verification (#314)"
   protocol's inability to carry an embedded NUL). This closes the class
   the leaky per-column `::text` approach could not (#319, follow-up to
   #312/#313; root cause of Elevarq/Analyzer#1871).
+- **OC-R006 — Char sweep covers the remaining schema collectors.** The
+  internal-`"char"` output-column whitelist the harness sweeps shall
+  include the aliases the remaining schema collectors expose — not only
+  the raw catalog names. Specifically it shall include
+  `partition_strategy` (`pg_partitions_v1`, from `partstrat`),
+  `tg_enabled` (`pg_triggers_v1` / `pg_triggers_definitions_v1`, from
+  `tgenabled`), `volatility` (`pg_functions_v1` /
+  `pg_functions_definitions_v1`, the **output alias** of `provolatile`),
+  and `attidentity` (`pg_identity_columns_v1`). Because the whitelist
+  keys the **exported column name**, the function alias is
+  `volatility`, never `provolatile`. The harness shall seed a
+  partitioned table, a user trigger, a SQL function, and an identity
+  column so each of these collectors emits at least one row, and shall
+  assert each aliased char value decodes as a single-character string
+  (or the empty string for the non-set `attidentity`), never a JSON
+  number. This regression-locks #319 for the whole char family across
+  the schema collectors #314 missed (#326).
+- **OC-R007 — FDW char is capability-gated.** When the environment
+  provides the FDW capability — a `postgres_fdw` foreign server the
+  collector role may create a foreign table against — the harness shall
+  seed a foreign table so `fdw_foreign_tables_v1` emits a row and shall
+  assert its `relkind` decodes as the single-character string `"f"`.
+  When the capability is absent (no superuser provisioning of the
+  extension/server) the FDW assertion is skipped with a documented
+  reason; the OC-R006 schema-collector assertions still run. (#326.)
 
 ## Invariants
 
@@ -131,6 +189,20 @@ and §"Collector output-contract verification (#314)"
   registration removed (columns #313 left uncast decode as numbers) and
   pass with it in place, independent of the redundant per-column
   `::text` casts.
+- **INV-05** — The OC-R006 schema-collector char assertions
+  (`partition_strategy`, `tg_enabled`, `volatility`) and, when the
+  capability is present, the OC-R007 `fdw_foreign_tables_v1.relkind`
+  assertion are the same regression lock extended across the remaining
+  schema collectors: each aliased internal-`"char"` value decodes as a
+  single-character string, never a JSON number, so reverting the OID-18
+  `AfterConnect` registration turns them RED. The FDW leg is
+  capability-gated — its absence never fails the run, but when the
+  capability is present the assertion is mandatory.
+- **INV-06** — The FDW-capability provisioning uses a separate,
+  optional superuser DSN and touches only a dedicated FDW server + a
+  `GRANT USAGE`; collection itself still runs as the non-superuser
+  collector role (INV-02 holds — no writes and no superuser during
+  collection).
 
 ## Failure conditions
 
@@ -140,6 +212,11 @@ and §"Collector output-contract verification (#314)"
   (e.g. `contype == 102`) fails OC-R003.
 - **FC-03** — A `status="success"`/`row_count=N` run with no joinable
   payload, or a payload whose row count ≠ N, fails OC-R004.
+- **FC-04** — An aliased schema-collector internal-`"char"` value
+  (`partition_strategy`, `tg_enabled`, `volatility`, or, when the FDW
+  capability is present, `fdw_foreign_tables_v1.relkind`) decoding as a
+  JSON number, or one of the seeded schema collectors emitting no such
+  value at all, fails OC-R006 / OC-R007.
 
 ## Constraints
 

--- a/tests/signals_collector_output_contract_integration_test.go
+++ b/tests/signals_collector_output_contract_integration_test.go
@@ -29,6 +29,17 @@
 //     per-column ::text sweep missed (relkind in the bloat collectors,
 //     provolatile AS volatility in pg_functions_v1, attidentity in
 //     pg_identity_columns_v1) decode as STRINGS, never JSON numbers.
+//   - OC-R006 / INV-05 (#326): the remaining internal-"char" schema
+//     collectors #314 missed — pg_partitions_v1.partition_strategy,
+//     pg_triggers_v1/_definitions_v1.tg_enabled, and
+//     pg_functions_v1/_definitions_v1.volatility — decode as single-char
+//     STRINGS. A seeded partitioned table, trigger, and function make
+//     each emit rows.
+//   - OC-R007 / INV-05 (#326, capability-gated): when a superuser DSN
+//     (SIGNALS_TEST_PG_SUPERUSER_DSN) provisions postgres_fdw + a server,
+//     a seeded foreign table makes fdw_foreign_tables_v1.relkind decode
+//     as the string "f"; absent the capability the assertion is skipped
+//     with a documented reason.
 //
 // Gated by the `integration` build tag and SIGNALS_TEST_PG_DSN (skips
 // locally when unset), matching signals_integration_test.go. In CI it
@@ -68,14 +79,31 @@ import (
 // internalCharColumns are the PostgreSQL internal-"char" columns the
 // #313 fix cast ::text. pgx scans an uncast "char" as an integer byte,
 // so any of these appearing as a JSON number in a payload is the #312
-// regression. Names are the exported column aliases in the collector
-// SQL.
+// regression. Names are the exported column ALIASES in the collector
+// SQL — the whitelist keys the OUTPUT column name, so the function
+// volatility field is "volatility" (its alias), never "provolatile".
+//
+// #326 adds the aliases the remaining schema collectors expose but the
+// #314 fixtures never exercised: partition_strategy (pg_partitions_v1,
+// from partstrat), tg_enabled (pg_triggers_v1 /
+// pg_triggers_definitions_v1, from tgenabled), volatility
+// (pg_functions_v1 / pg_functions_definitions_v1, the OUTPUT alias of
+// provolatile), and attidentity (pg_identity_columns_v1). relkind
+// already covers fdw_foreign_tables_v1 once that collector is seeded.
 var internalCharColumns = map[string]bool{
-	"contype":        true,
-	"relkind":        true,
-	"relpersistence": true,
-	"provolatile":    true,
-	"prokind":        true,
+	"contype":            true,
+	"relkind":            true,
+	"relpersistence":     true,
+	"provolatile":        true,
+	"prokind":            true,
+	"partition_strategy": true, // pg_partitions_v1 (from partstrat) — #326
+	"tg_enabled":         true, // pg_triggers_v1 / _definitions_v1 (from tgenabled) — #326
+	"volatility":         true, // pg_functions_v1 / _definitions_v1 (OUTPUT alias of provolatile) — #326
+	// NOTE: attidentity is deliberately NOT in this map. The non-set
+	// identity case is the empty string "" (a legitimate, non-numeric
+	// value), which the generic single-char sweep below would reject.
+	// It is instead asserted by the dedicated assertStringCol(...,
+	// allowEmpty=true) call for pg_identity_columns_v1 (OC-R005). #326.
 }
 
 // declaredColumnsByCollector is the subset of spec-declared columns
@@ -92,6 +120,37 @@ var declaredColumnsByCollector = map[string][]string{
 		"relid", "schemaname", "relname", "relkind", "relpersistence",
 		"relispartition", "relhasindex",
 	},
+	// #326 — the remaining internal-"char" schema collectors the
+	// representative fixture now makes emit rows. Columns per each
+	// collector's spec "Output columns" table (kept to the always-present
+	// structural set + the aliased char column under test).
+	"pg_partitions_v1": {
+		"parent_schema", "parent_name", "partition_strategy",
+		"partition_key", "child_schema", "child_name", "child_bounds",
+	},
+	"pg_triggers_v1": {
+		"schemaname", "relname", "tgname", "tgtype",
+		"tg_funcschema", "tg_funcname", "tg_enabled",
+	},
+	"pg_functions_v1": {
+		"schemaname", "proname", "identity_args", "return_type",
+		"language", "volatility", "security_definer", "is_strict",
+		"prokind",
+	},
+	"pg_identity_columns_v1": {
+		"schemaname", "relname", "attname", "atttypname", "attidentity",
+		"atthasdef", "default_is_nextval", "auto_owned_sequence",
+		"is_primary_key", "is_unique",
+	},
+}
+
+// fdwForeignTablesDeclaredColumns is asserted only when the FDW
+// capability is available (OC-R007) — the collector emits no rows and
+// no payload without a seeded foreign table, so it cannot live in the
+// unconditional declaredColumnsByCollector map.
+var fdwForeignTablesDeclaredColumns = []string{
+	"schemaname", "table_name", "table_oid", "relkind",
+	"server_name", "fdw_name", "foreign_table_options",
 }
 
 // exportedRun mirrors the query_runs.ndjson row shape emitted by
@@ -118,7 +177,7 @@ func TestIntegration_CollectorOutputContractAgainstRealPG(t *testing.T) {
 		t.Skip("SIGNALS_TEST_PG_DSN not set — skipping live PostgreSQL integration test")
 	}
 
-	seedRepresentativeSchema(t, dsn)
+	fdwSeeded := seedRepresentativeSchema(t, dsn)
 
 	connCfg, err := pgx.ParseConfig(dsn)
 	if err != nil {
@@ -172,6 +231,12 @@ func TestIntegration_CollectorOutputContractAgainstRealPG(t *testing.T) {
 		30,
 		collector.WithTargetTimeout(90*time.Second),
 		collector.WithQueryTimeout(20*time.Second),
+		// #326: enable the HighSensitivity definition-text collectors so
+		// pg_triggers_definitions_v1 and pg_functions_definitions_v1 run
+		// and their tg_enabled / volatility aliases are asserted too
+		// (they are off by default). The seeded schema carries no
+		// secrets, so exercising the definition bodies is safe here.
+		collector.WithHighSensitivityCollectors(true),
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -355,6 +420,51 @@ func TestIntegration_CollectorOutputContractAgainstRealPG(t *testing.T) {
 	// attidentity: may be "" (non-set) or a single char (a/d).
 	assertStringCol("pg_identity_columns_v1", "attidentity", true)
 
+	// --- OC-R006 / INV-05 (the #326 schema-family char lock) -------
+	// The remaining schema collectors that alias an internal-"char"
+	// column but the #314 fixtures never exercised. The seeded
+	// partitioned table, trigger, and function make each emit a row; the
+	// aliased char value must decode as a single, non-empty character
+	// string, never a number. These go RED with the OID-18 AfterConnect
+	// registration removed and GREEN with it in place.
+	//
+	//   - partition_strategy (pg_partitions_v1, from partstrat) — 'r' for
+	//     the RANGE-partitioned events table,
+	//   - tg_enabled (pg_triggers_v1 / _definitions_v1, from tgenabled) —
+	//     'O' for the enabled BEFORE INSERT trigger,
+	//   - volatility (pg_functions_v1 / _definitions_v1, the OUTPUT alias
+	//     of provolatile) — 'i' for the IMMUTABLE function.
+	assertStringCol("pg_partitions_v1", "partition_strategy", false)
+	assertStringCol("pg_triggers_v1", "tg_enabled", false)
+	assertStringCol("pg_triggers_definitions_v1", "tg_enabled", false)
+	assertStringCol("pg_functions_v1", "volatility", false)
+	assertStringCol("pg_functions_definitions_v1", "volatility", false)
+
+	// --- OC-R007 / INV-05 (the #326 FDW leg, capability-gated) ------
+	// fdw_foreign_tables_v1.relkind is always 'f' (a single char). Only
+	// asserted when the FDW capability was provisioned (a superuser DSN
+	// created the extension + server + granted USAGE); otherwise the
+	// fixture was skipped with a documented reason and the collector
+	// emits no rows.
+	if fdwSeeded {
+		assertStringCol("fdw_foreign_tables_v1", "relkind", false)
+		// The FDW collector's declared columns are present in its payload
+		// (OC-R002 extended to the capability-gated collector).
+		if payload, ok := payloadByQueryID["fdw_foreign_tables_v1"]; ok && len(payload) > 0 {
+			row := payload[0]
+			for _, col := range fdwForeignTablesDeclaredColumns {
+				if _, present := row[col]; !present {
+					t.Errorf("OC-R002 (INV-OUTPUT-CONTRACT): collector fdw_foreign_tables_v1 payload is missing declared column %q; keys present=%v",
+						col, keysOf(row))
+				}
+			}
+		} else {
+			t.Error("OC-R007: FDW capability was provisioned but fdw_foreign_tables_v1 produced no payload — the seeded foreign table should have made it emit a row")
+		}
+	} else {
+		t.Log("OC-R007: FDW capability absent — fdw_foreign_tables_v1.relkind assertion skipped (documented capability gate)")
+	}
+
 	// --- OC-R002 / INV-OUTPUT-CONTRACT -----------------------------
 	// Each char-type catalog collector's declared columns are present.
 	for collectorID, cols := range declaredColumnsByCollector {
@@ -381,7 +491,13 @@ func TestIntegration_CollectorOutputContractAgainstRealPG(t *testing.T) {
 // table whose FK to the parent is UNINDEXED, plus a non-PK index and
 // columns of varied types. The unindexed FK is what makes
 // pg_constraint emit a contype='f' row — the exact #312 fixture.
-func seedRepresentativeSchema(t *testing.T, dsn string) {
+//
+// #326 extends it with a partitioned table, a user trigger, and a SQL
+// function so the remaining internal-"char" schema collectors emit rows,
+// and — when the FDW capability is available — a foreign table. It
+// returns whether the FDW fixture was seeded so the caller can
+// capability-gate the fdw_foreign_tables_v1.relkind assertion (OC-R007).
+func seedRepresentativeSchema(t *testing.T, dsn string) (fdwSeeded bool) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -434,6 +550,28 @@ func seedRepresentativeSchema(t *testing.T, dsn string) {
 		`CREATE FUNCTION signals_oc_test.demo_immutable(x integer)
 			RETURNS integer LANGUAGE sql IMMUTABLE
 			AS 'SELECT x + 1'`,
+		// A RANGE-partitioned table with one child partition so
+		// pg_partitions_v1 emits a row carrying partition_strategy
+		// (partstrat AS partition_strategy — raw "char", 'r' for RANGE).
+		// The remaining internal-"char" schema collectors #314 missed.
+		// #326.
+		`CREATE TABLE signals_oc_test.events (
+			id  bigint NOT NULL,
+			ts  timestamptz NOT NULL
+		) PARTITION BY RANGE (ts)`,
+		`CREATE TABLE signals_oc_test.events_2026
+			PARTITION OF signals_oc_test.events
+			FOR VALUES FROM ('2026-01-01') TO ('2027-01-01')`,
+		// A trigger function + a user (non-internal) BEFORE INSERT row
+		// trigger so pg_triggers_v1 / pg_triggers_definitions_v1 emit a
+		// row carrying tg_enabled (tgenabled AS tg_enabled — raw "char",
+		// 'O' for an origin/enabled trigger). #326.
+		`CREATE FUNCTION signals_oc_test.tg_noop()
+			RETURNS trigger LANGUAGE plpgsql
+			AS 'BEGIN RETURN NEW; END'`,
+		`CREATE TRIGGER child_bi
+			BEFORE INSERT ON signals_oc_test.child
+			FOR EACH ROW EXECUTE FUNCTION signals_oc_test.tg_noop()`,
 		`INSERT INTO signals_oc_test.parent (id, label, ratio)
 			VALUES (1, 'a', 1.5), (2, 'b', 2.5)`,
 		`INSERT INTO signals_oc_test.child (id, fk_parent_id, note, amount)
@@ -445,6 +583,30 @@ func seedRepresentativeSchema(t *testing.T, dsn string) {
 		`ANALYZE signals_oc_test.child`,
 		`ANALYZE signals_oc_test.identity_demo`,
 	}
+
+	// --- FDW capability (OC-R007) ---------------------------------------
+	// fdw_foreign_tables_v1 only emits a row when a foreign table exists.
+	// A pg_monitor collector role cannot CREATE EXTENSION postgres_fdw or
+	// a FOREIGN DATA WRAPPER itself, so the extension + a foreign SERVER +
+	// a USAGE grant are provisioned via an OPTIONAL superuser DSN
+	// (SIGNALS_TEST_PG_SUPERUSER_DSN). The foreign table itself is then
+	// created by the collector role (pool) so the fixture stays in the
+	// dedicated schema. When the capability is unavailable the fixture is
+	// skipped and the caller capability-gates the relkind assertion.
+	fdwSeeded = provisionFDWCapability(t, ctx)
+	if fdwSeeded {
+		// The foreign table's remote target need not exist — the collector
+		// reads only local catalog metadata (pg_class.relkind='f'), never
+		// the remote data (see fdw_foreign_tables_v1.md). #326.
+		stmts = append(stmts,
+			`CREATE FOREIGN TABLE signals_oc_test.remote_events (
+				id bigint,
+				ts timestamptz
+			) SERVER signals_oc_test_fdw_srv
+			  OPTIONS (schema_name 'public', table_name 'nonexistent_ok')`,
+		)
+	}
+
 	for _, s := range stmts {
 		if _, err := pool.Exec(ctx, s); err != nil {
 			t.Fatalf("seed stmt failed: %v\nSQL: %s", err, s)
@@ -460,6 +622,85 @@ func seedRepresentativeSchema(t *testing.T, dsn string) {
 		defer p.Close()
 		_, _ = p.Exec(cctx, `DROP SCHEMA IF EXISTS signals_oc_test CASCADE`)
 	})
+	return fdwSeeded
+}
+
+// provisionFDWCapability provisions the postgres_fdw extension, a
+// dedicated foreign server, and a USAGE grant to the collector role,
+// using the OPTIONAL SIGNALS_TEST_PG_SUPERUSER_DSN superuser connection.
+// It reports whether the FDW capability is available for the fixture.
+//
+// Returns false (documented skip, OC-R007) when the superuser DSN is
+// unset or the extension is unavailable — the harness then omits the
+// foreign-table fixture and capability-gates fdw_foreign_tables_v1.relkind.
+// The provisioning is idempotent and touches only the dedicated server;
+// collection itself still runs as the non-superuser collector role
+// (INV-02 / INV-06 hold).
+func provisionFDWCapability(t *testing.T, ctx context.Context) bool {
+	t.Helper()
+
+	superDSN := os.Getenv("SIGNALS_TEST_PG_SUPERUSER_DSN")
+	if superDSN == "" {
+		t.Log("OC-R007: SIGNALS_TEST_PG_SUPERUSER_DSN unset — skipping FDW fixture (fdw_foreign_tables_v1.relkind assertion is capability-gated)")
+		return false
+	}
+
+	collectorRole := collectorRoleFromDSN(t)
+	if collectorRole == "" {
+		t.Log("OC-R007: could not resolve the collector role from SIGNALS_TEST_PG_DSN — skipping FDW fixture")
+		return false
+	}
+
+	sp, err := pgxpool.New(ctx, superDSN)
+	if err != nil {
+		t.Logf("OC-R007: superuser connect failed (%v) — skipping FDW fixture", err)
+		return false
+	}
+	defer sp.Close()
+
+	// Idempotent: drop a stale server, (re)create the extension + server,
+	// and grant USAGE. CREATE EXTENSION / FOREIGN DATA WRAPPER need
+	// superuser — hence the separate DSN.
+	superStmts := []string{
+		`DROP SERVER IF EXISTS signals_oc_test_fdw_srv CASCADE`,
+		`CREATE EXTENSION IF NOT EXISTS postgres_fdw`,
+		`CREATE SERVER signals_oc_test_fdw_srv
+			FOREIGN DATA WRAPPER postgres_fdw
+			OPTIONS (host 'localhost', port '5432', dbname 'postgres')`,
+		fmt.Sprintf(`GRANT USAGE ON FOREIGN SERVER signals_oc_test_fdw_srv TO %s`,
+			pgx.Identifier{collectorRole}.Sanitize()),
+	}
+	for _, s := range superStmts {
+		if _, err := sp.Exec(ctx, s); err != nil {
+			t.Logf("OC-R007: FDW provisioning failed (%v) on: %s — skipping FDW fixture", err, s)
+			return false
+		}
+	}
+
+	// Retire the server on cleanup so repeated runs stay clean.
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer ccancel()
+		p, err := pgxpool.New(cctx, superDSN)
+		if err != nil {
+			return
+		}
+		defer p.Close()
+		_, _ = p.Exec(cctx, `DROP SERVER IF EXISTS signals_oc_test_fdw_srv CASCADE`)
+	})
+	return true
+}
+
+// collectorRoleFromDSN returns the role name the collector authenticates
+// as, parsed from SIGNALS_TEST_PG_DSN, so the USAGE grant targets exactly
+// that role.
+func collectorRoleFromDSN(t *testing.T) string {
+	t.Helper()
+	cfg, err := pgx.ParseConfig(os.Getenv("SIGNALS_TEST_PG_DSN"))
+	if err != nil {
+		return ""
+	}
+	return cfg.User
 }
 
 func readRuns(t *testing.T, zr *zip.Reader) []exportedRun {


### PR DESCRIPTION
Closes #326.

Test-only harness coverage. The production defect was already fixed by #319 / PR #321 (OID 18 normalized to text at the connection boundary), so this adds no production SQL or `internal/` changes — it extends the output-contract integration harness to exercise and regression-lock the internal-`"char"` schema-collector aliases the #314 fixtures missed.

## What changed

- **Char whitelist** (`internalCharColumns`) gains the OUTPUT aliases the remaining schema collectors expose: `partition_strategy`, `tg_enabled`, `volatility` (the alias of `provolatile`, never the raw catalog name). `attidentity` is deliberately kept out of the single-char sweep and asserted via the dedicated `allowEmpty=true` path (the non-set case is `""`).
- **Fixtures** seed a RANGE-partitioned table, a user trigger, a SQL function (identity column already present), so these collectors emit rows. The high-sensitivity definition collectors are enabled so `pg_triggers_definitions_v1` / `pg_functions_definitions_v1` are covered too.
- **Assertions** (OC-R006) that each aliased char decodes as a single-character string, never a JSON number:
  - `pg_partitions_v1.partition_strategy`
  - `pg_triggers_v1` / `pg_triggers_definitions_v1.tg_enabled`
  - `pg_functions_v1` / `pg_functions_definitions_v1.volatility`
- **FDW leg** (OC-R007, capability-gated): a foreign table needs a `postgres_fdw` server the `pg_monitor` collector role cannot create, so it is provisioned via an optional `SIGNALS_TEST_PG_SUPERUSER_DSN` (wired into the CI matrix step). When the capability is absent the fixture + `fdw_foreign_tables_v1.relkind == "f"` assertion are skipped with a documented reason; every other assertion still runs.

## Regression lock verified

Temporarily reverting the #319 OID-18 `AfterConnect` registration turns the new assertions RED — `partition_strategy`=114, `tg_enabled`=79, `volatility`=118/105, `relkind`=102 — and GREEN with it restored. The assertions check for the string type, not just presence.

## STDD

Spec/acceptance/traceability updated: OC-R006, OC-R007, INV-05, INV-06, TC-OC-07, TC-OC-08, plus the char-family behaviours in `specifications/collector-output-contract.md`.

## Local verification

Ran the `integration`-tagged test live against docker PostgreSQL **17** and **18** (both PASS, 81 collectors success). Gates green locally: `gofmt`, `go vet` (default + `integration`), `golangci-lint` (default + `--build-tags=integration`, 0 issues), `actionlint` on `ci.yml`, `check-docs.sh`, and the default `go test ./tests/`.

Refs #314, #319, #316.