### PR TITLE
feat(export): scheduled auto-export to a configured file location (#350)

### DIFF
--- a/cmd/signals/main.go
+++ b/cmd/signals/main.go
@@ -206,6 +206,23 @@ func run() error {
 		})
 	}
 
+	// #350: scheduled auto-export. When enabled, write the latest snapshot
+	// export ZIP to the configured file location after every collection
+	// cycle. A failed export logs and is skipped — it must never disrupt
+	// collection. Signals has no knowledge of any downstream consumer.
+	if cfg.Signals.ExportOnCollect && cfg.Signals.ExportDest != "" {
+		se := export.NewScheduledExporter(exporter, cfg.Signals.ExportDest, instanceID, nil, slog.Warn)
+		coll.SetAfterCycle(func(ctx context.Context) {
+			path, err := se.ExportLatest(ctx)
+			if err != nil {
+				slog.Warn("scheduled export failed; skipping this cycle", "err", err.Error(), "dest", cfg.Signals.ExportDest)
+				return
+			}
+			slog.Info("scheduled export written", "path", path)
+		})
+		slog.Info("scheduled auto-export enabled", "dest", cfg.Signals.ExportDest, "cadence", "per collection cycle")
+	}
+
 	// Start collector in background.
 	go coll.Run(ctx)
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -53,6 +53,10 @@ type Collector struct {
 	targets       []config.TargetConfig // reload-mutable; access via currentTargets() / Targets().
 	interval      time.Duration         // set-at-construction; reload-v1 leaves the ticker armed at boot value.
 	retentionDays int                   // set-at-construction.
+	// afterCycle, when non-nil, is invoked after every completed collection
+	// cycle (#350 scheduled export). Set once via SetAfterCycle before
+	// Run starts, so it is read-only for Run's lifetime (no lock needed).
+	afterCycle func(context.Context)
 	// retention (R099) carries per-class retention thresholds.
 	// Zero-value (Retention.IsSet() == false) means the daemon
 	// uses the flat retentionDays for every class.
@@ -661,7 +665,7 @@ func (c *Collector) Run(ctx context.Context) {
 
 	// Initial collection — force all queries as a baseline. nil filter
 	// means "collect every enabled target".
-	c.runCycle(ctx, true, CollectRequest{})
+	c.cycle(ctx, true, CollectRequest{})
 
 	for {
 		select {
@@ -670,12 +674,30 @@ func (c *Collector) Run(ctx context.Context) {
 			c.closePools()
 			return
 		case <-ticker.C:
-			c.runCycle(ctx, false, CollectRequest{})
+			c.cycle(ctx, false, CollectRequest{})
 		case req := <-c.collectNowCh:
 			slog.Info("on-demand collection triggered", "targets", len(req.Targets), "request_id", req.RequestID)
-			c.runCycle(ctx, true, req)
+			c.cycle(ctx, true, req)
 		}
 	}
+}
+
+// cycle runs one collection cycle and then invokes the post-cycle hook
+// (#350 scheduled export). The hook runs after every cycle — the initial
+// baseline, each scheduled tick, and each on-demand collection — so a fresh
+// export follows every collection. A nil hook (the default) is a no-op.
+func (c *Collector) cycle(ctx context.Context, forceAll bool, req CollectRequest) {
+	c.runCycle(ctx, forceAll, req)
+	if c.afterCycle != nil {
+		c.afterCycle(ctx)
+	}
+}
+
+// SetAfterCycle registers the post-cycle hook (#350). It MUST be called
+// before Run starts; Run is then the only reader, so no synchronisation is
+// needed.
+func (c *Collector) SetAfterCycle(fn func(context.Context)) {
+	c.afterCycle = fn
 }
 
 // CollectNow triggers an immediate collection cycle (non-blocking).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,13 @@ type SignalsConfig struct {
 	// `per-collector/<query_id>.json` directory to the export ZIP.
 	// Default off — canonical NDJSON layout is unaffected.
 	ExportPerCollectorFiles bool `yaml:"export_per_collector_files"`
+	// #350: scheduled auto-export. When ExportOnCollect is true and
+	// ExportDest is a non-empty directory, Signals writes the latest
+	// snapshot export ZIP to ExportDest after each collection cycle. Both
+	// default off (no scheduled export). What consumes the files is out of
+	// scope for Signals.
+	ExportOnCollect bool   `yaml:"export_on_collect"`
+	ExportDest      string `yaml:"export_dest"`
 }
 
 // CircuitConfig holds the per-target circuit-breaker thresholds
@@ -598,6 +605,15 @@ func applyEnvOverrides(cfg *Config) error {
 		return err
 	} else if ok {
 		cfg.Signals.ExportPerCollectorFiles = b
+	}
+	// #350 — scheduled auto-export to a file location.
+	if b, ok, err := parseEnvBool("SIGNALS_EXPORT_ON_COLLECT"); err != nil {
+		return err
+	} else if ok {
+		cfg.Signals.ExportOnCollect = b
+	}
+	if v := os.Getenv("SIGNALS_EXPORT_DEST"); v != "" {
+		cfg.Signals.ExportDest = v
 	}
 	// File takes precedence over the raw env var when both are set —
 	// matches the _FILE convention used by the official postgres image.

--- a/internal/export/scheduled.go
+++ b/internal/export/scheduled.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Scantr LLC. All rights reserved.
+// Elevarq is a trade name of Scantr LLC.
+// This file is part of Elevarq Signals. Use is governed by the
+// commercial license at LICENSE in the repository root.
+
+// Scheduled auto-export (#350). Signals collects and stores on a schedule;
+// this writes the latest snapshot out to a configured file location on each
+// collection cycle, so the destination always holds a fresh export with no
+// per-cycle operator action. What (if anything) consumes those files is out
+// of scope — Signals has no knowledge of any downstream consumer.
+package export
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// snapshotWriter is the narrow slice of *Builder the scheduled exporter
+// needs — writing a scoped export to a writer. *Builder satisfies it; tests
+// substitute a fake so ExportLatest is exercised without a database.
+type snapshotWriter interface {
+	WriteTo(w io.Writer, opts Options) error
+}
+
+// ScheduledExporter writes the latest-snapshot export ZIP to a directory,
+// one file per invocation, using the shared long-lived Builder. It is
+// safe to call from the collector's post-cycle hook.
+type ScheduledExporter struct {
+	builder    snapshotWriter
+	dest       string
+	instanceID string
+	now        func() time.Time
+	logf       func(msg string, args ...any)
+}
+
+// NewScheduledExporter constructs the exporter. `dest` is the destination
+// directory; `instanceID` disambiguates files when several Signals
+// instances write to one shared directory (#350). `now`/`logf` default to
+// wall-clock / no-op when nil.
+func NewScheduledExporter(b snapshotWriter, dest, instanceID string, now func() time.Time, logf func(string, ...any)) *ScheduledExporter {
+	if now == nil {
+		now = time.Now
+	}
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	return &ScheduledExporter{builder: b, dest: dest, instanceID: instanceID, now: now, logf: logf}
+}
+
+// instanceToken keeps the filename component filesystem-safe and flat.
+var instanceToken = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+// exportFilename builds a FLAT, per-instance, per-timestamp filename:
+// `<instance>-<RFC3339Nano-ish UTC>.zip`. Flat (no subdirectories) so a
+// downstream flat directory watcher sees it; instance + nanosecond
+// timestamp make it unique across instances and cycles, so a new export
+// never overwrites a prior one.
+func (e *ScheduledExporter) exportFilename() string {
+	inst := instanceToken.ReplaceAllString(strings.TrimSpace(e.instanceID), "_")
+	if inst == "" {
+		inst = "signals"
+	}
+	ts := e.now().UTC().Format("20060102T150405.000000000Z")
+	return fmt.Sprintf("%s-%s.zip", inst, ts)
+}
+
+// ExportLatest builds the latest-snapshot export (default scope) and writes
+// it atomically into the destination directory (#350). The write is
+// temp-file + rename, so a consumer watching the directory never observes a
+// partially-written ZIP. Returns an error without leaving a partial final
+// file; a caller (the collector hook) logs and continues — a failed export
+// must never disrupt collection.
+func (e *ScheduledExporter) ExportLatest(_ context.Context) (string, error) {
+	if e.dest == "" {
+		return "", fmt.Errorf("scheduled export: destination not configured")
+	}
+	if err := os.MkdirAll(e.dest, 0o755); err != nil {
+		return "", fmt.Errorf("scheduled export: mkdir %s: %w", e.dest, err)
+	}
+	name := e.exportFilename()
+	final := filepath.Join(e.dest, name)
+	tmp := filepath.Join(e.dest, "."+name+".tmp")
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return "", fmt.Errorf("scheduled export: create temp: %w", err)
+	}
+	// Default Options = the latest snapshot per target (the same scope the
+	// on-demand GET /export uses with no filter).
+	werr := e.builder.WriteTo(f, Options{})
+	cerr := f.Close()
+	if werr != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("scheduled export: write: %w", werr)
+	}
+	if cerr != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("scheduled export: close: %w", cerr)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("scheduled export: rename: %w", err)
+	}
+	return final, nil
+}

--- a/internal/export/scheduled_test.go
+++ b/internal/export/scheduled_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Scantr LLC. All rights reserved.
+// Elevarq is a trade name of Scantr LLC.
+// This file is part of Elevarq Signals. Use is governed by the
+// commercial license at LICENSE in the repository root.
+
+package export
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeWriter stands in for *Builder so ExportLatest is testable without a DB.
+type fakeWriter struct {
+	payload []byte
+	err     error
+}
+
+func (f *fakeWriter) WriteTo(w io.Writer, _ Options) error {
+	if f.err != nil {
+		return f.err
+	}
+	_, err := w.Write(f.payload)
+	return err
+}
+
+func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+func TestScheduledExporter_ExportLatest_WritesAtomically(t *testing.T) {
+	dest := t.TempDir()
+	now := time.Date(2026, 8, 13, 9, 30, 0, 0, time.UTC)
+	se := NewScheduledExporter(&fakeWriter{payload: []byte("PK\x03\x04zip-bytes")}, dest, "signals-prod-1", fixedClock(now), nil)
+
+	path, err := se.ExportLatest(context.Background())
+	if err != nil {
+		t.Fatalf("ExportLatest: %v", err)
+	}
+	// Flat file directly in dest, instance-prefixed, .zip.
+	if filepath.Dir(path) != dest {
+		t.Errorf("wrote to %q, want flat in %q (no subdirectory)", path, dest)
+	}
+	base := filepath.Base(path)
+	if !strings.HasPrefix(base, "signals-prod-1-") || !strings.HasSuffix(base, ".zip") {
+		t.Errorf("filename %q, want signals-prod-1-<ts>.zip", base)
+	}
+	// Contents are the builder's bytes; no leftover temp file.
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != "PK\x03\x04zip-bytes" {
+		t.Errorf("file contents = %q (err %v), want the export payload", got, err)
+	}
+	entries, _ := os.ReadDir(dest)
+	if len(entries) != 1 {
+		t.Errorf("dest has %d entries, want exactly 1 (no leftover .tmp)", len(entries))
+	}
+}
+
+func TestScheduledExporter_ExportLatest_WriteFailureLeavesNoFile(t *testing.T) {
+	dest := t.TempDir()
+	se := NewScheduledExporter(&fakeWriter{err: errors.New("boom")}, dest, "inst", fixedClock(time.Now()), nil)
+
+	if _, err := se.ExportLatest(context.Background()); err == nil {
+		t.Fatal("expected error from a failing writer")
+	}
+	entries, _ := os.ReadDir(dest)
+	if len(entries) != 0 {
+		t.Errorf("dest has %d entries after a failed export, want 0 (no partial/temp file)", len(entries))
+	}
+}
+
+func TestScheduledExporter_ExportLatest_NoDestErrors(t *testing.T) {
+	se := NewScheduledExporter(&fakeWriter{}, "", "inst", nil, nil)
+	if _, err := se.ExportLatest(context.Background()); err == nil {
+		t.Error("expected an error when the destination is not configured")
+	}
+}
+
+func TestScheduledExporter_exportFilename(t *testing.T) {
+	now := time.Date(2026, 8, 13, 9, 30, 5, 123456789, time.UTC)
+	cases := []struct {
+		instance   string
+		wantPrefix string
+	}{
+		{"signals-prod-1", "signals-prod-1-"},
+		{"weird id/with:bad*chars", "weird_id_with_bad_chars-"}, // sanitized, flat
+		{"  ", "signals-"}, // blank falls back
+		{"", "signals-"},
+	}
+	for _, tc := range cases {
+		se := NewScheduledExporter(&fakeWriter{}, "/x", tc.instance, fixedClock(now), nil)
+		name := se.exportFilename()
+		if !strings.HasPrefix(name, tc.wantPrefix) {
+			t.Errorf("instance %q -> %q, want prefix %q", tc.instance, name, tc.wantPrefix)
+		}
+		if !strings.HasSuffix(name, ".zip") || strings.ContainsAny(name, "/\\") {
+			t.Errorf("filename %q must be a flat *.zip", name)
+		}
+	}
+	// Distinct timestamps yield distinct names (never overwrite a prior export).
+	seA := NewScheduledExporter(&fakeWriter{}, "/x", "i", fixedClock(now), nil)
+	seB := NewScheduledExporter(&fakeWriter{}, "/x", "i", fixedClock(now.Add(time.Second)), nil)
+	if seA.exportFilename() == seB.exportFilename() {
+		t.Error("different times produced the same filename")
+	}
+}

--- a/specifications/scheduled-export.md
+++ b/specifications/scheduled-export.md
@@ -1,0 +1,70 @@
+# Scheduled auto-export (SE)
+
+- **Prefix:** `SE`
+- **Issue:** [#350](https://github.com/Elevarq/Signals/issues/350)
+- **Status:** ACTIVE
+
+## Purpose
+
+Signals collects and stores its data on a schedule. Scheduled auto-export
+adds the ability to **write the latest snapshot export to a configured file
+location on that schedule**, so the destination always holds a fresh export
+with no per-cycle operator action.
+
+This is a self-contained Signals capability: **collect → store →
+export-to-a-file-location, repeated on the collection schedule.** What (if
+anything) consumes the exported files is out of scope; Signals has no
+knowledge of any downstream consumer.
+
+## Configuration
+
+| Setting | Env | YAML | Default | Meaning |
+|---|---|---|---|---|
+| Enable | `SIGNALS_EXPORT_ON_COLLECT` | `export_on_collect` | `false` | Write an export after each collection cycle. |
+| Destination | `SIGNALS_EXPORT_DEST` | `export_dest` | `""` | Directory to write exports into. |
+
+Scheduled export runs only when enabled **and** a non-empty destination is
+set; otherwise it is a no-op (existing behaviour unchanged).
+
+## Rules
+
+- **SE-R010** — When enabled, Signals writes the **latest-snapshot** export
+  (the default export scope — the newest snapshot per target, the same scope
+  a filterless on-demand export uses) to the destination **after every
+  completed collection cycle**: the initial baseline cycle, each scheduled
+  poll, and each on-demand collection.
+- **SE-R011** — Each export is written to a **flat file** in the destination
+  directory named `<instance-id>-<UTC-timestamp>.zip` (no subdirectories).
+  The instance-id component disambiguates several Signals instances writing
+  to one shared directory; the nanosecond timestamp makes each file unique
+  so a new export never overwrites a prior one. The instance-id is sanitized
+  to `[A-Za-z0-9._-]` (other runs of characters collapse to `_`); a blank
+  instance-id falls back to `signals`.
+- **SE-R012** — The write is **atomic**: the export is written to a temporary
+  file and renamed into place, so a process watching the destination never
+  observes a partially-written ZIP. A temporary file is never left behind on
+  success or failure.
+- **SE-R013** — A failed export (build error, unwritable destination) is
+  **logged and skipped**; it MUST NOT disrupt or fail the collection cycle.
+
+## Invariants
+
+- **SE-INV-01** — Scheduled export never changes what is collected or stored,
+  nor the export ZIP's contents; it only writes the already-defined
+  latest-snapshot export to a file on the collection schedule.
+- **SE-INV-02** — Files are flat in the destination (no per-target
+  subdirectories), so a flat-directory consumer sees every export.
+
+## Acceptance cases
+
+- **SE-AC-1 (normal)** — With `SIGNALS_EXPORT_ON_COLLECT=true` and
+  `SIGNALS_EXPORT_DEST=<dir>`, a fresh `<instance>-<ts>.zip` appears in
+  `<dir>` after each collection cycle, unattended.
+- **SE-AC-2 (boundary — shared destination)** — Two Signals instances with
+  distinct instance-ids exporting to one directory never collide (distinct
+  filename prefixes); distinct cycles never overwrite (distinct timestamps).
+- **SE-AC-3 (failure)** — When the export build fails or the destination is
+  unwritable, no partial/temp file remains and the collection cycle
+  completes normally (SE-R012/SE-R013).
+- **SE-AC-4 (disabled)** — With the feature off (default), no files are
+  written and behaviour is byte-identical to before.


### PR DESCRIPTION
## What
Signals collects and stores on a schedule; this adds the ability to **write the latest-snapshot export to a configured file location on that schedule**, so the destination always holds a fresh export with no per-cycle operator action. Self-contained: **collect → store → export-to-a-file-location, repeated on the collection schedule.** What consumes the files is out of scope — Signals has no knowledge of any downstream consumer.

## How
- **Config:** `SIGNALS_EXPORT_ON_COLLECT` (bool) + `SIGNALS_EXPORT_DEST` (dir), both off by default — behaviour is byte-identical when disabled.
- **`export.ScheduledExporter`** reuses the existing `Builder` to write the default **latest-snapshot** export as a **flat** `<instance-id>-<UTC-nanos>.zip` (no subdirectories; instance + timestamp make it unique across instances and cycles, so a new export never overwrites a prior one). **Atomic** temp-file + rename so a directory watcher never sees a partial ZIP; no temp file left on success or failure.
- **Collector post-cycle hook** (`SetAfterCycle`) fires after **every** cycle (initial baseline, each poll, each on-demand); `main` wires the exporter into it. A failed export is **logged and skipped** — it never disrupts collection.

## STDD
`specifications/scheduled-export.md` (SE-R010..R013, SE-INV-01/02, SE-AC-1..4). `ScheduledExporter` unit tests cover atomic write, no-partial-on-failure, flat unique naming, and the disabled no-op — via an injected writer so the path runs **without a database**.

## Verification
`go build ./...`, `go vet`, `golangci-lint` clean; `internal/export` + `internal/collector` + `internal/config` tests green. Rebased on latest main before push.

## Notes
- Flat filenames (not per-target subdirectories) are deliberate — it keeps a flat-directory consumer able to see every export (cf. Analyzer#2400).

closes #350