### PR TITLE
release: v1.2.0 (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-13
+
+### Added
+
+- Scheduled auto-export: an optional scheduler exports a diagnostic
+  snapshot to a configured file location after each collection cycle,
+  writing an atomic `<instance>-<UTC-nanos>.zip` per run. Enabled via
+  `SIGNALS_EXPORT_ON_COLLECT` + `SIGNALS_EXPORT_DEST`. Signals collects,
+  stores, and can export on a fixed interval with no external consumer
+  required (SE-R010..R013, SE-INV-01/02) (#350).
+- `pg_constraints_v1` now emits `is_validated` (from
+  `pg_constraint.convalidated`): `false` flags a `NOT VALID` FK/CHECK
+  constraint — enforced for new writes but never validated against
+  existing rows and not trusted by the planner — read from the clean
+  catalog boolean instead of string-parsing `condef` (#342).
+- Helm chart supports multiple PostgreSQL targets in a single release,
+  rendering one collection configuration per target (#347).
+- Examples: a repeatable one-command local snapshot and a
+  constraint-rich seed so the collectors have representative data to
+  report (#339).
+
 ### Fixed
 
 - FC-05 false-clean export gap: a default-scope `GET /export` with no

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 1.1.0
-appVersion: "1.1.0"
+version: 1.2.0
+appVersion: "1.2.0"
 keywords:
   - postgresql
   - monitoring

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "1.1.0"
+  tag: "1.2.0"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration. Rendered into the mounted


### PR DESCRIPTION
Version bump for the **v1.2.0** release (minor: new features, backward compatible).

## Changes
- `Chart.yaml` version + appVersion, `values.yaml` image.tag → **1.2.0**.
- CHANGELOG: cut `## [1.2.0]` from Unreleased with the feature entries.

## Notable since v1.1.0
- feat: scheduled auto-export to a configured file location (#350)
- feat: `pg_constraints_v1` exposes `is_validated` / `convalidated` (#342)
- feat: Helm chart supports multiple PostgreSQL targets (#347)
- fix: FC-05 false-clean export gap (#340)

After merge: verify `main` carries the bump, then tag `v1.2.0` → the tag-driven `release.yml` publishes the signed multi-arch image (GHCR + Docker Hub), the OCI Helm chart, SBOM/SLSA, and the GitHub Release.

## Verification
- `helm lint` green; version consistent across Chart.yaml/values.yaml; CHANGELOG `## [1.2.0]` present (release gate).

closes #359