### PR TITLE
Collect object and default privileges (#363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Object and default access-privilege collectors: `object_privileges_v1`
+  (table/view/matview/sequence/foreign-table `relacl`, schema `nspacl`,
+  function `proacl`) and `default_privileges_v1` (`pg_default_acl`). Both
+  normalise the `aclitem[]` ACLs via `aclexplode()` into (grantee, privilege,
+  grantable) rows, rendering the `PUBLIC` pseudo-role explicitly, so a
+  downstream security-posture analysis can flag over-broad grants — grants to
+  `PUBLIC` or broad privileges on the `public` schema. Category `security`,
+  no extra grant beyond the default `pg_monitor` collection role, role names
+  handled as the existing non-sensitive catalog data. Feeds the
+  `broad-or-public-grants` finding in Analyzer #1757 (#363).
+
 ### Fixed
 
 - Scheduled auto-export (`export_on_collect` / `export_dest`, #350) now writes

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ audit the binary. You own the output.
   cloud IAM** (RDS / Cloud SQL / Azure), or with the password fetched **live
   from a cloud secret store**, so no database secret lives in config
   ([details](#connecting-to-your-databases--passwordless--secret-store-auth))
-- Runs 100 read-only diagnostic collectors covering:
+- Runs 102 read-only diagnostic collectors covering:
   - Server configuration, identity, and cluster fingerprint
   - Session activity and connection pressure
   - Table, index, and I/O statistics (incl. `pg_stat_io` /
@@ -511,7 +511,7 @@ inspect exactly what Elevarq Signals collects without running it.
 
 ## Collected signals
 
-Elevarq Signals includes 100 read-only collectors. Grouped by domain:
+Elevarq Signals includes 102 read-only collectors. Grouped by domain:
 
 - **Baseline & runtime** — server config, sessions, databases,
   tables, indexes, table / index I/O, query stats
@@ -967,7 +967,7 @@ analyzer).
 ## Project resources
 
 - [Architecture](docs/architecture.md) — components, data flow, trust boundary, and no-egress design
-- [Collector inventory](docs/collectors.md) — all 100 collectors with sources and cadences
+- [Collector inventory](docs/collectors.md) — all 102 collectors with sources and cadences
 - [Database connections](docs/database-connections.md) — per-cloud `auth_method` recipes (RDS IAM, Entra, Cloud SQL IAM, secret stores) + grants
 - [Runtime safety model](docs/runtime-safety-model.md) — read-only enforcement details
 - [Adoption guide](docs/adoption-guide.md) — production deployment guidance

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -51,6 +51,8 @@ Operational health, security, and planner diagnostics.
 | `long_running_txns_v1` | `pg_stat_activity` | 5m | Transactions older than 5 minutes |
 | `blocking_locks_v1` | `pg_stat_activity` | 5m | Lock-blocking chains with wait durations |
 | `login_roles_v1` | `pg_roles` | 6h | Login roles with privilege flags (no password hashes) |
+| `object_privileges_v1` | `pg_class.relacl` + `pg_namespace.nspacl` + `pg_proc.proacl` via `aclexplode()` | 6h | Object/schema/function grants (grantee, privilege, grantable); renders `PUBLIC` explicitly for over-broad-grant analysis |
+| `default_privileges_v1` | `pg_default_acl` via `aclexplode()` | 6h | Default privileges future objects inherit (`ALTER DEFAULT PRIVILEGES` state); empty until customised |
 | `connection_utilization_v1` | `pg_stat_activity` | 5m | Connection counts vs max_connections |
 | `planner_stats_staleness_v1` | `pg_stat_user_tables` + `pg_class` | 1h | Estimate drift and modifications since analyze |
 | `pgss_reset_check_v1` | `pg_stat_statements_info` | 1h | Statistics reset timestamp (requires extension, PG 14+) |

--- a/internal/pgqueries/catalog_privileges.go
+++ b/internal/pgqueries/catalog_privileges.go
@@ -1,0 +1,119 @@
+package pgqueries
+
+import "time"
+
+// Object-level and default access privileges (#363; feeds Analyzer #1757).
+//
+// These collectors carry the actual ACLs so a downstream security-posture
+// analysis (Analyzer #1757) can flag over-broad privileges — grants to
+// PUBLIC, or broad privileges on the `public` schema. `login_roles_v1` /
+// `pg_role_capabilities_v1` already describe role *capabilities*; these add
+// the object/default *grants* that were missing.
+//
+// Both normalise the `aclitem[]` ACL arrays via `aclexplode()` into one
+// (grantee, privilege, grantable) row per grant. A grantee OID of 0 is
+// PUBLIC (rendered as the literal "PUBLIC"); every other OID is resolved to
+// its role name with `pg_get_userbyid`. Only catalog privilege *metadata*
+// is read — no object data — so no extra grant beyond the default
+// `pg_monitor` collection role is required, and role names are the same
+// class of already-emitted, non-sensitive catalog data as `login_roles_v1`
+// (no redaction).
+func init() {
+	// Object-level privileges: table/view/matview/sequence/foreign-table
+	// (pg_class.relacl), schema (pg_namespace.nspacl), and function
+	// (pg_proc.proacl) grants. A NULL acl means "owner default, no explicit
+	// grants" and produces no rows — the presence of an explicit row for a
+	// broad grantee (PUBLIC / a broad role) is exactly the signal the
+	// consumer wants. The `public` schema carries a default grant on every
+	// supported major, so this collector emits at least those rows on any
+	// database.
+	Register(QueryDef{
+		ID:       "object_privileges_v1",
+		Category: "security",
+		SQL: `WITH obj AS (
+	SELECT
+		CASE c.relkind
+			WHEN 'r' THEN 'table'
+			WHEN 'p' THEN 'partitioned_table'
+			WHEN 'v' THEN 'view'
+			WHEN 'm' THEN 'materialized_view'
+			WHEN 'S' THEN 'sequence'
+			WHEN 'f' THEN 'foreign_table'
+			ELSE c.relkind::text
+		END AS object_kind,
+		n.nspname AS schema_name,
+		c.relname AS object_name,
+		c.relacl  AS acl
+	FROM pg_class c
+	JOIN pg_namespace n ON n.oid = c.relnamespace
+	WHERE c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+	  AND c.relacl IS NOT NULL
+	  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+	  AND n.nspname NOT LIKE 'pg_temp_%'
+	  AND n.nspname NOT LIKE 'pg_toast_temp_%'
+	UNION ALL
+	SELECT 'schema', n.nspname, n.nspname, n.nspacl
+	FROM pg_namespace n
+	WHERE n.nspacl IS NOT NULL
+	  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+	  AND n.nspname NOT LIKE 'pg_temp_%'
+	  AND n.nspname NOT LIKE 'pg_toast_temp_%'
+	UNION ALL
+	SELECT 'function', n.nspname, p.proname, p.proacl
+	FROM pg_proc p
+	JOIN pg_namespace n ON n.oid = p.pronamespace
+	WHERE p.proacl IS NOT NULL
+	  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+	  AND n.nspname NOT LIKE 'pg_temp_%'
+	  AND n.nspname NOT LIKE 'pg_toast_temp_%'
+)
+SELECT
+	obj.object_kind,
+	obj.schema_name,
+	obj.object_name,
+	COALESCE(pg_get_userbyid(NULLIF(a.grantee, 0)), 'PUBLIC') AS grantee,
+	a.privilege_type,
+	a.is_grantable,
+	pg_get_userbyid(a.grantor) AS grantor
+FROM obj
+CROSS JOIN LATERAL aclexplode(obj.acl) AS a
+ORDER BY obj.object_kind, obj.schema_name, obj.object_name, grantee, a.privilege_type, a.is_grantable`,
+		ResultKind:     ResultRowset,
+		RetentionClass: RetentionLong,
+		Timeout:        10 * time.Second,
+		Cadence:        Cadence6h,
+	})
+
+	// Default privileges: pg_default_acl.defaclacl — what FUTURE objects
+	// created by `defaclrole` (optionally scoped to a schema) will inherit.
+	// Empty on a fresh database; rows appear only once someone runs
+	// ALTER DEFAULT PRIVILEGES, which is exactly the configuration the
+	// consumer needs to reason about. `schema_name` is empty for a global
+	// (non-schema-scoped) default.
+	Register(QueryDef{
+		ID:       "default_privileges_v1",
+		Category: "security",
+		SQL: `SELECT
+	pg_get_userbyid(d.defaclrole) AS for_role,
+	COALESCE(n.nspname, '') AS schema_name,
+	CASE d.defaclobjtype
+		WHEN 'r' THEN 'table'
+		WHEN 'S' THEN 'sequence'
+		WHEN 'f' THEN 'function'
+		WHEN 'T' THEN 'type'
+		WHEN 'n' THEN 'schema'
+		ELSE d.defaclobjtype::text
+	END AS object_kind,
+	COALESCE(pg_get_userbyid(NULLIF(a.grantee, 0)), 'PUBLIC') AS grantee,
+	a.privilege_type,
+	a.is_grantable
+FROM pg_default_acl d
+LEFT JOIN pg_namespace n ON n.oid = d.defaclnamespace
+CROSS JOIN LATERAL aclexplode(d.defaclacl) AS a
+ORDER BY for_role, schema_name, object_kind, grantee, a.privilege_type, a.is_grantable`,
+		ResultKind:     ResultRowset,
+		RetentionClass: RetentionLong,
+		Timeout:        10 * time.Second,
+		Cadence:        Cadence6h,
+	})
+}

--- a/specifications/collectors/collector-inventory.json
+++ b/specifications/collectors/collector-inventory.json
@@ -29,6 +29,10 @@
       "name": "database_sizes_v1"
     },
     {
+      "category": "security",
+      "name": "default_privileges_v1"
+    },
+    {
       "category": "server",
       "name": "extension_inventory_v1"
     },
@@ -75,6 +79,10 @@
     {
       "category": "activity",
       "name": "long_running_txns_v1"
+    },
+    {
+      "category": "security",
+      "name": "object_privileges_v1"
     },
     {
       "category": "schema",

--- a/specifications/collectors/default_privileges_v1.md
+++ b/specifications/collectors/default_privileges_v1.md
@@ -1,0 +1,79 @@
+# default_privileges_v1 — Collector Specification
+
+Status: ACTIVE
+
+## Purpose
+
+Enumerate the **default** access privileges (`ALTER DEFAULT PRIVILEGES`
+state) that FUTURE objects will inherit, so a downstream security-posture
+analysis (Analyzer #1757) can reason about grants that do not yet exist as
+concrete object ACLs but will be applied to every object a role creates —
+a common vector for silently re-introducing over-broad (`PUBLIC`) grants
+(#363). Complements `object_privileges_v1`, which carries the ACLs on
+objects that already exist.
+
+## Catalog source
+
+- `pg_default_acl` — `defaclrole` (the role whose future objects are
+  affected), `defaclnamespace` (schema scope, 0 = global), `defaclobjtype`
+  (object class the default applies to), `defaclacl` (the `aclitem[]`)
+- `aclexplode()` normalises `defaclacl` into one row per grant;
+  `pg_get_userbyid()` resolves grantee OIDs to role names
+
+`pg_default_acl` is empty until someone runs `ALTER DEFAULT PRIVILEGES`, so
+this collector emits rows only when default privileges have been
+customised.
+
+## Output columns
+
+| Column | Type | Description |
+|---|---|---|
+| for_role | text | Role whose newly-created objects inherit the default (`defaclrole`) |
+| schema_name | text | Schema the default is scoped to, or empty string for a global (non-schema) default |
+| object_kind | text | Object class the default applies to: `table`, `sequence`, `function`, `type`, or `schema` |
+| grantee | text | Role granted the default privilege, or the literal `PUBLIC` (grantee OID 0) |
+| privilege_type | text | Privilege granted (e.g. `SELECT`, `USAGE`, `EXECUTE`) |
+| is_grantable | boolean | Whether the grantee may re-grant the privilege (`WITH GRANT OPTION`) |
+
+## Scope filter
+
+None beyond `pg_default_acl`'s own contents — every default-ACL entry is
+reported. `defaclnamespace = 0` (global default) is rendered as an empty
+`schema_name`.
+
+## Invariants
+
+- Deterministic ordering: `ORDER BY for_role, schema_name, object_kind,
+  grantee, privilege_type, is_grantable`.
+- Stable output column order.
+- Read-only, passes linter (no side-effecting keyword or function).
+- `PUBLIC` is rendered as the literal string `PUBLIC`.
+- Emits zero rows on a database with no `ALTER DEFAULT PRIVILEGES` — a
+  legitimate empty result, not an error.
+
+## Failure Conditions
+
+- FC-01: Permission denied reading `pg_default_acl` (unusual — it is
+  world-readable) → standard collector error path.
+
+## Configuration
+
+- Category: security
+- Cadence: 6h (Cadence6h)
+- Retention: RetentionLong
+- Min PG version: 14 (all supported majors)
+- Requires extension: none
+- Semantics: snapshot
+- Enabled by default: yes
+
+## Sensitivity
+
+Low. Only catalog privilege *metadata* is read — no object data. Role
+names are the same class of data already emitted by `login_roles_v1` and
+are visible to every connected role, so no redaction is applied.
+
+## Analyzer requirements unblocked
+
+- **`broad-or-public-grants` finding (Analyzer #1757)** — the default-ACL
+  half of the over-broad-grant analysis: catches defaults that will grant
+  future objects to `PUBLIC` or a broad role.

--- a/specifications/collectors/object_privileges_v1.md
+++ b/specifications/collectors/object_privileges_v1.md
@@ -1,0 +1,87 @@
+# object_privileges_v1 — Collector Specification
+
+Status: ACTIVE
+
+## Purpose
+
+Enumerate the actual object-level access privileges (ACLs) granted on
+user objects, so a downstream security-posture analysis (Analyzer #1757)
+can flag **over-broad privileges** — grants to `PUBLIC`, or broad
+privileges on the `public` schema — which is a common misconfiguration.
+`login_roles_v1` / `pg_role_capabilities_v1` describe role *capabilities*;
+this collector adds the object *grants* that were previously unobserved
+(#363).
+
+## Catalog source
+
+- `pg_class.relacl` — tables, partitioned tables, views, materialized
+  views, sequences, foreign tables
+- `pg_namespace.nspacl` — schema-level grants (the `public`-schema case)
+- `pg_proc.proacl` — function/procedure `EXECUTE` grants
+- `aclexplode()` normalises each `aclitem[]` array into one row per grant;
+  `pg_get_userbyid()` resolves grantee/grantor OIDs to role names
+
+A `NULL` acl means "owner default, no explicit grants" and yields no rows
+— the presence of an explicit row for a broad grantee (`PUBLIC` / a broad
+role) is exactly the signal the consumer needs.
+
+## Output columns
+
+| Column | Type | Description |
+|---|---|---|
+| object_kind | text | `table`, `partitioned_table`, `view`, `materialized_view`, `sequence`, `foreign_table`, `schema`, or `function` |
+| schema_name | text | Schema of the object (the schema name itself for `object_kind = schema`) |
+| object_name | text | Object name (the schema name for `object_kind = schema`) |
+| grantee | text | Role granted the privilege, or the literal `PUBLIC` (grantee OID 0) |
+| privilege_type | text | Privilege granted (e.g. `SELECT`, `INSERT`, `USAGE`, `CREATE`, `EXECUTE`) |
+| is_grantable | boolean | Whether the grantee may re-grant the privilege (`WITH GRANT OPTION`) |
+| grantor | text | Role that granted the privilege |
+
+## Scope filter
+
+- Object relkinds `r`, `p`, `v`, `m`, `S`, `f` with a non-NULL `relacl`;
+  all schemas with a non-NULL `nspacl`; all functions with a non-NULL
+  `proacl`.
+- System schemas excluded: `pg_catalog`, `information_schema`, `pg_toast`,
+  and any `pg_temp_%` / `pg_toast_temp_%`.
+
+## Invariants
+
+- Deterministic ordering: `ORDER BY object_kind, schema_name,
+  object_name, grantee, privilege_type, is_grantable`.
+- Stable output column order.
+- Read-only, passes linter (no side-effecting keyword or function).
+- `PUBLIC` is rendered as the literal string `PUBLIC`, never a NULL or
+  empty grantee, so "granted to PUBLIC" is unambiguous.
+- Emits at least the `public`-schema default grants on any database
+  (`nspacl` is non-NULL by default on every supported major), so the
+  collector is never vacuously empty.
+
+## Failure Conditions
+
+- FC-01: Permission denied reading a catalog (unusual — `pg_class`,
+  `pg_namespace`, `pg_proc` are world-readable) → standard collector
+  error path.
+
+## Configuration
+
+- Category: security
+- Cadence: 6h (Cadence6h)
+- Retention: RetentionLong
+- Min PG version: 14 (all supported majors; `aclexplode` predates them)
+- Requires extension: none
+- Semantics: snapshot
+- Enabled by default: yes
+
+## Sensitivity
+
+Low. Only catalog privilege *metadata* is read — no object data. Role
+names are the same class of data already emitted by `login_roles_v1` /
+`pg_role_capabilities_v1` and are visible to every connected role, so no
+redaction is applied.
+
+## Analyzer requirements unblocked
+
+- **`broad-or-public-grants` finding (Analyzer #1757)** — flags grants
+  to `PUBLIC` and broad privileges on the `public` schema; deferred there
+  until this collector lands.

--- a/tests/signals_collector_output_contract_columns.go
+++ b/tests/signals_collector_output_contract_columns.go
@@ -126,6 +126,7 @@ var zeroRowAllowlist = map[string]string{
 	// --- config-gated: needs a non-default server GUC ---
 	"pg_prepared_xacts_v1":   "needs a prepared transaction; max_prepared_transactions defaults to 0 so 2PC is unavailable in the matrix",
 	"pg_db_role_settings_v1": "needs an ALTER ROLE/DATABASE ... SET; the least-privilege collector role cannot ALTER, and the harness avoids mutating global (non-schema) role/database state",
+	"default_privileges_v1":  "reads pg_default_acl, which is empty until an ALTER DEFAULT PRIVILEGES is run; a freshly-seeded database has no default-privilege customization to enumerate (object_privileges_v1 covers the ACLs that exist by default)",
 
 	// --- rare catalog objects: built-in-only in a fresh cluster, not worth a bespoke fixture ---
 	"pg_operators_v1":      "emits only non-extension user-defined operators; a fresh cluster has none and none is seeded (built-ins live in pg_catalog, excluded)",


### PR DESCRIPTION
closes #363

## What

Two new `security`-category collectors carrying the actual ACLs, so a downstream security-posture analysis (Analyzer #1757) can flag **over-broad privileges** — grants to `PUBLIC`, or broad privileges on the `public` schema:

- **`object_privileges_v1`** — `aclexplode()` over `pg_class.relacl` (tables, partitioned tables, views, matviews, sequences, foreign tables), `pg_namespace.nspacl` (schemas), and `pg_proc.proacl` (functions) → one `(object_kind, schema_name, object_name, grantee, privilege_type, is_grantable, grantor)` row per grant. The `PUBLIC` pseudo-role (grantee OID 0) is rendered as the literal `PUBLIC`. Emits at least the default `public`-schema grants on any database, so it is never vacuously empty.
- **`default_privileges_v1`** — `aclexplode()` over `pg_default_acl.defaclacl` — the `ALTER DEFAULT PRIVILEGES` state future objects inherit `(for_role, schema_name, object_kind, grantee, privilege_type, is_grantable)`. Empty until customised, so it is zero-row-allowlisted in the output-contract harness.

## Why

`login_roles_v1` / `pg_role_capabilities_v1` already describe role *capabilities*, but no signal carried the object/default *grants*. Analyzer #1757 defers its `broad-or-public-grants` finding until this lands.

## Safety / sensitivity

Only catalog privilege **metadata** is read — no object data. No grant beyond the default `pg_monitor` collection role is required (`relacl`/`nspacl`/`proacl`/`pg_default_acl` + `aclexplode`/`pg_get_userbyid` are world-readable). Role names are the same non-sensitive catalog data already emitted by `login_roles_v1`, so no redaction (matches that collector).

## STDD / wiring

- Spec files `specifications/collectors/object_privileges_v1.md` + `default_privileges_v1.md` (ACTIVE, with Output-columns tables the contract harness asserts against).
- Regenerated `collector-inventory.json` (`go run ./cmd/gen-collector-inventory`).
- `docs/collectors.md` + README collector count (100 → 102).
- CHANGELOG under Added.
- `default_privileges_v1` added to the output-contract zero-row allowlist with a reason.

## Verification

- SQL validated against **live PG 16.14 / 17.10 / 18.4** (cross-major valid; `object_privileges_v1` returns rows on every major via the default public-schema grant; `default_privileges_v1` empty on a fresh DB as expected).
- Real-PG **output-contract + type-contract integration tests** pass against a non-superuser `pg_monitor` collector role: `object_privileges_v1` row + declared-column asserted, `default_privileges_v1` recorded not-exercised.
- Local preflight green: gofmt, vet, build, unit tests, docs, secrets, vuln, semgrep, osv, kube-lint, **golangci-lint (0 issues)**.