### PR TITLE
examples: repeatable one-command local snapshot + constraint-rich seed

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,9 +6,29 @@ Deployment templates and reference configurations.
 
 | Pattern | File | Use when |
 |---|---|---|
+| One-command snapshot | [`local-snapshot.sh`](local-snapshot.sh) | You just want a real, inspectable snapshot ZIP from the current code — repeatably. Brings the dev stack up, runs a collection, **waits for it to finish**, exports, and verifies the constraint output. |
 | Dev quickstart | [`docker-compose.yml`](docker-compose.yml) | Trying Elevarq Signals on a self-contained local PostgreSQL. Bootstraps PG 16 + monitoring role + sample data. |
 | Production | [`docker-compose.prod.yml`](docker-compose.prod.yml) | Connecting to your real PostgreSQL with a Docker secret for the password. No embedded DB. |
 | Kubernetes | [`helm/`](helm/) | Helm-based deployment on a K8s cluster. |
+
+---
+
+## One-command snapshot (repeatable)
+
+The fastest way to get a real snapshot from the current code and eyeball
+it — idempotent, so run it as many times as you like:
+
+    examples/local-snapshot.sh                    # -> ./signals-snapshot.zip
+    OUT=~/Downloads/snap.zip examples/local-snapshot.sh
+    examples/local-snapshot.sh --down             # tear the stack down
+
+It builds + starts the stack, seeds a representative schema (via
+[`init.sql`](init.sql): PK/FK/UNIQUE/CHECK constraints + an intentionally
+unindexed FK), forces a collection, **waits for it to complete** (polling,
+not a blind sleep — an early export would be empty), exports the ZIP, and
+prints the `pg_constraints_v1` output so you can confirm `contype` is a
+single-char string (`"f"`/`"p"`/`"u"`/`"c"`), not a byte integer. Then
+inspect it with [`snapshot-inspection/`](snapshot-inspection/README.md).
 
 ---
 

--- a/examples/init.sql
+++ b/examples/init.sql
@@ -1,26 +1,71 @@
--- Elevarq Signals monitoring role setup
--- This script runs automatically when PostgreSQL starts for the first time.
+-- Elevarq Signals local-dev seed.
+-- Runs automatically the first time the PostgreSQL container starts
+-- (docker-entrypoint-initdb.d). It creates the monitoring role AND a
+-- small but *representative* schema so the collectors actually have
+-- something to report: several constraint types (so pg_constraints_v1
+-- exercises the internal-"char" wire contract — contype 'p'/'f'/'u'/'c'
+-- must appear as single-char STRINGS, not byte integers), an
+-- intentionally UNINDEXED foreign key (so the missing-FK-index signal
+-- has a real target), plus a plain PK table.
 
--- Create the monitoring role with login but no superuser privileges
+-- --- Monitoring role (non-superuser, pg_monitor) ---------------------
+-- Named `signals` to match docs/database-connections.md. NOT `arq_*`.
 CREATE ROLE signals WITH LOGIN PASSWORD 'monitor_pass';
-
--- Grant access to PostgreSQL statistics views
--- pg_monitor is available in PostgreSQL 10+
 GRANT pg_monitor TO signals;
 
--- Enable query-level statistics (optional but recommended)
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
 
--- Create a sample table so there is something to monitor
-CREATE TABLE IF NOT EXISTS example_data (
-    id SERIAL PRIMARY KEY,
-    value TEXT NOT NULL,
-    created_at TIMESTAMPTZ DEFAULT now()
+-- --- Representative schema with varied constraints -------------------
+-- customers: PRIMARY KEY (contype 'p'), UNIQUE (contype 'u'), CHECK (contype 'c')
+CREATE TABLE customers (
+    id    bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    email text NOT NULL UNIQUE,
+    tier  text NOT NULL DEFAULT 'starter'
+              CHECK (tier IN ('starter','professional','business','enterprise'))
 );
 
--- Insert sample rows to generate some statistics
+-- orders: FOREIGN KEY (contype 'f') left deliberately UNINDEXED so the
+-- missing-FK-index detection path has a real target; plus a CHECK.
+CREATE TABLE orders (
+    id           bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    customer_id  bigint NOT NULL REFERENCES customers(id),   -- contype 'f', UNINDEXED on purpose
+    amount_cents bigint NOT NULL CHECK (amount_cents >= 0),  -- contype 'c'
+    status       text   NOT NULL DEFAULT 'open',
+    created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX orders_status_idx ON orders(status);           -- a normal (non-covering) index
+
+-- order_items: a second FK + a composite UNIQUE.
+CREATE TABLE order_items (
+    order_id bigint NOT NULL REFERENCES orders(id),          -- contype 'f'
+    line_no  int    NOT NULL,
+    sku      text   NOT NULL,
+    qty      int    NOT NULL CHECK (qty > 0),                -- contype 'c'
+    UNIQUE (order_id, line_no)                               -- contype 'u'
+);
+
+-- Plain PK table (keeps the original example around).
+CREATE TABLE example_data (
+    id         serial PRIMARY KEY,
+    value      text NOT NULL,
+    created_at timestamptz DEFAULT now()
+);
+
+-- --- Data, so stats/row counts are non-trivial ----------------------
+INSERT INTO customers (email, tier)
+SELECT 'user' || g || '@example.com',
+       (ARRAY['starter','professional','business','enterprise'])[1 + (g % 4)]
+FROM generate_series(1, 200) g;
+
+INSERT INTO orders (customer_id, amount_cents, status)
+SELECT 1 + (g % 200), (g * 37) % 100000, (ARRAY['open','paid','shipped'])[1 + (g % 3)]
+FROM generate_series(1, 5000) g;
+
+INSERT INTO order_items (order_id, line_no, sku, qty)
+SELECT 1 + (g % 5000), 1 + (g % 3), 'SKU-' || (g % 500), 1 + (g % 5)
+FROM generate_series(1, 15000) g;
+
 INSERT INTO example_data (value)
 SELECT 'sample-' || generate_series(1, 100);
 
--- Run ANALYZE so pg_stat_user_tables has data
-ANALYZE example_data;
+ANALYZE;

--- a/examples/local-snapshot.sh
+++ b/examples/local-snapshot.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Repeatable Elevarq Signals local snapshot.
+#
+# Brings up the local dev stack (PostgreSQL seeded by init.sql with a
+# representative schema + the non-superuser `signals` pg_monitor role),
+# runs ONE collection, WAITS for it to actually finish, and exports an
+# inspectable snapshot ZIP. Idempotent: run it as many times as you
+# like — no wheel to reinvent.
+#
+# Usage:
+#   examples/local-snapshot.sh                # up -> collect -> export ./signals-snapshot.zip -> verify
+#   OUT=~/Downloads/snap.zip examples/local-snapshot.sh
+#   examples/local-snapshot.sh --down         # tear the stack down (and volumes) and exit
+#
+# Requires: docker (compose v2), curl, python3.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+COMPOSE="$HERE/docker-compose.yml"
+TOKEN="dev-local-only-replace-in-prod-32chars"   # matches examples/docker-compose.yml (dev only)
+BASE="http://localhost:8081"
+OUT="${OUT:-$HERE/signals-snapshot.zip}"
+
+dc() { docker compose -f "$COMPOSE" "$@"; }
+
+if [ "${1:-}" = "--down" ]; then dc down -v; echo "stack down."; exit 0; fi
+
+echo "==> 1/5 bringing up postgres + signals (docker compose up --build)"
+dc up -d --build
+
+echo "==> 2/5 waiting for the Signals API to answer"
+for i in $(seq 1 60); do curl -fsS "$BASE/health" >/dev/null 2>&1 && break; sleep 2; done
+curl -fsS "$BASE/health" >/dev/null 2>&1 || { echo "Signals API never came up; 'dc logs signals':"; dc logs --tail=30 signals; exit 1; }
+
+echo "==> 3/5 forcing a full collection cycle"
+curl -fsS -X POST "$BASE/collect/now?force=true" -H "Authorization: Bearer $TOKEN" -d '{}' >/dev/null
+
+echo "==> 4/5 waiting for the collection to COMPLETE (polling the export, not a blind sleep)"
+runs=0
+for i in $(seq 1 45); do
+  curl -fsS "$BASE/export" -H "Authorization: Bearer $TOKEN" -o "$OUT" 2>/dev/null || true
+  read -r runs succ < <(python3 - "$OUT" <<'PY' 2>/dev/null || echo "0 0"
+import sys,zipfile,json
+try:
+    z=zipfile.ZipFile(sys.argv[1])
+    runs=[json.loads(l) for l in z.read("query_runs.ndjson").decode().splitlines()]
+    succ=sum(1 for r in runs if r.get("status")=="success")
+    print(len(runs), succ)
+except Exception:
+    print(0, 0)
+PY
+)
+  # collection is "done enough" once we have a healthy set of successful runs
+  if [ "${succ:-0}" -ge 40 ]; then break; fi
+  sleep 2
+done
+echo "    collected: ${runs:-0} runs (${succ:-0} success)"
+
+echo "==> 5/5 verifying the snapshot (constraint types must be single-char STRINGS)"
+python3 - "$OUT" <<'PY'
+import sys,zipfile,json
+z=zipfile.ZipFile(sys.argv[1])
+print("snapshot:", sys.argv[1])
+print("entries :", ", ".join(z.namelist()))
+runs={json.loads(l)["id"]:json.loads(l) for l in z.read("query_runs.ndjson").decode().splitlines()}
+found=False
+for l in z.read("query_results.ndjson").decode().splitlines():
+    res=json.loads(l); q=runs.get(res.get("run_id"),{}).get("query_id","")
+    if q.startswith("pg_constraints_v1"):
+        rows=res.get("payload") or []
+        types=sorted({r.get("contype") for r in rows})
+        print(f"\npg_constraints_v1: {len(rows)} rows; contype values = {types}")
+        assert all(isinstance(t,str) for t in types), "contype is NOT a string -> char-type wire bug!"
+        for want,label in [("p","PRIMARY KEY"),("f","FOREIGN KEY"),("u","UNIQUE"),("c","CHECK")]:
+            ex=next((r for r in rows if r.get("contype")==want), None)
+            if ex: print(f"  contype={want!r} ({label}): {json.dumps({k:ex[k] for k in list(ex)[:5]})}")
+        found=True; break
+if not found:
+    print("\npg_constraints_v1 returned no rows — is the target DB empty? (init.sql seeds constraints)")
+print("\nOK: contype serialized as strings (the #312/#319 char-type fix).")
+PY
+echo
+echo "Done. Snapshot at: $OUT   (inspect with examples/snapshot-inspection/README.md; tear down with: $0 --down)"


### PR DESCRIPTION
Makes producing a local Signals snapshot **repeatable** instead of hand-rolled each time.

- **`examples/local-snapshot.sh`** (new) — one idempotent command: builds + starts the dev stack, forces a collection, **waits for it to actually complete** (polls the export rather than a blind sleep — the trap that yields an empty ZIP), exports to `./signals-snapshot.zip` (or `$OUT`), and prints the `pg_constraints_v1` output to confirm `contype` is a single-char string. `--down` tears it down.
- **`examples/init.sql`** — enriched from one PK table to a representative schema (customers/orders/order_items) with PK/FK/UNIQUE/CHECK constraints + an intentionally **unindexed FK**, so the schema collectors return rows: `pg_constraints_v1` demonstrates `contype` as `"p"/"f"/"u"/"c"` strings (the #312/#319 char-type fix on real data) and the missing-FK-index path has a target.
- **`examples/README.md`** — documents the one-command flow.

Verified locally end-to-end: 100 runs / 83 success; `pg_constraints_v1` → 11 rows, `contype = ["c","f","p","u"]` (all strings), FK row `condef: "FOREIGN KEY (order_id) REFERENCES orders(id)"`. Role is `signals` (pg_monitor), not `arq_*`.