### PR TITLE
test(output-contract): assert declared columns for all collectors (#316)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,16 @@ jobs:
 
   # #314: collector output-contract verification against a live
   # PostgreSQL, matrixed across every supported major so version-gated
-  # column/type differences surface. The integration test seeds a
-  # parent+child table with an UNINDEXED foreign key, runs the full
+  # column/type differences surface. The integration test seeds
+  # representative schema (a parent+child table with an UNINDEXED foreign
+  # key, plus a view, matview, partitioned table, trigger, function,
+  # types, RLS policy, extended statistics and a rule), runs the full
   # collection, exports a snapshot ZIP via the production export path,
-  # and asserts the per-collector output contract — most importantly the
-  # internal-"char" columns (contype/relkind/relpersistence/provolatile/
-  # prokind) serialize as single-char STRINGS, locking the #312 class
+  # and asserts the per-collector output contract for EVERY registered
+  # collector that emits rows (#316) — the spec-declared columns are
+  # present, and most importantly the internal-"char" columns
+  # (contype/relkind/relpersistence/provolatile/prokind) serialize as
+  # single-char STRINGS, locking the #312 class
   # (an uncast contype serialized as 102 instead of "f", so the Analyzer
   # skipped every FK — Elevarq/Analyzer#1871). The test is `integration`
   # build-tag + SIGNALS_TEST_PG_DSN gated, so it never runs in the unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,24 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   foreign table and asserts `fdw_foreign_tables_v1.relkind == "f"`;
   without the capability that leg is a documented skip. Test-only — the
   production normalization already landed in #319 (#326).
+- Output-contract harness now asserts spec-declared output columns for
+  EVERY registered collector, not only the schema ones — closing the
+  #314 fast-follow (#316). Declared columns are derived from each
+  collector's spec `## Output columns` table at test time (never
+  hand-copied, so they cannot drift from the spec); the seed gained a
+  view, materialized view, enum + composite type, RLS policy, extended
+  statistics, a SET-config function, and a user rule so the previously
+  zero-row schema collectors now emit rows and are asserted. Collectors
+  that legitimately emit no rows in the test environment (needing
+  concurrent sessions, in-flight operations, replication, an
+  uninstalled extension, a privilege the `pg_monitor` role lacks, or a
+  rare catalog object) are enumerated in an explicit zero-row allowlist
+  with per-collector reasons; a collector emitting no rows that is not
+  allowlisted fails the harness, and a coverage report records the
+  asserted count and the not-exercised allowlist (no silent coverage
+  gaps). Test-only — no production SQL changed; a mutation spot-check
+  (renaming `pg_indexes_v1.indexname`) confirms the sweep goes RED on a
+  dropped/renamed declared column (#316).
 
 ### Fixed
 

--- a/features/signals/traceability.md
+++ b/features/signals/traceability.md
@@ -291,13 +291,46 @@ seeds a foreign table and asserts `fdw_foreign_tables_v1.relkind == "f"`;
 without the capability that leg is a documented skip (OC-R007). This is
 test-only — the production normalization already landed in #319/#321.
 
+#316 closes the #314 fast-follow (NFR-02): the per-collector
+declared-column assertion (OC-R002) now spans the whole registry, not
+only the schema collectors. The declared columns are derived from each
+collector's spec `## Output columns` table at test time (a spec parser
++ a family-source map for the definition-mode / MCV variants), so the
+assertion can never drift from the spec (INV-07). New cheap fixtures (a
+view, materialized view, enum + composite type, RLS policy, extended
+statistics, a SET-config function, a user rule) lift the schema
+collectors that were previously zero-row into the asserted set. Every
+collector that still emits no rows in the test environment is
+enumerated in an explicit **zero-row allowlist** with a per-collector
+reason — contention (`blocking_locks_v1`, `pg_locks_summary_v1`, …),
+in-flight operations (`pg_stat_progress_*`), replication
+(`replication_status_v1`, …), uninstalled extensions
+(`pg_stat_statements_v1`, `pg_vector_columns_v1`, the `timescaledb_*`
+family), privilege the `pg_monitor` role lacks
+(`pg_statistic_ext_data_v1` / `_mcv_v1`), a non-default GUC
+(`pg_prepared_xacts_v1`), or rare user-only catalog objects
+(`pg_operators_v1`, `pg_aggregates_v1`, `pg_casts_v1`,
+`pg_collations_v1`, `pg_text_search_v1`, `fdw_user_mappings_v1`) — and a
+collector emitting no rows that is NOT allowlisted fails the harness
+(OC-R008), so coverage is honest and a newly-added collector cannot
+slip through unclassified. The assertions are proven real by a mutation
+spot-check: renaming `pg_indexes_v1.indexname`'s SQL alias turns the
+sweep RED. No production output-contract violation was found — the
+`missing column` hits during development were all spec-parsing artifacts
+(definition-mode columns wrongly attributed to inventory collectors, and
+the version-variant/scalar collectors), resolved by the family-source
+map and the column-dynamic classification, not by weakening any
+assertion. Test helper:
+`tests/signals_collector_output_contract_columns.go`.
+
 | Rule ID | Rule Summary | Test ID(s) | Coverage Status | Evidence Type | Notes |
 |---------|-------------|------------|-----------------|---------------|-------|
 | OC-R001 (collect against live PG) | Full collection runs against a real PostgreSQL target and exports a snapshot ZIP via the production export path | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | `//go:build integration` + `SIGNALS_TEST_PG_DSN`; CI matrix PG 14-18. Not in default unit CI. |
-| OC-R002 (declared columns present) | Each catalog/schema collector's spec-declared columns appear in its `query_results` payload objects | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-03; INV-OUTPUT-CONTRACT. |
+| OC-R002 (declared columns present) | **Every registered collector** (#316 — not only catalog/schema) with a non-empty payload has its spec-derived declared columns (parsed from `specifications/collectors/<id>.md` `## Output columns`, never hand-copied) present in each `query_results` payload object; column-dynamic collectors (`SELECT *`/version-variant/scalar) are row-presence-only | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-03; INV-OUTPUT-CONTRACT/INV-07; #316. Mutation-verified RED on a renamed `pg_indexes_v1.indexname` alias. |
 | OC-R003 (char-type is text) | Internal-`"char"` columns (`contype`/`relkind`/`relpersistence`/`provolatile`/`prokind`) decode as single-char strings; seeded FK yields `contype == "f"` | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-01/02; INV-CHAR-TEXT-VERIFIED; the #312 regression lock. Also caught + fixed an uncast `pg_class_storage_v1.relpersistence` residual. |
 | OC-R004 (status↔payload joinable) | Every exported `status=success`/`row_count=N` run has exactly one joinable payload with N objects | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-04; INV-STATUS-PAYLOAD-VERIFIED; end-to-end proof of INV-SNAP-STATUS-PAYLOAD (#312). |
 | INV-SNAP-STATUS-PAYLOAD (retention producer, #327) | Retention cleanup deletes a run's payload + its run row atomically; a failure after the payload delete leaves BOTH tables intact, so no `success` run is ever stripped of its joinable payload | `internal/db/retention_atomic_test.go` (`TestDeleteQueryRunsOlderThan_AtomicOnSecondStepFailure`, `TestDeleteQueryRunsOlderThanByClass_AtomicOnSecondStepFailure`, `TestDeleteQueryRuns*_InvariantHoldsAfterCleanup`) | COVERED | BEHAVIORAL | FC-23; failure-injection proving the transaction rolls back both deletes on a second-step failure; post-cleanup asserts every remaining `success` run has exactly one joinable payload with `row_count` rows. Covers both the legacy flat helper and the per-class production helper. |
 | OC-R005 (char-type normalized at connection boundary) | OID 18 decodes as text for ALL collectors via a pooled-connection type registration; the columns #313 missed — `relkind` (`catalog_bloat_v1`/`catalog_index_bloat_v1`/`fdw_*_v1`), `provolatile`/`volatility` (functions), `attidentity` (identity, `""` when non-set) — decode as strings, never JSON numbers | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-06; INV-04; the #319 central-fix regression lock (root cause of Elevarq/Analyzer#1871). |
 | OC-R006 (char sweep covers remaining schema collectors) | The char whitelist includes the aliases `partition_strategy` (`pg_partitions_v1`), `tg_enabled` (`pg_triggers_v1`/`pg_triggers_definitions_v1`), `volatility` (the **output alias** of `provolatile` in `pg_functions_v1`/`pg_functions_definitions_v1`), and `attidentity`; a seeded partitioned table, trigger, and function make each collector emit a single-char string for its aliased char column, never a JSON number | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-07; INV-05; regression-locks #319 across the schema collectors #314 missed (#326). |
 | OC-R007 (FDW char capability-gated) | When a superuser DSN provisions `postgres_fdw` + a foreign server + `GRANT USAGE`, a seeded foreign table makes `fdw_foreign_tables_v1` emit `relkind == "f"` (single-char string, never a number); absent the capability the FDW fixture + assertion are skipped with a documented reason and every other assertion still runs | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-08; INV-05/INV-06; capability-gated FDW leg of #326. |
+| OC-R008 (no silent coverage gap) | Every registered collector is accounted for: rows-asserted (OC-R002), column-dynamic row-presence, or zero-row allowlisted with a documented reason; a collector emitting no rows that is NOT allowlisted fails the harness naming it; a coverage report enumerates the asserted count + the not-exercised allowlist | `TestIntegration_CollectorOutputContractAgainstRealPG` | COVERED | INTEGRATION | TC-OC-09; INV-07; #316. Local PG-17 run: 55/100 declared-column-asserted + 2 column-dynamic row-presence; 43 not-exercised (allowlisted with reasons). |

--- a/specifications/collector-output-contract.acceptance.md
+++ b/specifications/collector-output-contract.acceptance.md
@@ -56,25 +56,32 @@ collectors is inspected in the exported payload.
 
 ---
 
-### TC-OC-03: Declared columns present in the payload
+### TC-OC-03: Declared columns present in the payload (ALL collectors)
 
 **Rule:** OC-R002 (normal)
 
-**Scenario:** For each catalog/schema collector that produced rows, the
-columns its spec declares are checked against the payload objects.
+**Scenario:** For **each registered collector** (#316 — not only the
+catalog/schema ones) that produced rows, the columns its spec declares
+are checked against the payload objects. The declared column set is
+derived from the spec at test time (`## Output columns` table[s]), never
+hand-copied.
 
 **Given:**
 - A collected + exported snapshot ZIP; the per-collector declared
-  column sets for the char-type catalog collectors.
+  column sets derived from `specifications/collectors/<id>.md`
+  (or the parent spec for definition-mode / MCV family variants).
 
 **When:**
-- Each non-empty catalog/schema payload is inspected.
+- Each non-empty payload is inspected.
 
 **Then:**
-- Every declared column for that collector is present in each payload
-  object.
+- Every spec-declared column for that collector is present in each
+  payload object. Column-dynamic collectors (`SELECT *`,
+  version-variant, scalar) are checked for row presence only.
 
-**Expected Result:** Pass.
+**Expected Result:** Pass; RED if a declared column is dropped or
+renamed while the spec keeps it (verified by a mutation spot-check on
+`pg_indexes_v1.indexname`).
 (`TestIntegration_CollectorOutputContractAgainstRealPG`)
 
 ---
@@ -222,4 +229,36 @@ skip otherwise.
   service container it RUNS across PG 14/15/16/17/18.
 
 **Expected Result:** Skip locally, run in CI.
+(`TestIntegration_CollectorOutputContractAgainstRealPG`)
+
+---
+
+### TC-OC-09: Every collector is accounted for (no silent coverage gap)
+
+**Rule:** OC-R008 (normal / boundary — the #316 completeness gate)
+
+**Scenario:** After collection + export, every registered collector is
+classified: rows-asserted, column-dynamic row-presence, or zero-row
+allowlisted with a reason. A collector emitting no rows that is not
+allowlisted fails.
+
+**Given:**
+- A collected + exported snapshot ZIP and the full registry
+  (`pgqueries.All()`).
+
+**When:**
+- Each registered collector is looked up in the exported payloads.
+
+**Then:**
+- A collector with a non-empty payload has its declared columns
+  asserted (or its row presence, when column-dynamic).
+- A collector with no rows is present in the zero-row allowlist with a
+  documented reason; otherwise the harness fails naming the
+  unclassified collector(s).
+- The harness logs a coverage report: the asserted count and the
+  enumerated not-exercised allowlist.
+
+**Expected Result:** Pass when every collector is classified; RED with a
+descriptive failure if a new collector emits no rows and is not
+allowlisted.
 (`TestIntegration_CollectorOutputContractAgainstRealPG`)

--- a/specifications/collector-output-contract.md
+++ b/specifications/collector-output-contract.md
@@ -1,8 +1,10 @@
 # Collector Output-Contract Verification — Behavioral Specification
 
-Spec version: 1.0
+Spec version: 1.1
 Status: ACTIVE
 Issue: [Elevarq/Signals#314](https://github.com/Elevarq/Signals/issues/314)
+Extended by: [Elevarq/Signals#316](https://github.com/Elevarq/Signals/issues/316)
+(declared-column completeness across ALL collectors)
 
 ## Purpose
 
@@ -24,16 +26,31 @@ the ZIP back, and asserts the per-collector output contract. It locks
 the #312 class permanently — the assertions go RED on pre-#313 code and
 GREEN after.
 
-Scope is the **catalog/schema collectors** (`Category == "schema"`),
-with emphasis on the internal-`"char"` collectors PR #313 touched
-(`pg_constraints_v1`, `pg_class_storage_v1`, `pg_functions_v1`,
-`pg_functions_definitions_v1`, `pg_proc_config_v1`) **and the remaining
-schema collectors that alias an internal-`"char"` column** but were not
-exercised by the #314 fixtures (#326): `pg_partitions_v1`
-(`partition_strategy`), `pg_triggers_v1` / `pg_triggers_definitions_v1`
-(`tg_enabled`), and `fdw_foreign_tables_v1` (`relkind`). The remaining
-non-schema collectors are an explicit fast-follow (see
-Non-Functional Requirements).
+Scope (#314/#326) began with the **catalog/schema collectors**
+(`Category == "schema"`), with emphasis on the internal-`"char"`
+collectors PR #313 touched (`pg_constraints_v1`, `pg_class_storage_v1`,
+`pg_functions_v1`, `pg_functions_definitions_v1`, `pg_proc_config_v1`)
+**and the remaining schema collectors that alias an internal-`"char"`
+column** but were not exercised by the #314 fixtures (#326):
+`pg_partitions_v1` (`partition_strategy`), `pg_triggers_v1` /
+`pg_triggers_definitions_v1` (`tg_enabled`), and
+`fdw_foreign_tables_v1` (`relkind`).
+
+**#316 closes the fast-follow: the per-collector declared-column
+assertion (OC-R002 / OC-R008) now covers EVERY registered collector,
+not only the schema ones.** For each collector that emits rows against
+the seeded live PG, its declared output columns — derived from the
+authoritative spec `## Output columns` table(s), never a hand-copied
+list — are asserted present in the exported payload. Collectors that
+legitimately emit no rows in the test environment (needing concurrent
+sessions, in-flight operations, replication, an uninstalled extension,
+a privilege the `pg_monitor` role lacks, or a rare catalog object) are
+recorded in an explicit **zero-row allowlist** with a per-collector
+reason; a collector emitting no rows that is NOT allowlisted fails the
+harness, so coverage is honest and a newly-added collector cannot slip
+through unclassified (OC-R008). Column-dynamic collectors (`SELECT *`,
+version-variant, or scalar) are asserted for row presence only, since a
+fixed declared-column list cannot apply.
 
 This spec complements `appendix-a-api-contract.md` §"Snapshot
 data-integrity invariants (#312)" (INV-SNAP-STATUS-PAYLOAD, INV-CHAR-TEXT)
@@ -118,9 +135,18 @@ and §"Collector output-contract verification (#314)"
   collection cycle against a real PostgreSQL target, not a mock, and
   export a snapshot ZIP via the production export path
   (`export.Builder.WriteTo`) — never a hand-built payload.
-- **OC-R002 — Declared columns present.** For each catalog/schema
-  collector whose exported payload is non-empty, every column its spec
-  declares shall appear in each payload object. (INV-OUTPUT-CONTRACT.)
+- **OC-R002 — Declared columns present.** For **each registered
+  collector** (not only the catalog/schema ones — #316) whose exported
+  payload is non-empty, every column its spec declares shall appear in
+  each payload object. The declared column set shall be **derived from
+  the authoritative spec** (`specifications/collectors/<id>.md`
+  `## Output columns` table(s), or the parent spec for the
+  definition-mode / MCV family variants), never hand-copied into the
+  test, so it cannot drift from the spec. Column-dynamic collectors
+  (`SELECT *`, version-variant, or scalar — e.g. `bgwriter_stats_v1`,
+  `pg_version_v1`, the TimescaleDB family) are exempt from the fixed
+  column check and asserted for row presence only.
+  (INV-OUTPUT-CONTRACT.)
 - **OC-R003 — Char-type is text.** Every internal-`"char"` column
   (`contype`, `relkind`, `relpersistence`, `provolatile`, `prokind`)
   present in a payload shall decode as a single-character string, never
@@ -170,6 +196,17 @@ and §"Collector output-contract verification (#314)"
   When the capability is absent (no superuser provisioning of the
   extension/server) the FDW assertion is skipped with a documented
   reason; the OC-R006 schema-collector assertions still run. (#326.)
+- **OC-R008 — No silent coverage gap.** Every registered collector
+  shall be accounted for by the harness: it either (a) emits rows and
+  has its declared columns asserted (OC-R002), (b) is column-dynamic
+  and has its row presence asserted, or (c) emits no rows in the test
+  environment and is listed in the **zero-row allowlist** with a
+  documented reason (contention, in-flight operation, replication,
+  uninstalled extension, insufficient privilege, or rare catalog
+  object). A collector that emits no rows and is NOT allowlisted shall
+  fail the harness. The harness shall emit a coverage report recording
+  the asserted count and the enumerated not-exercised allowlist, so
+  what is and is not exercised is explicit and auditable. (#316.)
 
 ## Invariants
 
@@ -203,6 +240,13 @@ and §"Collector output-contract verification (#314)"
   `GRANT USAGE`; collection itself still runs as the non-superuser
   collector role (INV-02 holds — no writes and no superuser during
   collection).
+- **INV-07** — The declared-column set the harness asserts (OC-R002)
+  is derived from the spec at test time, so it can never silently
+  diverge from the spec: renaming or dropping a spec-declared output
+  column while leaving the SQL alias unchanged (or vice versa) turns
+  the assertion RED. The zero-row allowlist (OC-R008) is exhaustive
+  over the not-exercised collectors — a collector may be absent from
+  it only if it emits rows.
 
 ## Failure conditions
 
@@ -217,6 +261,11 @@ and §"Collector output-contract verification (#314)"
   capability is present, `fdw_foreign_tables_v1.relkind`) decoding as a
   JSON number, or one of the seeded schema collectors emitting no such
   value at all, fails OC-R006 / OC-R007.
+- **FC-05** — A registered collector that emits no rows and is absent
+  from the zero-row allowlist fails OC-R008 (unclassified coverage
+  gap). A collector whose spec has no `## Output columns` table and no
+  column-dynamic classification also fails OC-R002 (underivable
+  contract) rather than being silently skipped.
 
 ## Constraints
 
@@ -229,7 +278,10 @@ and §"Collector output-contract verification (#314)"
 
 - **NFR-01 — Version coverage.** The harness runs across PG
   14/15/16/17/18 in CI so version-gated column/type differences surface.
-- **NFR-02 — Fast-follow scope.** This spec covers catalog/schema
-  collectors. Sweeping the remaining (~80) non-schema collectors under
-  the same output-contract harness is an explicit follow-up, to be
-  filed as a child issue of #314.
+- **NFR-02 — Full-collector scope (DELIVERED #316).** The
+  declared-column assertion now covers the whole registry, not only the
+  catalog/schema collectors. Of the ~100 registered collectors, those
+  that emit rows against the seeded live PG have their declared columns
+  asserted (or their row presence, for the column-dynamic ones); the
+  remainder are enumerated in the zero-row allowlist with reasons
+  (OC-R008). The original #314 fast-follow is closed.

--- a/tests/signals_collector_output_contract_columns.go
+++ b/tests/signals_collector_output_contract_columns.go
@@ -93,6 +93,13 @@ var zeroRowAllowlist = map[string]string{
 	"replication_slots_risk_v1":    "needs a replication slot; none created on the test server",
 	"pg_stat_replication_slots_v1": "needs a logical replication slot with stats; none created on the test server",
 
+	// --- version-gated: underlying view requires a newer PG than the
+	// older matrix legs, so the collector is skipped / empty there. On the
+	// versions where the view exists these emit rows and ARE column-asserted
+	// (the allowlist is consulted only in the zero-row branch). ---
+	"checkpointer_stats_v1": "reads pg_stat_checkpointer (PG 17+, MinPGVersion 17); version-gated to no rows on the 14/15/16 legs; asserted on 17/18 where it emits its single global row",
+	"pg_stat_io_v1":         "reads pg_stat_io (PG 16+, MinPGVersion 16); no rows on the 14/15 legs (version-gated) and can be empty on a quiescent freshly-started cluster; asserted where it emits rows",
+
 	// --- capability-gated: extension not installed ---
 	"pg_stat_statements_v1":                "requires the pg_stat_statements extension (not installed in the CI/local matrix)",
 	"pgss_capacity_v1":                     "requires the pg_stat_statements extension (not installed)",

--- a/tests/signals_collector_output_contract_columns.go
+++ b/tests/signals_collector_output_contract_columns.go
@@ -1,0 +1,282 @@
+//go:build integration
+
+// Declared-column derivation for the collector output-contract harness
+// (#316). The authoritative source of a collector's declared output
+// columns is its specification under specifications/collectors/. This
+// file parses those specs at test time so the harness never hand-copies
+// a column list that would silently drift from the spec — mirroring how
+// #314/#326 derived the char-column assertions from the spec.
+//
+// A collector's declared columns are the first cell of every row of the
+// markdown table(s) that follow a heading beginning "## Output columns"
+// in its spec. Most collectors have their own <id>.md; a handful of
+// family variants (definition-mode collectors, the MCV stats sibling)
+// are documented inside a parent spec — familySpecSources maps those to
+// the parent file and merges the base + definition-mode tables.
+//
+// Collectors whose output is intentionally dynamic (SELECT *, so the
+// column set is version-dependent and not enumerable from the spec) are
+// listed in dynamicColumnCollectors and are asserted for row presence
+// only, never for a fixed declared-column set.
+//
+// Spec: specifications/collector-output-contract.md (OC-R002).
+
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// dynamicColumnCollectors emit a version-dependent column set via
+// SELECT * (documented in their specs as R037 dynamic-column precedent),
+// so a fixed declared-column list cannot be asserted. Their row-presence
+// and char/status invariants are still covered by the ALL-payload
+// sweeps (OC-R003/R004/R005). Each entry carries the reason it is
+// column-dynamic.
+var dynamicColumnCollectors = map[string]string{
+	"pg_version_v1":                        "scalar SELECT version(); single value keyed by the version() output column, no fixed column table",
+	"bgwriter_stats_v1":                    "spec-documented dynamic: whatever pg_stat_bgwriter exposes on the target (PG 17 split checkpoints into pg_stat_checkpointer, so the pre-17 columns are absent)",
+	"pg_stats_array_range_v1":              "SELECT * over per-column histogram/array-range stats; columns vary by type (opt-in, HighSensitivity)",
+	"timescaledb_hypertables_v1":           "SELECT * over timescaledb_information.hypertables; columns drift across TimescaleDB versions (>=2.20 primary_dimension*)",
+	"timescaledb_continuous_aggregates_v1": "SELECT * over continuous_aggregates; finalized column <=2.24 only",
+	"timescaledb_jobs_v1":                  "SELECT * over jobs; column set drifts across TimescaleDB versions",
+	"timescaledb_job_stats_v1":             "SELECT * over job_stats; column set drifts across TimescaleDB versions",
+	"timescaledb_job_errors_v1":            "SELECT * over job_errors; column set drifts across TimescaleDB versions",
+	"timescaledb_chunks_v1":                "SELECT * over chunks; column set drifts across TimescaleDB versions",
+	"timescaledb_chunk_summary_v1":         "SELECT * over chunk summary; column set drifts across TimescaleDB versions",
+	"timescaledb_dimensions_v1":            "SELECT * over dimensions; column set drifts across TimescaleDB versions",
+	"timescaledb_compression_settings_v1":  "SELECT * over compression_settings; column set drifts across TimescaleDB versions",
+	"timescaledb_compression_stats_v1":     "SELECT * over compression stats; column set drifts across TimescaleDB versions",
+	"timescaledb_hypertable_sizes_v1":      "SELECT * over hypertable sizes; column set drifts across TimescaleDB versions",
+}
+
+// zeroRowAllowlist enumerates the collectors that legitimately emit no
+// rows in the seeded live-PG test environment, each with the reason it
+// cannot be exercised here. A collector emitting no rows that is NOT on
+// this list fails the harness (OC-R002) — so the allowlist is the
+// explicit, auditable record of what is NOT covered, never a silent gap.
+// Adding a collector to the registry forces a decision: seed a fixture
+// that makes it emit rows, or classify it here with a reason.
+//
+// The reasons fall into four families:
+//   - contention: needs a concurrent, contended, or long-lived session
+//     the single-connection harness cannot manufacture;
+//   - in-flight op: needs an operation running AT sample time
+//     (pg_stat_progress_*);
+//   - replication: needs a standby / replication slot;
+//   - capability-gated: needs an extension or a privilege the
+//     least-privilege pg_monitor collector role lacks;
+//   - rare object: a catalog object type not worth a bespoke fixture
+//     (built-in-only in a fresh cluster).
+var zeroRowAllowlist = map[string]string{
+	// --- contention / live-session state (no concurrent load in the harness) ---
+	"blocking_locks_v1":         "needs a blocked+blocking session pair; the single-connection harness cannot create lock contention",
+	"pg_locks_summary_v1":       "needs held locks from concurrent sessions; none exist in the quiescent test target",
+	"idle_in_txn_offenders_v1":  "needs a session idle-in-transaction past the threshold; no such session in the harness",
+	"long_running_txns_v1":      "needs a transaction open longer than the threshold; the harness runs no long txn",
+	"temp_io_pressure_v1":       "needs a backend spilling temp files at sample time; no temp-heavy query runs",
+	"pg_stat_user_functions_v1": "needs track_functions enabled AND a tracked function actually called; the harness makes no such call",
+
+	// --- in-flight maintenance operations (pg_stat_progress_*) ---
+	"pg_stat_progress_analyze_v1":      "one row only while an ANALYZE is in progress at sample time; none running",
+	"pg_stat_progress_vacuum_v1":       "one row only while a VACUUM is in progress at sample time; none running",
+	"pg_stat_progress_cluster_v1":      "one row only while a CLUSTER/VACUUM FULL is in progress; none running",
+	"pg_stat_progress_create_index_v1": "one row only while a CREATE INDEX/REINDEX is in progress; none running",
+	"pg_stat_progress_copy_v1":         "one row only while a COPY is in progress; none running",
+	"pg_stat_progress_basebackup_v1":   "one row only while a base backup is streaming; none running",
+
+	// --- replication (no standby / slots in a standalone test server) ---
+	"replication_status_v1":        "needs a connected streaming standby (pg_stat_replication); the test server has none",
+	"replication_slots_risk_v1":    "needs a replication slot; none created on the test server",
+	"pg_stat_replication_slots_v1": "needs a logical replication slot with stats; none created on the test server",
+
+	// --- capability-gated: extension not installed ---
+	"pg_stat_statements_v1":                "requires the pg_stat_statements extension (not installed in the CI/local matrix)",
+	"pgss_capacity_v1":                     "requires the pg_stat_statements extension (not installed)",
+	"pgss_reset_check_v1":                  "requires the pg_stat_statements extension (not installed)",
+	"pg_vector_columns_v1":                 "requires the pgvector (vector) extension (not installed)",
+	"pg_stats_array_range_v1":              "opt-in HighSensitivity histogram collector (RequiresArrayRangeOptIn); disabled in the harness",
+	"timescaledb_extension_v1":             "requires the timescaledb extension (not installed in the matrix)",
+	"timescaledb_hypertables_v1":           "requires the timescaledb extension (not installed)",
+	"timescaledb_hypertable_sizes_v1":      "requires the timescaledb extension (not installed)",
+	"timescaledb_dimensions_v1":            "requires the timescaledb extension (not installed)",
+	"timescaledb_chunks_v1":                "requires the timescaledb extension (not installed)",
+	"timescaledb_chunk_summary_v1":         "requires the timescaledb extension (not installed)",
+	"timescaledb_compression_settings_v1":  "requires the timescaledb extension (not installed)",
+	"timescaledb_compression_stats_v1":     "requires the timescaledb extension (not installed)",
+	"timescaledb_continuous_aggregates_v1": "requires the timescaledb extension (not installed)",
+	"timescaledb_jobs_v1":                  "requires the timescaledb extension (not installed)",
+	"timescaledb_job_stats_v1":             "requires the timescaledb extension (not installed)",
+	"timescaledb_job_errors_v1":            "requires the timescaledb extension (not installed)",
+
+	// --- capability-gated: privilege the pg_monitor role lacks ---
+	"pg_statistic_ext_data_v1":     "reads pg_statistic_ext_data, which has PUBLIC SELECT revoked; a pg_monitor role is skipped (#200)",
+	"pg_statistic_ext_data_mcv_v1": "HighSensitivity MCV sibling of pg_statistic_ext_data_v1; also needs privileged read of pg_statistic_ext_data (skipped under pg_monitor)",
+
+	// --- config-gated: needs a non-default server GUC ---
+	"pg_prepared_xacts_v1":   "needs a prepared transaction; max_prepared_transactions defaults to 0 so 2PC is unavailable in the matrix",
+	"pg_db_role_settings_v1": "needs an ALTER ROLE/DATABASE ... SET; the least-privilege collector role cannot ALTER, and the harness avoids mutating global (non-schema) role/database state",
+
+	// --- rare catalog objects: built-in-only in a fresh cluster, not worth a bespoke fixture ---
+	"pg_operators_v1":      "emits only non-extension user-defined operators; a fresh cluster has none and none is seeded (built-ins live in pg_catalog, excluded)",
+	"pg_aggregates_v1":     "emits only user-defined aggregates; none seeded (built-ins excluded by schema/OID filter)",
+	"pg_casts_v1":          "emits only user-defined casts; none seeded (built-ins excluded by OID < 16384)",
+	"pg_collations_v1":     "emits only user-defined collations; none seeded (built-ins excluded)",
+	"pg_text_search_v1":    "emits only user-defined text-search configs/dictionaries; none seeded (built-ins excluded)",
+	"fdw_user_mappings_v1": "needs a USER MAPPING on the foreign server; the FDW fixture creates a server + foreign table but no user mapping",
+
+	// --- wraparound: no relation is near the freeze thresholds in a fresh cluster ---
+	"wraparound_blockers_v1": "flags relations past the autovacuum-freeze age thresholds; a freshly-seeded cluster has none",
+}
+
+// specSource identifies one spec file (and optionally which
+// "## Output columns ..." table modes within it) whose column table(s)
+// contribute to a collector's declared column set. The default for a
+// collector is its own <id>.md with every "## Output columns*" table
+// merged; family variants documented inside a parent spec are mapped
+// explicitly via familySpecSources.
+type specSource struct {
+	file string // spec filename under specifications/collectors/
+	// modes limits which "## Output columns ..." tables are merged. Empty
+	// means "all tables under any Output columns heading in the file".
+	modes []string
+}
+
+// familySpecSources maps the family/variant collectors that lack their
+// own <id>.md to the parent spec + the table modes that define their
+// columns. Definition-mode variants inherit the parent's inventory
+// columns plus the definition-mode additions.
+var familySpecSources = map[string][]specSource{
+	// Definition-mode variants emit the parent's inventory columns PLUS
+	// the "definition mode, adds" columns — modes ["*"] merges both.
+	"pg_functions_definitions_v1": {
+		{file: "pg_functions_v1.md", modes: []string{"*"}},
+	},
+	"pg_triggers_definitions_v1": {
+		{file: "pg_triggers_v1.md", modes: []string{"*"}},
+	},
+	"pg_views_definitions_v1": {
+		{file: "pg_views_v1.md", modes: []string{"*"}},
+	},
+	"pg_matviews_definitions_v1": {
+		{file: "pg_matviews_v1.md", modes: []string{"*"}},
+	},
+	"pg_statistic_ext_data_mcv_v1": {
+		{file: "pg_statistic_ext_data_v1.md"}, // identical identity + kind_data/available columns
+	},
+}
+
+// declaredColumnsForCollector derives the declared output columns for a
+// collector ID from its spec, or returns ("", nil, false) when the
+// collector is column-dynamic (SELECT *). It fails the test if a
+// collector has neither a parseable spec nor a dynamic classification —
+// there is no silent gap.
+func declaredColumnsForCollector(t *testing.T, id string) (cols []string, dynamic bool) {
+	t.Helper()
+	if reason, ok := dynamicColumnCollectors[id]; ok {
+		t.Logf("OC-R002: collector %s is column-dynamic (%s) — asserting row-presence only", id, reason)
+		return nil, true
+	}
+
+	sources, ok := familySpecSources[id]
+	if !ok {
+		sources = []specSource{{file: id + ".md"}}
+	}
+
+	seen := map[string]bool{}
+	for _, s := range sources {
+		path := filepath.Join(repoRoot(t), "specifications", "collectors", s.file)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("OC-R002: collector %s: reading spec %s: %v", id, s.file, err)
+		}
+		for _, c := range parseOutputColumns(string(data), s.modes) {
+			if !seen[c] {
+				seen[c] = true
+				cols = append(cols, c)
+			}
+		}
+	}
+	if len(cols) == 0 {
+		t.Fatalf("OC-R002: collector %s: no declared output columns parsed from %v — spec missing an '## Output columns' table? (add it, or classify the collector as column-dynamic)", id, sources)
+	}
+	return cols, false
+}
+
+// parseOutputColumns extracts the first-cell column names from every
+// markdown table that follows a heading beginning "## Output columns"
+// (case-insensitive), up to the next "## " heading. When modes is
+// non-empty only headings whose text contains one of the mode strings
+// are considered. Backticks and surrounding whitespace are stripped; the
+// table's header row (Column/---) and separator rows are skipped.
+func parseOutputColumns(body string, modes []string) []string {
+	var out []string
+	lines := strings.Split(body, "\n")
+	inSection := false
+	for _, raw := range lines {
+		line := strings.TrimRight(raw, " \t")
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "## ") {
+			heading := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(trimmed, "## ")))
+			if strings.HasPrefix(heading, "output columns") {
+				inSection = matchesMode(heading, modes)
+			} else {
+				inSection = false
+			}
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "|") {
+			continue
+		}
+		cells := strings.Split(trimmed, "|")
+		if len(cells) < 2 {
+			continue
+		}
+		name := strings.TrimSpace(cells[1])
+		name = strings.Trim(name, "`")
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		lc := strings.ToLower(name)
+		// Skip the header row and the |---|---| separator row.
+		if lc == "column" || lc == "column name" || strings.HasPrefix(name, "-") || strings.HasPrefix(name, ":-") {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out
+}
+
+// matchesMode decides whether an "## Output columns ..." heading's table
+// contributes to the derived column set.
+//
+//   - modes empty (the default for a plain <id>.md collector): include
+//     the inventory table(s) but EXCLUDE the "definition mode, adds"
+//     table — those columns belong only to the collector's
+//     *_definitions_v1 sibling, not the inventory collector itself.
+//   - modes == ["*"]: include every Output-columns table (used for the
+//     definition-mode variants, which emit inventory + definition
+//     columns).
+//   - otherwise: include a heading only if it contains one of the mode
+//     substrings.
+func matchesMode(heading string, modes []string) bool {
+	if len(modes) == 0 {
+		return !strings.Contains(heading, "definition mode")
+	}
+	for _, m := range modes {
+		if m == "*" {
+			return true
+		}
+		if strings.Contains(heading, strings.ToLower(m)) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/signals_collector_output_contract_integration_test.go
+++ b/tests/signals_collector_output_contract_integration_test.go
@@ -65,6 +65,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -74,6 +75,7 @@ import (
 	"github.com/elevarq/signals/internal/collector"
 	"github.com/elevarq/signals/internal/config"
 	"github.com/elevarq/signals/internal/export"
+	"github.com/elevarq/signals/internal/pgqueries"
 )
 
 // internalCharColumns are the PostgreSQL internal-"char" columns the
@@ -465,8 +467,10 @@ func TestIntegration_CollectorOutputContractAgainstRealPG(t *testing.T) {
 		t.Log("OC-R007: FDW capability absent — fdw_foreign_tables_v1.relkind assertion skipped (documented capability gate)")
 	}
 
-	// --- OC-R002 / INV-OUTPUT-CONTRACT -----------------------------
-	// Each char-type catalog collector's declared columns are present.
+	// --- OC-R002 / INV-OUTPUT-CONTRACT (targeted char collectors) --
+	// The #314/#326 char-type catalog collectors keep an explicit,
+	// hand-audited declared-column list as a stronger, drift-proof
+	// belt-and-braces check alongside the spec-derived sweep below.
 	for collectorID, cols := range declaredColumnsByCollector {
 		payload, ok := payloadByQueryID[collectorID]
 		if !ok {
@@ -484,6 +488,72 @@ func TestIntegration_CollectorOutputContractAgainstRealPG(t *testing.T) {
 					collectorID, col, keysOf(row))
 			}
 		}
+	}
+
+	// --- OC-R002 / INV-OUTPUT-CONTRACT (spec-derived, ALL collectors) ---
+	// #316: extend the per-collector declared-column assertion from the
+	// handful of char collectors above to EVERY registered collector.
+	// For each collector that emitted rows against the seeded live PG,
+	// derive its declared output columns from its spec (parseOutputColumns)
+	// and assert each is present in its exported payload objects — closing
+	// the gap where a non-schema collector could silently drop or rename a
+	// declared column. Collectors that legitimately emit zero rows in this
+	// environment are recorded in zeroRowAllowlist (with a reason) rather
+	// than silently skipped, so coverage is honest and a newly-added
+	// collector cannot slip through unclassified.
+	asserted := 0        // collectors whose declared columns were verified against emitted rows
+	dynamicAsserted := 0 // column-dynamic collectors verified for row-presence only
+	var notExercised []string
+	var missing []string // unclassified zero-row/absent collectors (fail)
+
+	for _, q := range pgqueries.All() {
+		id := q.ID
+		payload, ran := payloadByQueryID[id]
+		if ran && len(payload) > 0 {
+			cols, dynamic := declaredColumnsForCollector(t, id)
+			if dynamic {
+				// Column-dynamic (SELECT *) — assert row presence only.
+				dynamicAsserted++
+				t.Logf("OC-R002: collector %s asserted (column-dynamic, %d rows, row-presence only)", id, len(payload))
+				continue
+			}
+			for _, row := range payload {
+				for _, col := range cols {
+					if _, present := row[col]; !present {
+						t.Errorf("OC-R002 (INV-OUTPUT-CONTRACT): collector %s payload is missing spec-declared column %q; keys present=%v",
+							id, col, keysOf(row))
+					}
+				}
+			}
+			asserted++
+			continue
+		}
+
+		// No rows emitted (skipped, not eligible, or 0-row success). It
+		// MUST be classified in the zero-row allowlist with a reason —
+		// no silent coverage gap.
+		reason, ok := zeroRowAllowlist[id]
+		if !ok {
+			missing = append(missing, id)
+			continue
+		}
+		notExercised = append(notExercised, fmt.Sprintf("%s (%s)", id, reason))
+	}
+
+	sort.Strings(notExercised)
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		t.Errorf("OC-R002: %d collector(s) emitted no rows and are NOT in zeroRowAllowlist — classify each with a fixture (seed it to emit rows) or an explicit reason, no silent gaps: %v",
+			len(missing), missing)
+	}
+
+	// Coverage report — the honest accounting the issue asks for.
+	total := len(pgqueries.All())
+	t.Logf("OC-R002 coverage: %d/%d collectors have declared-column assertions against emitted rows (+%d column-dynamic row-presence); %d not exercised (allowlisted):",
+		asserted, total, dynamicAsserted, len(notExercised))
+	for _, e := range notExercised {
+		t.Logf("  not-exercised: %s", e)
 	}
 }
 
@@ -572,6 +642,45 @@ func seedRepresentativeSchema(t *testing.T, dsn string) (fdwSeeded bool) {
 		`CREATE TRIGGER child_bi
 			BEFORE INSERT ON signals_oc_test.child
 			FOR EACH ROW EXECUTE FUNCTION signals_oc_test.tg_noop()`,
+		// #316 — representative fixtures that lift the remaining
+		// cheaply-seedable non-schema/schema collectors into the
+		// declared-column assertion set (OC-R002). Each object lands in
+		// the dedicated schema so collection stays scoped and the seed
+		// stays read-only against the target's own objects.
+		//
+		// A view + materialized view so pg_views_v1 / pg_views_definitions_v1
+		// and pg_matviews_v1 / pg_matviews_definitions_v1 emit rows.
+		`CREATE VIEW signals_oc_test.parent_view AS
+			SELECT id, label FROM signals_oc_test.parent`,
+		`CREATE MATERIALIZED VIEW signals_oc_test.parent_mv AS
+			SELECT id, label FROM signals_oc_test.parent WITH DATA`,
+		`CREATE INDEX parent_mv_idx ON signals_oc_test.parent_mv (id)`,
+		// An enum type and a composite type so pg_types_v1 emits rows
+		// (it filters to typtype IN ('e','c','d')).
+		`CREATE TYPE signals_oc_test.color AS ENUM ('red', 'green', 'blue')`,
+		`CREATE TYPE signals_oc_test.point2d AS (x double precision, y double precision)`,
+		// An RLS policy on the child table so pg_policies_v1 emits a row.
+		`ALTER TABLE signals_oc_test.child ENABLE ROW LEVEL SECURITY`,
+		`CREATE POLICY child_all ON signals_oc_test.child
+			USING (fk_parent_id > 0)`,
+		// Multi-column extended statistics so pg_statistic_ext_v1 emits a
+		// row; ANALYZE computes the dependency data.
+		`CREATE STATISTICS signals_oc_test.child_stats (dependencies)
+			ON fk_parent_id, note FROM signals_oc_test.child`,
+		// A function carrying a SET config so pg_proc_config_v1 emits a
+		// row (it filters to proconfig IS NOT NULL).
+		`CREATE FUNCTION signals_oc_test.demo_config()
+			RETURNS integer LANGUAGE sql
+			SET search_path = 'pg_catalog'
+			AS 'SELECT 1'`,
+		// A user rule so pg_rules_v1 emits a row (the implicit view
+		// _RETURN rule is excluded by the collector).
+		`CREATE TABLE signals_oc_test.rule_log (
+			id bigint,
+			note text
+		)`,
+		`CREATE RULE rule_log_noop AS ON UPDATE TO signals_oc_test.rule_log
+			DO INSTEAD NOTHING`,
 		`INSERT INTO signals_oc_test.parent (id, label, ratio)
 			VALUES (1, 'a', 1.5), (2, 'b', 2.5)`,
 		`INSERT INTO signals_oc_test.child (id, fk_parent_id, note, amount)


### PR DESCRIPTION
Closes #316.

Fast-follow to #314 (PR #315) and #326: extend the live-PG collector output-contract harness from the catalog/schema collectors to **every registered collector** (NFR-02). For each collector that emits rows against the seeded live PG, its spec-declared output columns are now asserted present in the exported snapshot ZIP — closing the gap where a non-schema collector could silently drop or rename a declared column.

## What changed (test-only)

- **Declared columns derived from the spec, not hand-copied.** A new helper (`tests/signals_collector_output_contract_columns.go`) parses each collector's `## Output columns` table from `specifications/collectors/<id>.md` at test time, with a family-source map for the definition-mode (`*_definitions_v1`) and MCV variants that live in a parent spec. The assertion cannot drift from the spec (INV-07).
- **Column-dynamic collectors** (`SELECT *` / version-variant / scalar — `bgwriter_stats_v1`, `pg_version_v1`, the `timescaledb_*` family) are asserted for row presence only, since a fixed column list cannot apply.
- **New seed fixtures** (a view, materialized view, enum + composite type, RLS policy, extended statistics, a SET-config function, a user rule) lift previously zero-row schema collectors into the asserted set.
- **Explicit zero-row allowlist (OC-R008).** Collectors that legitimately emit no rows here (contention, in-flight `pg_stat_progress_*` ops, replication, uninstalled extensions, `pg_monitor` privilege limits, a non-default GUC, or rare user-only catalog objects) are enumerated with per-collector reasons. A collector emitting no rows that is **not** allowlisted fails the harness, and a coverage report logs the asserted count + not-exercised allowlist — no silent coverage gaps.

## Coverage (local PG-17 run)

55/100 collectors declared-column-asserted + 2 column-dynamic row-presence; **43 not-exercised (all allowlisted with reasons)**.

## Proof the assertions are real

Mutation spot-check: renaming `pg_indexes_v1.indexname`'s SQL alias turns the new sweep **RED** (verified locally); reverted. No production output-contract violation was found — the `missing column` hits during development were all spec-parsing artifacts (definition-mode columns wrongly attributed to inventory collectors, plus the version-variant/scalar collectors), resolved by the family-source map and column-dynamic classification, **not** by weakening any assertion. No `internal/` SQL changed.

## STDD

- Spec `specifications/collector-output-contract.md` bumped to 1.1: OC-R002 broadened to all collectors, new **OC-R008** (no silent coverage gap), INV-07, FC-05, NFR-02 marked delivered.
- Acceptance: TC-OC-03 broadened + new **TC-OC-09**.
- Traceability rows updated (OC-R002, new OC-R008) + a #316 narrative.

## Gates

gofmt, `go vet ./...`, `golangci-lint run ./...` and `--build-tags integration ./tests/` all green locally; full unit suite green; the `integration`-tagged harness green against a local docker `postgres:17` (matches the CI PG 14–18 matrix). CI ran the FDW leg (OC-R007) too.

Refs #314, #326, #312, #319, Elevarq/Analyzer#1871.