### PR TITLE
feat(collector): expose pg_constraint.convalidated as is_validated (#342)

### DIFF
--- a/examples/init.sql
+++ b/examples/init.sql
@@ -51,6 +51,23 @@ CREATE TABLE example_data (
     created_at timestamptz DEFAULT now()
 );
 
+-- --- NOT VALID constraints (pg_constraints_v1.is_validated = false) --
+-- A constraint added NOT VALID is enforced for new writes but was never
+-- checked against existing rows, so pg_constraint.convalidated is false.
+-- Every constraint above is validated (is_validated = true); these two
+-- give the is_validated signal a false case to report as well (#342).
+
+-- Self-referential FK on customers, added NOT VALID.
+ALTER TABLE customers ADD COLUMN referred_by bigint;
+ALTER TABLE customers
+    ADD CONSTRAINT customers_referred_by_fk
+    FOREIGN KEY (referred_by) REFERENCES customers(id) NOT VALID;   -- convalidated = false
+
+-- CHECK on orders, added NOT VALID.
+ALTER TABLE orders
+    ADD CONSTRAINT orders_amount_sane_chk
+    CHECK (amount_cents < 1000000000) NOT VALID;                    -- convalidated = false
+
 -- --- Data, so stats/row counts are non-trivial ----------------------
 INSERT INTO customers (email, tier)
 SELECT 'user' || g || '@example.com',

--- a/features/signals/traceability.md
+++ b/features/signals/traceability.md
@@ -71,7 +71,7 @@ Coverage Status values:
 | R054 | Database sizes | TC-SIG-048 | COVERED | BEHAVIORAL | Registered, passes linter |
 | R055 | Largest relations | TC-SIG-048 | COVERED | BEHAVIORAL | Registered, passes linter |
 | R056 | Temp I/O pressure | TC-SIG-048 | COVERED | BEHAVIORAL | Registered, passes linter, no secrets |
-| R057 | Schema constraint inventory | TC-SIG-050 | COVERED | BEHAVIORAL | pg_constraints_v1: registered, linter pass, 24h cadence, schema filter, unnest/ordinality multi-column, deterministic order |
+| R057 | Schema constraint inventory | TC-SIG-050 | COVERED | BEHAVIORAL | pg_constraints_v1: registered, linter pass, 24h cadence, schema filter, unnest/ordinality multi-column, deterministic order, constraint validity (is_validated from convalidated, #342) |
 | R058 | Schema index definitions | TC-SIG-050 | COVERED | BEHAVIORAL | pg_indexes_v1: registered, linter pass, 24h cadence, schema filter, indexdef included, COALESCE tablespace |
 | R059 | Column planner statistics | TC-SIG-051 | COVERED | BEHAVIORAL | pg_stats_v1: registered, linter pass, 24h cadence, schema filter, no data samples, n_distinct/correlation included |
 | R060 | Column inventory with types | TC-SIG-052 | COVERED | BEHAVIORAL | pg_columns_v1: registered, linter pass, 24h cadence, schema filter, pg_attribute native, format_type, no default text, excludes system/dropped columns |

--- a/internal/pgqueries/catalog_schema.go
+++ b/internal/pgqueries/catalog_schema.go
@@ -47,7 +47,8 @@ func init() {
 			c.relkind::text AS relkind,
 			COALESCE(s.n_live_tup, 0)::bigint AS n_live_tup,
 			COALESCE(rc.relname, '') AS confrelname,
-			COALESCE(rn.nspname, '') AS confschemaname
+			COALESCE(rn.nspname, '') AS confschemaname,
+			con.convalidated AS is_validated
 		FROM pg_constraint con
 		JOIN pg_class c ON c.oid = con.conrelid
 		JOIN pg_namespace n ON n.oid = c.relnamespace

--- a/specifications/collectors/pg_constraints_v1.md
+++ b/specifications/collectors/pg_constraints_v1.md
@@ -30,6 +30,7 @@ Primary consumer: the Elevarq Analyzer first-impression missing-FK-index detecto
 | n_live_tup | bigint | Live tuple count from pg_stat_user_tables |
 | confrelname | text | Referenced table (FK only; empty otherwise) |
 | confschemaname | text | Referenced schema (FK only; empty otherwise) |
+| is_validated | bool | `pg_constraint.convalidated`. `false` means the constraint is `NOT VALID`: it was added without validating existing rows, so it is enforced only for new writes and is not trusted by the planner. `true` for validated constraints. |
 
 ## Multi-column design
 

--- a/tests/signals_collector_output_contract_integration_test.go
+++ b/tests/signals_collector_output_contract_integration_test.go
@@ -116,7 +116,7 @@ var internalCharColumns = map[string]bool{
 var declaredColumnsByCollector = map[string][]string{
 	"pg_constraints_v1": {
 		"schemaname", "relname", "conname", "contype", "condef",
-		"column_name", "column_position", "relkind",
+		"column_name", "column_position", "relkind", "is_validated",
 	},
 	"pg_class_storage_v1": {
 		"relid", "schemaname", "relname", "relkind", "relpersistence",
@@ -370,6 +370,41 @@ func TestIntegration_CollectorOutputContractAgainstRealPG(t *testing.T) {
 			distinctContype(constraints))
 	}
 
+	// --- #342: pg_constraints_v1.is_validated mirrors pg_constraint
+	// .convalidated. The two seeded NOT VALID constraints MUST surface
+	// is_validated == false; the validated PK/FK above MUST surface true.
+	// This proves the NOT-VALID signal end to end so a consumer reads the
+	// clean catalog boolean instead of string-parsing condef (Analyzer
+	// #1759). is_validated marshals as a JSON bool (never "t"/"f"). ---
+	validity := map[string]bool{}
+	sawValidatedTrue := false
+	for _, row := range constraints {
+		name, _ := row["conname"].(string)
+		v, isBool := row["is_validated"].(bool)
+		if !isBool {
+			t.Errorf("#342: pg_constraints_v1 row %q is_validated is %T (%v), want a JSON bool",
+				name, row["is_validated"], row["is_validated"])
+			continue
+		}
+		validity[name] = v
+		if v {
+			sawValidatedTrue = true
+		}
+	}
+	for _, nv := range []string{"child_amount_nonneg_nv", "child_alt_parent_fk_nv"} {
+		got, present := validity[nv]
+		if !present {
+			t.Errorf("#342: seeded NOT VALID constraint %q missing from pg_constraints_v1 payload (conkey should have emitted a row)", nv)
+			continue
+		}
+		if got {
+			t.Errorf("#342: constraint %q was added NOT VALID but is_validated=true — want false (convalidated must be false)", nv)
+		}
+	}
+	if !sawValidatedTrue {
+		t.Error("#342: no pg_constraints_v1 row with is_validated=true — the seeded validated PK/FK should surface convalidated=true")
+	}
+
 	// --- OC-R005 / INV-04 (the #319 central-fix lock) --------------
 	// The columns #313's per-column ::text sweep left uncast must ALSO
 	// decode as strings, proving OID 18 is normalized at the connection
@@ -605,6 +640,18 @@ func seedRepresentativeSchema(t *testing.T, dsn string) (fdwSeeded bool) {
 		// table + its index also feed the bloat collectors so their
 		// relkind columns ('r'/'i') are exercised (OC-R005 / #319).
 		`CREATE INDEX child_note_idx ON signals_oc_test.child (note)`,
+		// #342 — NOT VALID constraints so pg_constraints_v1.is_validated
+		// (convalidated) has a false case alongside the validated PK/FK
+		// above (which surface true). A NOT VALID constraint is enforced
+		// for new writes but was never checked against existing rows.
+		// Both reference a column, so conkey is non-empty and the
+		// unnest(conkey) join emits a row for each.
+		`ALTER TABLE signals_oc_test.child
+			ADD CONSTRAINT child_amount_nonneg_nv CHECK (amount >= 0) NOT VALID`,
+		`ALTER TABLE signals_oc_test.child ADD COLUMN alt_parent_id bigint`,
+		`ALTER TABLE signals_oc_test.child
+			ADD CONSTRAINT child_alt_parent_fk_nv
+			FOREIGN KEY (alt_parent_id) REFERENCES signals_oc_test.parent(id) NOT VALID`,
 		// An identity column so pg_identity_columns_v1 emits attidentity
 		// (the raw "char" column #313's per-column sweep missed). The
 		// generated column yields attidentity='a'; the plain int/uuid

--- a/tests/signals_collector_type_contract_integration_test.go
+++ b/tests/signals_collector_type_contract_integration_test.go
@@ -186,6 +186,7 @@ var auditedTypeAssertions = []typeAssertion{
 	{"bool", "index_health_summary_v1", "is_unique", classBool, false},
 	{"bool", "pg_functions_v1", "security_definer", classBool, false},
 	{"bool", "pg_role_capabilities_v1", "is_superuser", classBool, false},
+	{"bool", "pg_constraints_v1", "is_validated", classBool, false}, // #342 convalidated → NOT VALID signal
 }
 
 // notExercisedTypeClasses records the audited type classes for which no

--- a/tests/signals_schema_collectors_test.go
+++ b/tests/signals_schema_collectors_test.go
@@ -147,13 +147,31 @@ func TestConstraintsCollectorOutputColumns(t *testing.T) {
 	requiredColumns := []string{
 		"schemaname", "relname", "conname", "contype", "condef",
 		"column_name", "column_position", "relkind", "n_live_tup",
-		"confrelname", "confschemaname",
+		"confrelname", "confschemaname", "is_validated",
 	}
 
 	for _, col := range requiredColumns {
 		if !strings.Contains(sql, col) {
 			t.Errorf("pg_constraints_v1 must include column %q in output", col)
 		}
+	}
+}
+
+// TestConstraintsCollectorExposesValidity pins the NOT-VALID signal (#342):
+// the collector must expose pg_constraint.convalidated as the is_validated
+// column so a consumer can flag NOT VALID constraints from the clean catalog
+// boolean rather than string-parsing condef.
+func TestConstraintsCollectorExposesValidity(t *testing.T) {
+	q := pgqueries.ByID("pg_constraints_v1")
+	if q == nil {
+		t.Fatal("pg_constraints_v1 not registered")
+	}
+	sql := strings.ToLower(q.SQL)
+	if !strings.Contains(sql, "convalidated") {
+		t.Error("pg_constraints_v1 must read pg_constraint.convalidated")
+	}
+	if !strings.Contains(sql, "convalidated as is_validated") {
+		t.Error("pg_constraints_v1 must expose convalidated aliased as is_validated")
 	}
 }
 


### PR DESCRIPTION
Adds the constraint-validity boolean to the `pg_constraints_v1` collector so consumers can flag `NOT VALID` constraints from the clean catalog boolean instead of string-parsing `condef`.

## Change
- **Query**: `con.convalidated AS is_validated` on `pg_constraints_v1`. `false` = the constraint is `NOT VALID` (enforced for new writes, never validated against existing rows, not trusted by the planner); `true` = validated. Plain `pg_constraint` read, present on all supported majors, no version gating, no extension dependency.
- **Spec**: new column documented in `specifications/collectors/pg_constraints_v1.md`; traceability R057 updated.
- **Unit contract** (`tests/signals_schema_collectors_test.go`): `is_validated` added to the required-columns assertion; new `TestConstraintsCollectorExposesValidity` pins the `convalidated AS is_validated` alias. Both fail before the change.
- **Wire contract** (integration, `//go:build integration`): type-contract asserts `is_validated` serializes as a JSON bool (the Analyzer-expected form, the #312-class guard); output-contract asserts it is present; the seed now adds a `NOT VALID` FK and a `NOT VALID` CHECK and the test asserts both surface `is_validated=false` while the validated PK/FK surface `true`.
- **`examples/init.sql`**: adds a `NOT VALID` FK and CHECK so the demo/dev seed exercises the `false` case end to end.

## Verification
- `go test ./...` (unit) — green; `gofmt`/`go vet`/`golangci-lint run ./...` — 0 issues.
- Both integration contract tests (`TestIntegration_CollectorOutputContractAgainstRealPG`, `TestIntegration_CollectorTypeContractAgainstRealPG`) run **live against PostgreSQL 16** — green (0 collectors failed), confirming the `NOT VALID` → `false` / validated → `true` split end to end.

## Notes
This is a standalone, additive collector change. Analyzer tolerates the new column with zero changes (it decodes rows into `map[string]any` with no strict column contract), and it *unblocks* — but does not require — the `not-valid-constraint` half of Analyzer#1759, which is separate future work.

closes #342