### PR TITLE
ci(lint): lint //go:build integration files too (#357)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,13 @@
 
 version: "2"
 
+run:
+  # Lint the build-tagged code too. Without this golangci-lint compiles
+  # only the default build and never sees `//go:build integration` files,
+  # so lint findings in the integration tests merge green (#357).
+  build-tags:
+    - integration
+
 linters:
   default: standard
   settings:
@@ -34,6 +41,9 @@ linters:
         - (*database/sql.Stmt).Close
         - (*database/sql.Tx).Rollback
         - (*compress/gzip.Writer).Close
+        # pgx is our DB driver; a deferred Conn.Close(ctx) is the same
+        # resource-teardown idiom as (*database/sql.DB).Close above.
+        - (*github.com/jackc/pgx/v5.Conn).Close
         # HTTP response writers are a one-way pipe by the time
         # Encode runs; the connection is already gone if it
         # errors and the handler has no useful recovery.


### PR DESCRIPTION
The lint gate (`scripts/preflight.sh lint` -> `golangci-lint run ./...`, also CI) passed no build tags, so golangci-lint compiled only the default build and **never linted `//go:build integration` files**. Findings in the integration tests merged green — e.g. an unchecked `pgx.Conn.Close` at `internal/collector/credprovider_live_test.go:164`.

## Fix (config-only)
- `.golangci.yml` `run.build-tags: [integration]` — every invocation (local, `preflight.sh`, pre-push hook, CI) now lints the integration build.
- Carve out `(*github.com/jackc/pgx/v5.Conn).Close` in the errcheck `exclude-functions` list — a deferred `Conn.Close(ctx)` is the same resource-teardown idiom as the `(*database/sql.DB).Close` already excluded there (our DB driver is pgx).

## Verification
- With `build-tags` enabled and the pgx carve-out **removed** (clean cache): the errcheck reappears at `credprovider_live_test.go:164` and it is the **only** finding — proving integration files are now linted and nothing else was hiding.
- With the carve-out in place (clean cache): `golangci-lint run ./...` = **0 issues**.
- `golangci-lint config verify` passes.

closes #357