### PR TITLE
build: bump Go toolchain to 1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - name: Download modules
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - name: Download modules
@@ -170,7 +170,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: go.sum
 
       - name: Trivy filesystem scan (vuln + secret)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - name: Download modules
@@ -444,7 +444,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - name: Build binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
 
 RUN apk add --no-cache git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elevarq/signals
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/secretmanager v1.21.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain pin from 1.26.5 to 1.26.6 across every declaration site to clear the govulncheck vulnerability gate.

govulncheck flags 7 `net/http` standard-library vulnerabilities reachable through the GCP/Azure credential providers — all fixed in go1.26.6. This turns `security-scan` red on `main` and on every open PR (#364, #365).

## Changes

- `go.mod` `go` directive → 1.26.6
- `Dockerfile` builder base → `golang:1.26.6-alpine` (digest refreshed to `sha256:3889b4…2d83`)
- `.github/workflows/ci.yml` — 3x `setup-go` → 1.26.6
- `.github/workflows/release.yml` — 2x `setup-go` → 1.26.6

## Verification

Ran govulncheck locally against the go1.26.6 toolchain: **0 called vulnerabilities** (the 7 `net/http` findings are gone; the single remaining finding is an uncalled module vuln that does not fail the gate).

closes #366