### PR TITLE
Release v1.3.0 (#373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-17
+
 ### Added
 
 - Object and default access-privilege collectors: `object_privileges_v1`
@@ -30,6 +32,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   unique flat `<instance>-t<targetID>-<timestamp>.zip` filename); a per-target
   failure is isolated and never disrupts collection. Spec: SIGNALS-R127
   (Elevarq/Signals#368).
+
+### Security
+
+- Bumped `golang.org/x/mod` to v0.40.0, clearing two HIGH advisories
+  (GO-2026-6179 / GO-2026-6180 — GOPROXY/GOSUMDB module-integrity issues).
+  `govulncheck` already reported the affected paths were not called; the
+  module version is raised to clear the alerts (#371).
 
 ## [1.2.0] - 2026-08-13
 

--- a/deploy/helm/signals/Chart.yaml
+++ b/deploy/helm/signals/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # Policy: chart `version`, `appVersion`, and `image.tag` in values.yaml
 # are kept in lockstep with the released container image. Bump all three
 # together at release time; do not float chart version independently.
-version: 1.2.0
-appVersion: "1.2.0"
+version: 1.3.0
+appVersion: "1.3.0"
 keywords:
   - postgresql
   - monitoring

--- a/deploy/helm/signals/values.yaml
+++ b/deploy/helm/signals/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "1.2.0"
+  tag: "1.3.0"
   pullPolicy: IfNotPresent
 
 # PostgreSQL target configuration. Rendered into the mounted


### PR DESCRIPTION
closes #373

Version bump + CHANGELOG so the `v1.3.0` tag can be cut (the release workflow STOPs if `CHANGELOG.md` lacks a `## [1.3.0]` entry).

Minor bump (new collectors under Added since v1.2.0).

## Changes

- `deploy/helm/signals/Chart.yaml` `version` + `appVersion` 1.2.0 → 1.3.0
- `deploy/helm/signals/values.yaml` image `tag` 1.2.0 → 1.3.0
- `CHANGELOG.md` `## [Unreleased]` → dated `## [1.3.0] - 2026-08-17`

## Included since v1.2.0

- **Added** — `object_privileges_v1` + `default_privileges_v1` privilege collectors (#363).
- **Fixed** — scheduled auto-export writes one ZIP per database, not a combined archive (#350 / #368).
- **Security** — `golang.org/x/mod` → v0.40.0, clearing GO-2026-6179 / GO-2026-6180 (#371).

## Verification

- Release-gate simulation: `grep "## \[1.3.0\]" CHANGELOG.md` passes.
- `helm lint deploy/helm/signals` clean; no stray `1.2.0` in the chart.

**The `v1.3.0` tag itself is a human gate** — cut it after this merges to main (`git tag v1.3.0 <sha> && git push origin v1.3.0`), never before.