### PR TITLE
Wire mTLS auth into the Helm chart (#330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- The Helm chart can now deploy the shipped `mtls` (client-certificate)
+  authentication method. Previously `deploy/helm/signals/values.schema.json`
+  rejected `target.authMethod: mtls` and `templates/configmap.yaml`
+  rendered no `sslcert` / `sslkey` / `sslkey_passphrase_file` fields, so a
+  supported target could be hand-configured but not deployed through the
+  chart. The schema now admits `mtls` and adds `target.sslCertFile`,
+  `target.sslKeyFile`, and optional `target.sslKeyPassphraseFile`
+  (conditionally requiring cert+key paths for `mtls`, mirroring
+  config.go FC-MTLS-001); the ConfigMap renders those paths into
+  `signals.yaml` only when set. Only filesystem PATHS reach the values
+  and ConfigMap — certificate, key, and passphrase contents are mounted
+  from a Kubernetes Secret via `extraVolumes` / `extraVolumeMounts`. The
+  chart README authentication table and `docs/database-connections.md`
+  document the mount (#330).
 - Concurrent exports can no longer cross-contaminate each other's
   archives. The daemon shares one long-lived `export.Builder` across
   every `GET /export` request, and request-specific scope (resolved

--- a/deploy/helm/signals/README.md
+++ b/deploy/helm/signals/README.md
@@ -47,7 +47,9 @@ extraEnv:
 
 `target.authMethod` selects how the collector authenticates. The
 default (empty) is the password method; the rest are **passwordless** —
-the pod's ambient cloud identity mints the credential at connect time.
+the pod's ambient cloud identity mints the credential at connect time
+(`aws_rds_iam` / `azure_entra` / `gcp_cloudsql_iam` / `secret_store`),
+or the pod presents a client certificate (`mtls`).
 
 | `authMethod` | Credential source | Password? |
 |---|---|---|
@@ -56,6 +58,7 @@ the pod's ambient cloud identity mints the credential at connect time.
 | `azure_entra` | Entra OAuth2 token from the pod's Azure identity | no |
 | `gcp_cloudsql_iam` | Google OAuth2 token from the pod's GCP identity | no |
 | `secret_store` | Password fetched from a cloud vault | no |
+| `mtls` | Client X.509 certificate presented from mounted PEM files | no |
 
 Invariants enforced by the chart and the collector:
 
@@ -220,6 +223,57 @@ target:
   sslRootCertFile: /etc/ssl/db/ca.pem
 # ... extraVolumes / extraVolumeMounts for the CA bundle
 ```
+
+### `mtls` — client-certificate auth (self-managed / on-prem)
+
+For self-managed PostgreSQL that mandates mutual TLS, the collector
+presents a client X.509 certificate instead of a password or token
+(`pg_hba.conf` `cert clientcert=verify-full`). The chart takes only the
+**paths** of the PEM files — never their contents. Mount the client
+certificate and private key (and, for an encrypted key, the passphrase
+file) from a Kubernetes Secret via `extraVolumes` / `extraVolumeMounts`,
+then point `sslCertFile` / `sslKeyFile` / `sslKeyPassphraseFile` at the
+mount paths.
+
+`mtls` requires **both** `sslCertFile` and `sslKeyFile`, and
+`sslmode: verify-full` in every environment — a client certificate is
+only presented to a fully verified server. `sslKeyPassphraseFile` is
+optional (encrypted keys only).
+
+```yaml
+target:
+  host: db.internal
+  dbname: appdb
+  user: signals                       # must match the cert CN / pg_ident mapping
+  authMethod: mtls
+  sslmode: verify-full
+  sslCertFile: /etc/signals/mtls/client.crt   # PATH only — mounted below
+  sslKeyFile: /etc/signals/mtls/client.key    # PATH only — mounted below
+  # sslKeyPassphraseFile: /etc/signals/mtls/key.pass  # optional; encrypted key only
+  sslRootCertFile: /etc/ssl/db/ca.pem         # verifies the server
+
+extraVolumes:
+  - name: db-mtls
+    secret:
+      secretName: signals-mtls        # holds client.crt, client.key (+ key.pass)
+extraVolumeMounts:
+  - name: db-mtls
+    mountPath: /etc/signals/mtls
+    readOnly: true
+```
+
+Create the Secret out-of-band so no key material lands in Helm values or
+release history:
+
+```bash
+kubectl create secret generic signals-mtls \
+  --from-file=client.crt=./client.crt \
+  --from-file=client.key=./client.key
+  # --from-file=key.pass=./key.pass   # only if the key is encrypted
+```
+
+The private key is read at connect time and never logged or exported; a
+rotated cert/key is picked up on the next reconnect.
 
 ## CA bundles for `verify-full`
 

--- a/deploy/helm/signals/templates/configmap.yaml
+++ b/deploy/helm/signals/templates/configmap.yaml
@@ -53,6 +53,25 @@ data:
         {{- with .Values.target.secretRef }}
         secret_ref: {{ . }}
         {{- end }}
+        {{- /*
+          #330 — mTLS client-certificate auth. Only PATHS are rendered
+          (sslcert / sslkey / sslkey_passphrase_file); the certificate,
+          key, and passphrase CONTENTS never enter values or this
+          ConfigMap. Mount the corresponding Kubernetes Secret via
+          extraVolumes/extraVolumeMounts so the files land on disk, then
+          point these paths at the mount. The schema requires cert+key
+          when auth_method is mtls (FC-MTLS-001); the passphrase file is
+          optional and renders only when set.
+        */}}
+        {{- with .Values.target.sslCertFile }}
+        sslcert: {{ . }}
+        {{- end }}
+        {{- with .Values.target.sslKeyFile }}
+        sslkey: {{ . }}
+        {{- end }}
+        {{- with .Values.target.sslKeyPassphraseFile }}
+        sslkey_passphrase_file: {{ . }}
+        {{- end }}
         {{- /* Password source only for the default (password) method —
                token/secret methods are passwordless (FC005). */}}
         {{- if and (not .Values.target.authMethod) .Values.target.passwordSecretName }}

--- a/deploy/helm/signals/values.schema.json
+++ b/deploy/helm/signals/values.schema.json
@@ -14,22 +14,40 @@
     },
     "target": {
       "type": "object",
-      "description": "PostgreSQL target. Set host to enable collection; token/secret auth methods require sslmode verify-full.",
+      "description": "PostgreSQL target. Set host to enable collection; token/secret/mtls auth methods require sslmode verify-full.",
       "properties": {
         "host": { "type": "string", "description": "PostgreSQL hostname (e.g. the RDS endpoint). Required to enable collection." },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "dbname": { "type": "string" },
         "user": { "type": "string" },
         "sslmode": { "type": "string", "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"] },
-        "authMethod": { "type": "string", "enum": ["", "aws_rds_iam", "azure_entra", "gcp_cloudsql_iam", "secret_store"] },
+        "authMethod": { "type": "string", "enum": ["", "aws_rds_iam", "azure_entra", "gcp_cloudsql_iam", "secret_store", "mtls"] },
         "region": { "type": "string" },
         "azureClientId": { "type": "string" },
         "gcpImpersonateServiceAccount": { "type": "string" },
         "secretRef": { "type": "string" },
         "sslRootCertFile": { "type": "string" },
+        "sslCertFile": { "type": "string", "description": "mtls: filesystem PATH to the PEM client certificate (never its contents). Mount the cert via extraVolumes/extraVolumeMounts and point this at the mount path. Required for mtls." },
+        "sslKeyFile": { "type": "string", "description": "mtls: filesystem PATH to the PEM client private key (never its contents). Mount the key via extraVolumes/extraVolumeMounts and point this at the mount path. Required for mtls." },
+        "sslKeyPassphraseFile": { "type": "string", "description": "mtls: optional filesystem PATH to a file holding the passphrase for an encrypted client key (never the passphrase itself). Mount via extraVolumes/extraVolumeMounts." },
         "passwordSecretName": { "type": "string" },
         "passwordSecretKey": { "type": "string" }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "authMethod": { "const": "mtls" } },
+            "required": ["authMethod"]
+          },
+          "then": {
+            "required": ["sslCertFile", "sslKeyFile"],
+            "properties": {
+              "sslCertFile": { "type": "string", "minLength": 1 },
+              "sslKeyFile": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      ]
     },
     "collector": {
       "type": "object",

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -25,11 +25,24 @@ target:
   # ambient cloud identity (IRSA / Pod Identity / Workload Identity)
   # mints the credential; see deploy/helm/signals/README.md for
   # per-platform values snippets.
-  authMethod: ""     # "" | aws_rds_iam | azure_entra | gcp_cloudsql_iam | secret_store
+  authMethod: ""     # "" | aws_rds_iam | azure_entra | gcp_cloudsql_iam | secret_store | mtls
   region: ""         # aws_rds_iam: optional (also read from AWS_REGION / IMDS)
   azureClientId: ""  # azure_entra: optional user-assigned MI disambiguation (also AZURE_CLIENT_ID)
   gcpImpersonateServiceAccount: ""  # gcp_cloudsql_iam: optional impersonation target
   secretRef: ""      # secret_store: cloud vault reference (NOT a secret — an ARN/URI/name)
+
+  # Client-certificate auth (authMethod: mtls, #98/#330). For on-prem /
+  # self-managed PostgreSQL that mandates mutual TLS. These are
+  # filesystem PATHS to PEM files — never the certificate/key/passphrase
+  # CONTENTS. Mount the client cert + key (and any passphrase file) from
+  # a Kubernetes Secret via extraVolumes / extraVolumeMounts (below) and
+  # point these at the mount paths. mtls requires BOTH sslCertFile and
+  # sslKeyFile and sslmode: verify-full (config.go FC-MTLS-001/004);
+  # sslKeyPassphraseFile is optional (encrypted keys only). See
+  # deploy/helm/signals/README.md for the full mount snippet.
+  sslCertFile: ""           # PATH to the PEM client certificate
+  sslKeyFile: ""            # PATH to the PEM client private key
+  sslKeyPassphraseFile: ""  # optional PATH to a file holding the key passphrase
 
   # verify-full needs a CA bundle. Mount it via extraVolumes /
   # extraVolumeMounts (below) and point this at the mounted path. In

--- a/docs/database-connections.md
+++ b/docs/database-connections.md
@@ -360,6 +360,14 @@ The private key is read at connect time and **never logged or exported**;
 a rotated cert/key is picked up on the next reconnect. `verify-full` is
 required — a client certificate is only presented to a verified server.
 
+**On Kubernetes (Helm):** the chart exposes `target.authMethod: mtls`
+with `target.sslCertFile` / `target.sslKeyFile` /
+`target.sslKeyPassphraseFile` — these are **paths only**, never the PEM
+contents. Mount the client cert + key from a Kubernetes Secret with
+`extraVolumes` / `extraVolumeMounts` and point the path values at the
+mount. The full snippet is in
+[`deploy/helm/signals/README.md`](../deploy/helm/signals/README.md#mtls--client-certificate-auth-self-managed--on-prem).
+
 ---
 
 ## TLS, at a glance

--- a/tests/signals_helm_mtls_auth_test.go
+++ b/tests/signals_helm_mtls_auth_test.go
@@ -1,0 +1,130 @@
+package tests
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// #330 — the Helm chart must be able to render the shipped `mtls`
+// authentication method. Signals' internal/config/config.go supports
+// auth_method: mtls with the file-path fields sslcert / sslkey /
+// sslkey_passphrase_file (both cert+key required — FC-MTLS-001), yet
+// before #330 the chart's values.schema.json rejected
+// target.authMethod=mtls and templates/configmap.yaml rendered none of
+// the certificate/key path fields — so a supported target could be
+// hand-written but never deployed via the chart.
+//
+// These tests are the chart contract: a VALID mTLS target renders the
+// sslcert/sslkey (+ optional passphrase file) PATHS into signals.yaml,
+// and a mTLS target MISSING the required cert/key paths is REJECTED by
+// values.schema.json at `helm template` time. Only PATHS ever reach the
+// values/ConfigMap — never certificate, key, or passphrase CONTENTS.
+
+func TestHelm_MTLSRendersCertAndKeyPaths(t *testing.T) {
+	out := renderHelm(t,
+		targetHost,
+		"target.authMethod=mtls",
+		"target.sslmode=verify-full",
+		"target.sslCertFile=/etc/signals/mtls/client.crt",
+		"target.sslKeyFile=/etc/signals/mtls/client.key",
+	)
+	for _, want := range []string{
+		"auth_method: mtls",
+		"sslmode: verify-full",
+		"sslcert: /etc/signals/mtls/client.crt",
+		"sslkey: /etc/signals/mtls/client.key",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("mtls config missing %q:\n%s", want, out)
+		}
+	}
+	// mTLS authenticates by client certificate — passwordless (FC-MTLS-005).
+	if strings.Contains(out, "password_env") {
+		t.Errorf("mtls is passwordless; password_env must not render (FC-MTLS-005):\n%s", out)
+	}
+	// The optional passphrase file is not set here — it must not render.
+	if strings.Contains(out, "sslkey_passphrase_file:") {
+		t.Errorf("sslkey_passphrase_file must not render when unset:\n%s", out)
+	}
+}
+
+func TestHelm_MTLSRendersOptionalPassphraseFileWhenSet(t *testing.T) {
+	out := renderHelm(t,
+		targetHost,
+		"target.authMethod=mtls",
+		"target.sslmode=verify-full",
+		"target.sslCertFile=/etc/signals/mtls/client.crt",
+		"target.sslKeyFile=/etc/signals/mtls/client.key",
+		"target.sslKeyPassphraseFile=/etc/signals/mtls/key.pass",
+	)
+	if !strings.Contains(out, "sslkey_passphrase_file: /etc/signals/mtls/key.pass") {
+		t.Errorf("optional sslkey_passphrase_file path not rendered when set:\n%s", out)
+	}
+}
+
+// SECURITY: only PATHS ever reach the values/ConfigMap. The chart must
+// expose no value that carries certificate, key, or passphrase content;
+// the files land on disk via a mounted Secret (extraVolumes /
+// extraVolumeMounts), and the chart only writes their paths.
+func TestHelm_MTLSDoesNotRenderCertificateContents(t *testing.T) {
+	out := renderHelm(t,
+		targetHost,
+		"target.authMethod=mtls",
+		"target.sslmode=verify-full",
+		"target.sslCertFile=/etc/signals/mtls/client.crt",
+		"target.sslKeyFile=/etc/signals/mtls/client.key",
+	)
+	for _, forbidden := range []string{
+		"BEGIN CERTIFICATE",
+		"BEGIN PRIVATE KEY",
+		"BEGIN RSA PRIVATE KEY",
+		"BEGIN ENCRYPTED PRIVATE KEY",
+	} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("rendered manifest leaked certificate/key material (%q):\n%s", forbidden, out)
+		}
+	}
+}
+
+// A mTLS target that omits the required cert/key paths must be rejected
+// by values.schema.json at `helm template` time — mirroring
+// config.go's FC-MTLS-001 (both sslcert and sslkey are required). This
+// fails the render fast rather than shipping an invalid target.
+func TestHelm_MTLSMissingCertKeyRejectedBySchema(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm CLI not on PATH; skipping helm-template assertion")
+	}
+	cmd := exec.Command("helm", "template", "signals", prodChartPath,
+		"--set", targetHost,
+		"--set", "target.authMethod=mtls",
+		"--set", "target.sslmode=verify-full",
+		// sslCertFile / sslKeyFile deliberately omitted.
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("mtls target without cert/key paths was accepted; schema must reject it:\n%s", out)
+	}
+	if !strings.Contains(string(out), "sslCertFile") && !strings.Contains(string(out), "sslKeyFile") {
+		t.Fatalf("schema rejection should name the missing mTLS path field(s):\n%s", out)
+	}
+}
+
+// The add-on / Helm values schema must ADMIT mtls as an authMethod
+// enum value (before #330 it rejected it outright).
+func TestHelm_MTLSAuthMethodAcceptedBySchema(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm CLI not on PATH; skipping helm-template assertion")
+	}
+	cmd := exec.Command("helm", "template", "signals", prodChartPath,
+		"--set", targetHost,
+		"--set", "target.authMethod=mtls",
+		"--set", "target.sslmode=verify-full",
+		"--set", "target.sslCertFile=/etc/signals/mtls/client.crt",
+		"--set", "target.sslKeyFile=/etc/signals/mtls/client.key",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("valid mtls values must pass schema validation; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes #330.

## Problem

Signals ships `auth_method: mtls` (config.go's `TargetConfig` supports `SSLCert`, `SSLKey`, `SSLKeyPassphraseFile` and requires cert+key for mTLS; docs mark it shipped), but the Helm chart could not render a valid mTLS target: `values.schema.json` restricted `target.authMethod` to `""`/`aws_rds_iam`/`azure_entra`/`gcp_cloudsql_iam`/`secret_store`, and `templates/configmap.yaml` rendered no `sslcert`/`sslkey`/`sslkey_passphrase_file` fields. A supported target could be hand-configured but not deployed via the chart.

## Change (chart-wiring only — `internal/config/config.go` unchanged)

- **`values.schema.json`** — add `mtls` to the `target.authMethod` enum; add `target.sslCertFile` / `target.sslKeyFile` / `target.sslKeyPassphraseFile` (PATH-only, documented); conditional `allOf`/`if`-`then` requiring cert+key paths when `authMethod` is `mtls`, mirroring config.go FC-MTLS-001.
- **`templates/configmap.yaml`** — render `sslcert` / `sslkey` / `sslkey_passphrase_file` into `signals.yaml` only when set. mTLS stays passwordless.
- **`values.yaml`** — document the three PATH fields, empty by default.
- **`README.md`** — add `mtls` to the authentication table + a dedicated client-certificate section with the `extraVolumes`/`extraVolumeMounts` Secret-mount snippet.
- **`docs/database-connections.md`** — point the mTLS section at the Helm mount guidance.

## Security

Only filesystem **PATHS** enter the values and ConfigMap. Certificate, key, and passphrase **contents** are mounted from a Kubernetes Secret via `extraVolumes`/`extraVolumeMounts`; the chart writes only their paths.

## Tests (STDD)

`tests/signals_helm_mtls_auth_test.go` — added, proven failing before the change and passing after:

- valid mTLS target renders `sslcert`/`sslkey` (+ optional passphrase) into `signals.yaml`;
- `mtls` target missing required cert/key paths is **rejected** by schema validation at `helm template` time;
- rendered manifests carry no PEM material;
- `mtls` enum value is admitted by the schema.

All 35 Helm/schema tests pass. `helm lint` clean; kube-lint gate (kube-linter + conftest, 40 tests) passes; `check-docs` passes (relative links resolve); `go vet` clean.