### PR TITLE
Control Plane template: require verify-full/verify-ca TLS (fix prod crash-loop)

### DIFF
--- a/deploy/controlplane/signals/LISTING.md
+++ b/deploy/controlplane/signals/LISTING.md
@@ -43,12 +43,13 @@ download snapshots over a token-protected HTTP API.
 
 - An existing PostgreSQL reachable from the GVC.
 - A read-only role: `GRANT pg_monitor TO signals;` + `CONNECT` on the database.
+- A CA bundle for TLS (`verify-full`) — managed PostgreSQL providers publish one.
 - An API bearer token (`openssl rand -base64 32`).
 
 ## Security & privacy
 
 - Non-root (UID/GID 10001), all caps dropped, no privilege escalation.
-- TLS to PostgreSQL (`require`/`verify-ca`/`verify-full`); CA bundle supported.
+- Verified TLS to PostgreSQL (`verify-full`/`verify-ca` with a CA bundle).
 - Credentials held in Control Plane secrets, revealed only to the Signals
   identity — never baked into the image.
 - No outbound data; snapshots stay on the workload volume until you fetch them.

--- a/deploy/controlplane/signals/versions/1.0.0/README.md
+++ b/deploy/controlplane/signals/versions/1.0.0/README.md
@@ -45,6 +45,7 @@ The image is pinned by immutable digest
 | `postgres.host` | PostgreSQL hostname/IP reachable from the GVC |
 | `postgres.user` | The read-only role above |
 | `postgres.password` | Password for that role (stored in a Control Plane secret) |
+| `postgres.caCert` | PEM CA bundle to verify the server cert (TLS is `verify-full` in prod). Managed PostgreSQL: use the provider bundle, e.g. [Amazon RDS](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) |
 | `api.token` | API bearer token, `openssl rand -base64 32` (≥ 32 chars) |
 
 ## Common optional inputs
@@ -53,8 +54,7 @@ The image is pinned by immutable digest
 |-------|---------|-------------|
 | `postgres.port` | `5432` | |
 | `postgres.database` | `postgres` | Database to connect to |
-| `postgres.sslMode` | `require` | `require` \| `verify-ca` \| `verify-full` (`disable`/`prefer` are rejected in prod) |
-| `postgres.caCert` | — | PEM CA bundle, **required** for `verify-ca`/`verify-full` |
+| `postgres.sslMode` | `verify-full` | `verify-full` \| `verify-ca` (weaker modes are rejected by Signals in prod) |
 | `collection.pollInterval` | `5m` | Time between collection cycles |
 | `collection.retentionDays` | `30` | Snapshot retention window |
 | `logLevel` | `info` | `debug` \| `info` \| `warn` \| `error` |

--- a/deploy/controlplane/signals/versions/1.0.0/templates/_helpers.tpl
+++ b/deploy/controlplane/signals/versions/1.0.0/templates/_helpers.tpl
@@ -63,15 +63,14 @@ Validation — fail fast on missing/invalid inputs before any resource renders.
 {{- if not .Values.api.token -}}
 {{- fail "api.token is required — generate with `openssl rand -base64 32` (>= 32 chars)" -}}
 {{- end -}}
-{{- $validSsl := list "disable" "prefer" "require" "verify-ca" "verify-full" -}}
+{{- /* The workload runs with SIGNALS_ENV=prod, which requires a verifying TLS
+       mode with a CA cert. Signals rejects require/prefer/disable in prod. */ -}}
+{{- $validSsl := list "verify-ca" "verify-full" -}}
 {{- if not (has .Values.postgres.sslMode $validSsl) -}}
-{{- fail (printf "postgres.sslMode '%s' is invalid. Must be one of: %s" .Values.postgres.sslMode (join ", " $validSsl)) -}}
+{{- fail (printf "postgres.sslMode '%s' is not allowed: the workload runs with SIGNALS_ENV=prod, which requires verify-ca or verify-full (require/prefer/disable are rejected by Signals in prod)." .Values.postgres.sslMode) -}}
 {{- end -}}
-{{- if or (eq .Values.postgres.sslMode "disable") (eq .Values.postgres.sslMode "prefer") -}}
-{{- fail "postgres.sslMode 'disable'/'prefer' is not allowed: the workload runs with SIGNALS_ENV=prod, which requires TLS. Use require, verify-ca or verify-full." -}}
-{{- end -}}
-{{- if and (or (eq .Values.postgres.sslMode "verify-ca") (eq .Values.postgres.sslMode "verify-full")) (not .Values.postgres.caCert) -}}
-{{- fail (printf "postgres.caCert (PEM CA bundle) is required when postgres.sslMode is '%s'" .Values.postgres.sslMode) -}}
+{{- if not .Values.postgres.caCert -}}
+{{- fail (printf "postgres.caCert (PEM CA bundle) is required for sslMode '%s'. For managed PostgreSQL use the provider bundle (e.g. Amazon RDS: https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem)." .Values.postgres.sslMode) -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/controlplane/signals/versions/1.0.0/values.yaml
+++ b/deploy/controlplane/signals/versions/1.0.0/values.yaml
@@ -34,11 +34,13 @@ postgres:
   database: "postgres"   # database to connect to
   user: ""               # REQUIRED — read-only role (see README: minimum grants)
   password: ""           # REQUIRED — stored in a Control Plane dictionary secret
-  # TLS to PostgreSQL. Recommended: require (default) or verify-full.
-  # One of: disable | prefer | require | verify-ca | verify-full
-  # `disable` / `prefer` are rejected because the workload runs with SIGNALS_ENV=prod.
-  sslMode: "require"
-  # PEM CA bundle — REQUIRED only for sslMode verify-ca / verify-full.
+  # TLS to PostgreSQL. The workload runs with SIGNALS_ENV=prod, which requires a
+  # verifying mode with a CA cert — `verify-full` (default) or `verify-ca`.
+  # Weaker modes (require / prefer / disable) are rejected by Signals in prod.
+  sslMode: "verify-full"
+  # PEM CA bundle — REQUIRED (verify-full/verify-ca need it to verify the server
+  # certificate). For managed PostgreSQL use the provider bundle, e.g. Amazon RDS:
+  # https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
   # Stored in a Control Plane opaque secret and mounted read-only into the workload.
   caCert: ""
 


### PR DESCRIPTION
Follow-up to #378, found by the live Control Plane test-install against staging RDS.

The catalog workload runs with `SIGNALS_ENV=prod`, under which Signals rejects `sslmode=require/prefer/disable` and requires `verify-ca`/`verify-full` **with a CA cert** (`internal/config/config.go:1087`). The merged template defaulted `postgres.sslMode: require` and only rejected `disable`/`prefer`, so a default install crash-looped on config validation:

```
signals: TLS policy: target[0] (default): sslmode=require is not allowed in prod; set sslmode=verify-full and provide sslrootcert_file
```

## Changes
- `values.yaml`: default `sslMode: verify-full`; `caCert` documented as required (with the RDS bundle URL).
- `_helpers.tpl`: allow only `verify-ca`/`verify-full`; require `caCert`; clear fail-fast messages.
- `README.md` / `LISTING.md`: corrected TLS guidance; `caCert` is a required input.

## Validation
- `helm lint` 0 failures.
- Negative: default `verify-full` without `caCert` fails; `sslMode=require` rejected.
- Positive: `verify-full` + CA renders the opaque CA secret, `SIGNALS_TARGET_SSLMODE=verify-full`, and the CA mount.
- **Live**: redeployed into the `elevarq` GVC against staging RDS with `verify-full` + the RDS global CA bundle → workload ready, `snapshot collected`, `collection_completed status=success`.

`v1.0.0` is not yet published to `controlplane-com/templates`, so the version is edited in place.

closes #379