### PR TITLE
test: lock target_identity.host as the stable cluster identity contract (#353)

### DIFF
--- a/features/signals/specification.md
+++ b/features/signals/specification.md
@@ -1586,6 +1586,19 @@ Invariants:
   authoritative.
 - Backward compatibility: existing consumers that don't read
   `target_identity` continue to work — it is an additive field.
+- **Stable cluster identity (Workbench#1190 / #353).** `target_identity.host`
+  is the operator-**configured** connection host — stored verbatim from the
+  target config (the DNS endpoint / service name the operator pointed Signals
+  at), NOT a resolved server address. It is therefore stable across container
+  recreation, Kubernetes reschedule, and RDS/Aurora failover, whereas the
+  collected `inet_server_addr` (in `cluster_identity_v1`) is the ephemeral
+  resolved IP and churns. Downstream consumers (Analyzer → Workbench) key the
+  stable database/cluster identity on `target_identity.{host,port,dbname}`;
+  the collected `inet_server_addr` is provenance/display only. Signals emits
+  no resolved-address field inside `target_identity`, so a consumer cannot
+  accidentally key on the churning value. This requires no privilege — Signals
+  knows the configured host from its own DSN, so it works on least-privilege
+  read-only roles where the superuser-only `system_identifier` is unavailable.
 
 ### Failure conditions
 

--- a/features/signals/specification.md
+++ b/features/signals/specification.md
@@ -1586,7 +1586,10 @@ Invariants:
   authoritative.
 - Backward compatibility: existing consumers that don't read
   `target_identity` continue to work — it is an additive field.
-- **Stable cluster identity (Workbench#1190 / #353).** `target_identity.host`
+- **Stable cluster identity (Workbench#1190 / #353).** The authoritative
+  cross-repo decision behind this invariant is recorded in **Analyzer
+  `docs/architecture/adr-0002-cluster-identity-connect-host.md`** — amend
+  the ADR if the identity model changes. `target_identity.host`
   is the operator-**configured** connection host — stored verbatim from the
   target config (the DNS endpoint / service name the operator pointed Signals
   at), NOT a resolved server address. It is therefore stable across container

--- a/tests/signals_export_target_identity_test.go
+++ b/tests/signals_export_target_identity_test.go
@@ -192,6 +192,53 @@ func TestExportMetadataOmitsTargetIdentityForOrphanSnapshot(t *testing.T) {
 	}
 }
 
+// #1190 (Workbench) / #353 — the stable-cluster-identity contract the
+// downstream consumers (Analyzer -> Workbench) rely on: target_identity.host
+// is the OPERATOR-CONFIGURED connection host (the DNS endpoint / service name
+// the operator pointed Signals at, stored verbatim from the target config),
+// NOT a resolved server address. Because it is config-derived it is stable
+// across container recreation / K8s reschedule / RDS failover — the churn
+// that made Workbench re-register the same database (with duplicate findings)
+// when it keyed on the ephemeral inet_server_addr. This test reads the
+// exported ZIP and asserts (a) the host is the configured DNS endpoint and
+// (b) the identity block carries no resolved-IP field, so the identity can
+// never be sourced from the churning address.
+func TestExportTargetIdentityIsConfiguredHostForStableClusterIdentity(t *testing.T) {
+	store := openTestDB(t)
+
+	const configuredHost = "tsdemo.abc123.us-east-1.rds.amazonaws.com"
+	targetID, err := store.UpsertTarget(
+		"tsdemo", configuredHost, 5432, "timeseries", "signals_ro",
+		"require", "FILE", "/etc/signals/tsdemo.pw", true,
+	)
+	if err != nil {
+		t.Fatalf("UpsertTarget: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := store.InsertSnapshot(db.Snapshot{
+		ID: "snap-1190-001", TargetID: targetID, CollectedAt: now,
+		PGVersion: "PostgreSQL 18.0", Payload: json.RawMessage(`{}`), SizeBytes: 42,
+	}); err != nil {
+		t.Fatalf("InsertSnapshot: %v", err)
+	}
+
+	meta := buildScopedExportZIP(t, store, targetID)
+	ident, ok := meta["target_identity"].(map[string]any)
+	if !ok {
+		t.Fatal("metadata.json missing target_identity")
+	}
+	if got := ident["host"]; got != configuredHost {
+		t.Errorf("target_identity.host = %v, want the configured DNS endpoint %q (the stable identity)", got, configuredHost)
+	}
+	// The identity must be config-derived: no resolved-address field may
+	// appear, or a consumer could key on the churning value again (#1190).
+	for _, ipField := range []string{"inet_server_addr", "server_addr", "resolved_host", "ip"} {
+		if _, present := ident[ipField]; present {
+			t.Errorf("target_identity must NOT carry a resolved-address field %q — identity is the configured host, not the ephemeral IP", ipField)
+		}
+	}
+}
+
 // readZipNDJSONRows decodes every line of an ndjson member in a ZIP
 // into map[string]any. Used by the multi-target tests below which
 // need to inspect nested objects (target_identity) per row, not just


### PR DESCRIPTION
The Signals half of Workbench#1190 — and the good news is **no emitter change is required**.

## Finding
Signals already writes the operator-configured connection host into every export ZIP as `target_identity.host` (R094), in both `metadata.json` and per-row `snapshots.ndjson`, sourced verbatim from the target config via `UpsertTarget(tgt.Host, …)` — **not** a resolved server address. That is exactly the stable, privilege-free cluster identity Workbench#1190 needs to stop re-registering the same database when the resolved `inet_server_addr` churns (container recreation / RDS failover). Because it comes from the DSN config, it needs no database privilege — it works on the least-privilege read-only role where the superuser-only `system_identifier` is unavailable.

## Change
- **Contract test** (`signals_export_target_identity_test.go`): builds an export ZIP, reads it back, and asserts `target_identity.host` is the configured DNS endpoint **and** carries no resolved-address field — so a consumer can never accidentally key on the churning IP.
- **Spec note** (`specification.md` R094): records that downstream consumers key the stable identity on `target_identity.{host,port,dbname}` and that the collected `inet_server_addr` is provenance / display only.

Local gates green: `go vet`, `golangci-lint run` (0 issues), export target_identity tests.

closes #353