### PR TITLE
test: make orphan fixtures survive real FK enforcement (closes #345)

### DIFF
--- a/tests/signals_collector_test.go
+++ b/tests/signals_collector_test.go
@@ -150,14 +150,22 @@ func TestInstanceIDStableAcrossRestarts(t *testing.T) {
 func TestRetentionCleanup(t *testing.T) {
 	store := openTestDB(t)
 
-	_ = store.InsertSnapshot(db.Snapshot{
-		ID: "old-snap", TargetID: 0, CollectedAt: "2020-01-01T00:00:00Z",
+	targetID, err := store.UpsertTarget("retention", "localhost", 5432, "db", "user", "prefer", "NONE", "", true)
+	if err != nil {
+		t.Fatalf("UpsertTarget: %v", err)
+	}
+	if err := store.InsertSnapshot(db.Snapshot{
+		ID: "old-snap", TargetID: targetID, CollectedAt: "2020-01-01T00:00:00Z",
 		PGVersion: "16", Payload: []byte("{}"), SizeBytes: 2,
-	})
-	_ = store.InsertSnapshot(db.Snapshot{
-		ID: "new-snap", TargetID: 0, CollectedAt: "2099-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("InsertSnapshot old-snap: %v", err)
+	}
+	if err := store.InsertSnapshot(db.Snapshot{
+		ID: "new-snap", TargetID: targetID, CollectedAt: "2099-01-01T00:00:00Z",
 		PGVersion: "16", Payload: []byte("{}"), SizeBytes: 2,
-	})
+	}); err != nil {
+		t.Fatalf("InsertSnapshot new-snap: %v", err)
+	}
 
 	deleted, err := store.DeleteSnapshotsOlderThan("2025-01-01T00:00:00Z")
 	if err != nil {

--- a/tests/signals_export_target_identity_test.go
+++ b/tests/signals_export_target_identity_test.go
@@ -170,9 +170,11 @@ func TestExportMetadataOmitsTargetIdentityForOrphanSnapshot(t *testing.T) {
 		Payload:     json.RawMessage(`{"version":"PostgreSQL 16.2"}`),
 		SizeBytes:   42,
 	}
-	if err := store.InsertSnapshot(orphan); err != nil {
-		t.Fatalf("InsertSnapshot: %v", err)
-	}
+	withFKDisabled(t, store, func() {
+		if err := store.InsertSnapshot(orphan); err != nil {
+			t.Fatalf("InsertSnapshot: %v", err)
+		}
+	})
 
 	builder := export.NewBuilder(store, "test-instance-id")
 	var buf bytes.Buffer
@@ -341,10 +343,14 @@ func TestExportSnapshotsFailsOnNonOrphanTargetIdentityError(t *testing.T) {
 	}
 
 	// Nuke the targets table so GetTargetIdentity returns a
-	// non-ErrNoRows error ("no such table").
-	if _, err := store.SQL().Exec("DROP TABLE targets"); err != nil {
-		t.Fatalf("DROP TABLE targets: %v", err)
-	}
+	// non-ErrNoRows error ("no such table"). FK enforcement must be
+	// off for the DROP: its implicit delete of the referenced target
+	// row would otherwise violate the FK from the seeded snapshot.
+	withFKDisabled(t, store, func() {
+		if _, err := store.SQL().Exec("DROP TABLE targets"); err != nil {
+			t.Fatalf("DROP TABLE targets: %v", err)
+		}
+	})
 
 	builder := export.NewBuilder(store, "test-instance-id")
 	var buf bytes.Buffer
@@ -375,14 +381,16 @@ func TestExportSnapshotsOmitsTargetIdentityForOrphanRowInMultiTarget(t *testing.
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	for _, snap := range []db.Snapshot{
-		{ID: "snap-prod-001", TargetID: prodID, CollectedAt: now, PGVersion: "PostgreSQL 16.2", Payload: json.RawMessage(`{}`), SizeBytes: 42},
-		{ID: "snap-orphan-multi", TargetID: 999999, CollectedAt: now, PGVersion: "PostgreSQL 16.2", Payload: json.RawMessage(`{}`), SizeBytes: 42},
-	} {
-		if err := store.InsertSnapshot(snap); err != nil {
-			t.Fatalf("InsertSnapshot %s: %v", snap.ID, err)
+	withFKDisabled(t, store, func() {
+		for _, snap := range []db.Snapshot{
+			{ID: "snap-prod-001", TargetID: prodID, CollectedAt: now, PGVersion: "PostgreSQL 16.2", Payload: json.RawMessage(`{}`), SizeBytes: 42},
+			{ID: "snap-orphan-multi", TargetID: 999999, CollectedAt: now, PGVersion: "PostgreSQL 16.2", Payload: json.RawMessage(`{}`), SizeBytes: 42},
+		} {
+			if err := store.InsertSnapshot(snap); err != nil {
+				t.Fatalf("InsertSnapshot %s: %v", snap.ID, err)
+			}
 		}
-	}
+	})
 
 	// Use the --all selector so orphans surface (default scope filters
 	// them out per R090).

--- a/tests/signals_target_identity_test.go
+++ b/tests/signals_target_identity_test.go
@@ -209,10 +209,39 @@ func seedWithOrphans(t *testing.T, store *db.DB) (canonical int64, orphans []int
 	return canonical, orphans
 }
 
+// withFKDisabled runs fn with SQLite foreign-key enforcement off,
+// restoring the previous setting afterwards. Orphan fixtures use it to
+// fabricate rows that represent the v0.3.x drift state — rows the FK
+// on snapshots.target_id rejects now that modernc.org/sqlite >= 1.55.0
+// honors the `_foreign_keys=on` DSN parameter. Safe on the store's
+// connection pool because db.Open sets SetMaxOpenConns(1).
+func withFKDisabled(t *testing.T, store *db.DB, fn func()) {
+	t.Helper()
+	var prev int
+	if err := store.SQL().QueryRow("PRAGMA foreign_keys").Scan(&prev); err != nil {
+		t.Fatalf("read foreign_keys pragma: %v", err)
+	}
+	if _, err := store.SQL().Exec("PRAGMA foreign_keys=OFF"); err != nil {
+		t.Fatalf("disable foreign_keys: %v", err)
+	}
+	defer func() {
+		restore := "ON"
+		if prev == 0 {
+			restore = "OFF"
+		}
+		if _, err := store.SQL().Exec("PRAGMA foreign_keys=" + restore); err != nil {
+			t.Fatalf("restore foreign_keys pragma: %v", err)
+		}
+	}()
+	fn()
+}
+
 // insertOneCycle bypasses UpsertTarget so it can write rows with any
 // target_id — including orphan ids that violate the foreign-key
 // intent. Used by seedWithOrphans to simulate the v0.3.x drift bug
-// in stored data without depending on the buggy code.
+// in stored data without depending on the buggy code. FK enforcement
+// is disabled for the insert because the fabricated orphan rows are
+// exactly the legacy state R090 must tolerate.
 func insertOneCycle(t *testing.T, store *db.DB, targetID int64, snapID, collectedAt string) {
 	t.Helper()
 	snap := db.Snapshot{
@@ -230,9 +259,11 @@ func insertOneCycle(t *testing.T, store *db.DB, targetID int64, snapID, collecte
 	results := []db.QueryResult{{
 		RunID: runs[0].ID, Payload: []byte("{\"k\":\"v\"}\n"), SizeBytes: 8,
 	}}
-	if err := store.InsertCollectionAtomic(snap, runs, results); err != nil {
-		t.Fatalf("InsertCollectionAtomic: %v", err)
-	}
+	withFKDisabled(t, store, func() {
+		if err := store.InsertCollectionAtomic(snap, runs, results); err != nil {
+			t.Fatalf("InsertCollectionAtomic: %v", err)
+		}
+	})
 }
 
 // readZipNDJSONIDsFromBuf is a helper specific to this file (cannot


### PR DESCRIPTION
Closes #345. Unblocks #344.

## What

- New `withFKDisabled` test helper: toggles `PRAGMA foreign_keys` around fixture code that deliberately fabricates FK-violating rows, restoring the prior setting afterwards (safe — `db.Open` sets `SetMaxOpenConns(1)`).
- `insertOneCycle` / `seedWithOrphans` and the export orphan tests use it, preserving their documented purpose of simulating the v0.3.x drift state.
- The `DROP TABLE targets` error-injection test wraps the DROP (its implicit delete violates the FK from the seeded snapshot).
- `TestRetentionCleanup` now seeds a real target and checks `InsertSnapshot` errors instead of discarding them with `_ =` — that pattern silently ran the test against an empty table.

## Why

modernc.org/sqlite 1.55.0 added support for mattn-style shorthand DSN params; our DSN has declared `_foreign_keys=on` all along, but releases <= 1.54.0 silently ignored it. Dependabot #344 therefore turns FK enforcement on for the first time and eight tests that fabricate orphan rows fail. Full analysis in #345 — production code paths are FK-compatible; this is fixtures-only. Deliberately NOT pinning sqlite <1.55: that would keep both FK enforcement and the declared 5s busy_timeout disabled.

## Verification

- `go test ./tests/` green on main's sqlite 1.54.0
- `go test ./tests/` green with `go get modernc.org/sqlite@v1.55.0` (the #344 state; bump reverted before commit — it lands via #344)
- `gofmt` clean, `go vet` clean, `scripts/preflight.sh lint` 0 issues