### PR TITLE
Control Plane template: drop snapshot ZIPs to the volume by default

### DIFF
--- a/deploy/controlplane/signals/versions/1.0.0/README.md
+++ b/deploy/controlplane/signals/versions/1.0.0/README.md
@@ -59,6 +59,8 @@ The image is pinned by immutable digest
 | `collection.retentionDays` | `30` | Snapshot retention window |
 | `logLevel` | `info` | `debug` \| `info` \| `warn` \| `error` |
 | `metrics.enabled` | `false` | Prometheus `/metrics` (behind the API token) |
+| `export.onCollect` | `true` | Drop one ZIP per database into `export.dest` after each cycle (see Snapshot exports) |
+| `export.dest` | `/data/exports` | Directory for dropped ZIPs — keep it on the volume (`/data...`) |
 | `resources.cpu` / `resources.memory` | `100m` / `128Mi` | |
 | `storage.capacity` | `10` | Volume size in GiB (Control Plane minimum is 10) |
 
@@ -72,6 +74,27 @@ The image is pinned by immutable digest
 - **Trigger a collection now:** `POST /collect/now` (bearer auth).
 - **Download a snapshot:** `GET /export` (bearer auth) → a `signals-snapshot.v1` ZIP.
 - **Metrics:** `GET /metrics` (bearer auth) when `metrics.enabled=true`.
+
+## Snapshot exports
+
+Snapshots are always available two ways:
+
+- **Pull (always on):** `GET /export` (bearer) streams a `signals-snapshot.v1` ZIP.
+- **Drop to disk (`export.onCollect`, on by default):** after every collection
+  cycle Signals writes one ZIP per database into `export.dest` (default
+  `/data/exports` on the persistent volume), named
+  `<instance>-t<targetID>-<UTC>.zip`. The directory is created automatically.
+
+Retrieving dropped files: list/copy them with
+`cpln workload exec <name> --gvc <gvc> -- ls -la /data/exports`, or run a
+sidecar/second workload that mounts the same volume and syncs the directory to
+object storage.
+
+> **Files accumulate.** Dropped ZIPs are timestamped and never overwritten, and
+> Signals does not prune them (only the SQLite store honours
+> `collection.retentionDays`). Sync them out and delete, or size
+> `storage.capacity` for your cadence and retention. Set `export.onCollect=false`
+> to disable dropping and rely on `GET /export` only.
 
 ## Security model
 

--- a/deploy/controlplane/signals/versions/1.0.0/templates/_helpers.tpl
+++ b/deploy/controlplane/signals/versions/1.0.0/templates/_helpers.tpl
@@ -72,6 +72,9 @@ Validation — fail fast on missing/invalid inputs before any resource renders.
 {{- if not .Values.postgres.caCert -}}
 {{- fail (printf "postgres.caCert (PEM CA bundle) is required for sslMode '%s'. For managed PostgreSQL use the provider bundle (e.g. Amazon RDS: https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem)." .Values.postgres.sslMode) -}}
 {{- end -}}
+{{- if and .Values.export.onCollect (not .Values.export.dest) -}}
+{{- fail "export.dest is required when export.onCollect is true (use a path on the persistent volume, e.g. /data/exports)" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/deploy/controlplane/signals/versions/1.0.0/templates/workload-signals.yaml
+++ b/deploy/controlplane/signals/versions/1.0.0/templates/workload-signals.yaml
@@ -37,6 +37,13 @@ spec:
           value: {{ .Values.collection.retentionDays | quote }}
         - name: SIGNALS_METRICS_ENABLED
           value: {{ .Values.metrics.enabled | quote }}
+        {{- if .Values.export.onCollect }}
+        # Drop one ZIP per database into dest after each collection cycle.
+        - name: SIGNALS_EXPORT_ON_COLLECT
+          value: "true"
+        - name: SIGNALS_EXPORT_DEST
+          value: {{ .Values.export.dest | quote }}
+        {{- end }}
         # --- PostgreSQL target (customer-supplied external database) ---
         - name: SIGNALS_TARGET_NAME
           value: {{ .Values.postgres.name | default "default" | quote }}

--- a/deploy/controlplane/signals/versions/1.0.0/values.yaml
+++ b/deploy/controlplane/signals/versions/1.0.0/values.yaml
@@ -63,6 +63,18 @@ collection:
   pollInterval: "5m"   # time between collection cycles (e.g. 5m, 1h)
   retentionDays: 30    # days of snapshots retained in the local SQLite store
 
+# ---------------------------------------------------------------------------
+# Snapshot export. Signals always serves snapshots on demand via GET /export.
+# With onCollect enabled it ALSO drops one ZIP per database into `dest` after
+# every collection cycle (files are timestamped and accumulate — see README:
+# they are not pruned, so sync them out and/or size storage.capacity).
+# `dest` must be on the persistent volume (/data...) to survive restarts; the
+# directory is created automatically.
+# ---------------------------------------------------------------------------
+export:
+  onCollect: true
+  dest: "/data/exports"
+
 # debug | info | warn | error
 logLevel: "info"
 


### PR DESCRIPTION
Customers expect Signals to write out the snapshot ZIPs, not only serve them on demand via `GET /export`. This enables the native scheduled auto-export (#350) in the catalog template.

After each collection cycle Signals drops **one ZIP per database** into `export.dest` (default `/data/exports` on the persistent volumeset), named `<instance>-t<targetID>-<UTC>.zip`; the directory is auto-created.

## Changes
- `values.yaml`: `export.onCollect` (default `true`) + `export.dest` (`/data/exports`).
- `workload-signals.yaml`: emit `SIGNALS_EXPORT_ON_COLLECT`/`SIGNALS_EXPORT_DEST` when enabled.
- `_helpers.tpl`: require `export.dest` when `onCollect` is true.
- `README.md`: pull-vs-drop, filename pattern, retrieval (exec/`cp` or a volume-sharing sidecar), and the accumulation caveat — files are timestamped and never pruned, so sync out and delete or size `storage.capacity`; `export.onCollect=false` disables it.

## Validation
- `helm lint` 0 failures; renders the export env by default; `onCollect=false` emits none; empty `dest` fails fast.
- **Live** in the `elevarq` GVC against staging RDS: `scheduled export written files=1 dest=/data/exports`, ZIP present on the volume (`…-t1-…Z.zip`, 86 KB).

`closes #381`