### PR TITLE
Marketplace: canonical RestrictDeliveryOptions template (#375)

### DIFF
--- a/docs/marketplace/catalog-api/06-restrict-delivery.json
+++ b/docs/marketplace/catalog-api/06-restrict-delivery.json
@@ -1,0 +1,15 @@
+{
+  "Catalog": "AWSMarketplace",
+  "ChangeSet": [
+    {
+      "ChangeType": "RestrictDeliveryOptions",
+      "Entity": {
+        "Type": "ContainerProduct@1.0",
+        "Identifier": "${PRODUCT_ID}"
+      },
+      "DetailsDocument": {
+        "DeliveryOptionIds": ["${DELIVERY_OPTION_ID}"]
+      }
+    }
+  ]
+}

--- a/docs/marketplace/catalog-api/README.md
+++ b/docs/marketplace/catalog-api/README.md
@@ -45,6 +45,35 @@ Once the listing is live, extra delivery options can be added — each reuses th
 | EKS add-on, #236 | `AddDeliveryOptions` (`05-add-eks-addon-delivery.json`) | `EksAddOnDeliveryOptionDetails` | Additive; reuses the same image **and** chart as the Helm option. `AddOnName: signals`, `AddOnType: observability`, `Namespace: signals` are **immutable across all future versions** — do not change once published (`INCOMPATIBLE_ADDON_*`). Only **one** add-on option per version. `K8S_VERSIONS` must list only tested EKS versions. Unlike Helm/container options, the add-on option is **not** auto-Public — publishing it is a separate visibility step. See `specifications/marketplace-eks-addon-delivery.md`. |
 | AMI / EC2 Image Builder, #235 | **separate `AmiProduct@1.0` product** (not a delivery option on this container product) | — | **Groundwork only**, demand-gated. The reusable EC2 Image Builder component lives in `deploy/aws/imagebuilder/` (`specifications/marketplace-ami-image-builder.md`); the live AMI product + its onboarding/review are deferred until real EC2-baked-deployment demand. No runnable AMI change-set is committed. |
 
+### Version supersession — retiring an old delivery option (`06-restrict-delivery.json`)
+
+MP ECR tags are immutable and versions accumulate, so each release publishes a
+new delivery option beside the old ones. Once the new version's option is
+**Public**, retire the superseded one with `RestrictDeliveryOptions`
+(`06-restrict-delivery.json`):
+
+```sh
+PRODUCT_ID=prod-7tz6zxncwjmw4 DELIVERY_OPTION_ID=<uuid> \
+  scripts/marketplace-changeset.sh docs/marketplace/catalog-api/06-restrict-delivery.json
+```
+
+Find the delivery option id (and confirm it is `Public`) with `describe-entity`:
+
+```sh
+aws marketplace-catalog describe-entity --catalog AWSMarketplace \
+  --entity-id "$PRODUCT_ID" --region us-east-1 --query 'Details' --output text \
+  | jq '.Versions[] | {VersionTitle} + (.DeliveryOptions[] | {Id,Type,Visibility})'
+```
+
+Rules:
+
+- **Only `Public` options can be restricted.** Batching a `Limited`/`Restricted`
+  option fails `INVALID_DELIVERY_OPTIONS_STATUS` ("Provide delivery options in
+  the public state"). Limited EKS-add-on options were never auto-Public, so they
+  are **not** retired this way — they are already non-buyer-facing.
+- **Retire only AFTER the superseding version is Public**, never before — a
+  restrict-then-add ordering briefly leaves the listing with no public option.
+
 Notes on the ordering, all verified on the pgAgroal launch:
 
 1. **`UpdateInformation` requires all core fields in one call** and works on a

--- a/scripts/marketplace-changeset.sh
+++ b/scripts/marketplace-changeset.sh
@@ -45,6 +45,18 @@
 #   # AddOnName/AddOnType/Namespace in the template are IMMUTABLE across versions
 #   # (signals / observability / signals) — do not change once published.
 #
+#   # For 06-restrict-delivery.json (RETIRE a superseded delivery option once a
+#   # newer version is Public), export the product id and the delivery option id
+#   # to restrict. RestrictDeliveryOptions accepts ONLY options in the Public
+#   # state (a Limited/Restricted one fails INVALID_DELIVERY_OPTIONS_STATUS), and
+#   # must run AFTER the superseding version is Public so the listing is never
+#   # left without a public option. Find the id with describe-entity:
+#   #   aws marketplace-catalog describe-entity --catalog AWSMarketplace \
+#   #     --entity-id $PRODUCT_ID --query 'Details' --output text | \
+#   #     jq '.Versions[].DeliveryOptions[] | {Id,Type,Visibility}'
+#   PRODUCT_ID=prod-xxxx DELIVERY_OPTION_ID=<uuid> \
+#     scripts/marketplace-changeset.sh docs/marketplace/catalog-api/06-restrict-delivery.json
+#
 # Env: AWS_PROFILE (default elevarq), AWS_REGION (default us-east-1).
 # Requires: aws, jq, envsubst (gettext).
 


### PR DESCRIPTION
closes #375

Adds the missing retire step to the Catalog API toolkit so superseding a version does not require an ad-hoc `aws marketplace-catalog start-change-set` call.

- **`docs/marketplace/catalog-api/06-restrict-delivery.json`** — a `RestrictDeliveryOptions` change-set parameterised by `${PRODUCT_ID}` + `${DELIVERY_OPTION_ID}`, run through the existing `scripts/marketplace-changeset.sh`.
- Usage block in the script header + a "Version supersession" section in `catalog-api/README.md`, including the `describe-entity` one-liner to find the delivery option id.

Documents the two hard rules: `RestrictDeliveryOptions` accepts **only Public** options (a Limited/Restricted one fails `INVALID_DELIVERY_OPTIONS_STATUS`), and it must run **only after** the superseding version is Public.

Validated: template renders to valid JSON through the script's envsubst/ASCII/JSON checks; `bash -n` + docs check clean. First real use: retiring Signals 1.2.0 once v1.3.0 is Public.