### PR TITLE
Harden Signals Control Plane template — submission-CI blockers and posture (review)

### DIFF
--- a/.github/workflows/controlplane-template.yml
+++ b/.github/workflows/controlplane-template.yml
@@ -1,0 +1,32 @@
+name: Control Plane template
+
+# Validates the Control Plane Catalog template (deploy/controlplane/signals):
+# positive default render (upstream validate-charts.yml parity) plus this
+# template's fail-fast contract. Scoped to the template path so it only runs
+# when that package changes.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/controlplane/**'
+      - '.github/workflows/controlplane-template.yml'
+  pull_request:
+    paths:
+      - 'deploy/controlplane/**'
+      - '.github/workflows/controlplane-template.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  render-acceptance:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Helm version
+        run: helm version --short
+
+      - name: Chart acceptance tests (positive + negative render)
+        run: bash deploy/controlplane/signals/tests/render-acceptance.sh

--- a/deploy/controlplane/README.md
+++ b/deploy/controlplane/README.md
@@ -64,9 +64,16 @@ dependencies:
     repository: "oci://ghcr.io/controlplane-com/templates"
 ```
 
-Category vocabulary (observed in the live catalog): `observability`, `database`,
-`security`, `analytics`, `storage`, `search`, `proxy`, `secrets-management`,
-`event-streaming`, `app`, `library`. Signals uses **`observability`**.
+Category vocabulary — **examples** observed in the live catalog (not an
+exhaustive/authoritative list; confirm against current templates before relying
+on one): `observability`, `database`, `security`, `analytics`, `storage`,
+`search`, `proxy`, `secrets-management`, `event-streaming`, `app`, `library`.
+Signals uses **`observability`**.
+
+> `LISTING.md` and this runbook are **internal** artifacts — the upstream catalog
+> has no `LISTING.md` convention and its workflow does not consume one. Keep listing
+> copy here for our own reference; hand it to Control Plane only if they request it
+> during review. Only `<product>/icon.png` + `versions/<semver>/…` is submitted.
 
 ---
 

--- a/deploy/controlplane/signals/LISTING.md
+++ b/deploy/controlplane/signals/LISTING.md
@@ -8,16 +8,17 @@ Source of truth for the catalog-facing text. Keep in sync with the live listing.
 - **Price:** Free (open source, BSD-3-Clause)
 - **One-line description:** Lightweight, read-only PostgreSQL diagnostic and
   telemetry collector — connects to your existing PostgreSQL, collects
-  statistics, and stores portable snapshots. No data egress, no AI.
+  statistics, and stores portable snapshots locally. No AI.
 
 ## Fuller description
 
 Elevarq Signals is a read-only PostgreSQL diagnostic collector. It connects to a
 PostgreSQL database you already run, gathers statistics and metadata with an
 approved read-only SQL set (102 queries), and writes portable `signals-snapshot`
-ZIP archives to a local volume. Everything stays inside the workload: there is no
-outbound telemetry, no analytics upload, and no AI or LLM inside Signals — it is
-the collection layer, not the Elevarq Analyzer.
+ZIP archives to a local volume. Signals initiates no outbound telemetry and no
+automatic upload, and there is no AI or LLM inside Signals — it is the collection
+layer, not the Elevarq Analyzer. Snapshots stay on the workload until you retrieve
+them.
 
 Read-only is enforced in three independent layers: static SQL linting, a
 session-level `default_transaction_read_only=on`, and a per-query
@@ -25,19 +26,20 @@ session-level `default_transaction_read_only=on`, and a per-query
 replication, or `BYPASSRLS` role — a plain `pg_monitor` grant is all it needs.
 
 Deployed here as a single, stateful Control Plane workload, Signals runs as a
-non-root user with all capabilities dropped, connects to PostgreSQL over TLS, and
-keeps its snapshot history on a persistent volume. Trigger collections and
-download snapshots over a token-protected HTTP API.
+non-root user under Control Plane's restricted container capabilities, connects to
+PostgreSQL over TLS, and keeps its snapshot history on a persistent volume. Trigger
+collections and download snapshots over a token-protected HTTP API.
 
 ## Main capabilities
 
-- Read-only collection from any PostgreSQL 12+ (and TimescaleDB), enforced at
+- Read-only collection from PostgreSQL 14–18 (and TimescaleDB), enforced at
   three layers.
 - Portable `signals-snapshot.v1` ZIP exports, on a schedule or on demand.
 - Token-protected HTTP API for status, on-demand collection, and export.
 - Optional Prometheus operational metrics (never collected database data).
-- Multi-target support; per-target sensitivity profiles.
-- No data egress, no phone-home, no AI — safe for regulated/air-gapped estates.
+- Single target per deployment; opt-out for collectors that can include query
+  text or stored SQL bodies.
+- No phone-home or automatic export, no AI — snapshots stay local until retrieved.
 
 ## Requirements
 
@@ -48,15 +50,17 @@ download snapshots over a token-protected HTTP API.
 
 ## Security & privacy
 
-- Non-root (UID/GID 10001), all caps dropped, no privilege escalation.
+- Non-root (UID/GID 10001) under Control Plane's restricted container
+  capabilities, no privilege escalation.
 - Verified TLS to PostgreSQL (`verify-full`/`verify-ca` with a CA bundle).
 - Credentials held in Control Plane secrets, revealed only to the Signals
   identity — never baked into the image.
-- No outbound data; snapshots stay on the workload volume until you fetch them.
+- Signals initiates no automatic export; snapshots stay on the workload volume
+  until you retrieve them.
 
 ## PostgreSQL compatibility
 
-PostgreSQL 12–17 and TimescaleDB. Managed services supported (Amazon RDS/Aurora,
+PostgreSQL 14–18 and TimescaleDB. Managed services supported (Amazon RDS/Aurora,
 Azure Database for PostgreSQL, Google Cloud SQL) — Signals needs only network
 reachability and a read-only role.
 

--- a/deploy/controlplane/signals/tests/render-acceptance.sh
+++ b/deploy/controlplane/signals/tests/render-acceptance.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Acceptance tests for the Signals Control Plane Catalog template.
+#
+# Traceability (spec rule -> case). These mirror the upstream
+# controlplane-com/templates validate-charts.yml gate plus this template's own
+# fail-fast contract (deploy/controlplane/signals/versions/1.0.0/templates/_helpers.tpl):
+#
+#   CP-TMPL-R001  chart renders with DEFAULT values + a dummy GVC (upstream CI parity)
+#   CP-TMPL-R002  rendered output carries the required cpln/marketplace* tags
+#   CP-TMPL-R003  Chart.yaml description is <= 15 words
+#   CP-TMPL-R004  workload image is the exact reviewed repository@digest (no mutable tag)
+#   CP-TMPL-R005  image.repository / image.digest cannot be changed
+#   CP-TMPL-R006  required inputs (host/user/password/api.token/caCert) fail-fast when empty
+#   CP-TMPL-R007  prod TLS: only verify-ca/verify-full accepted
+#   CP-TMPL-R008  api.token must be >= 32 chars
+#   CP-TMPL-R009  logLevel / firewall.inboundAllowType / storage.performanceClass enums
+#   CP-TMPL-R010  postgres.port range; storage.capacity range; high-throughput-ssd >= 200 GiB
+#   CP-TMPL-R011  export.dest must be under /data
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/versions/1.0.0"
+GVC="--set global.cpln.gvc=validation-gvc"
+EXPECTED_DIGEST="sha256:76aeda85f41ee716797535824c62dee72b5524d98267deacf589983b9a6feadc"
+fails=0
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n' "$1"; fails=$((fails + 1)); }
+
+# shellcheck disable=SC2086  # $GVC is intentionally word-split into helm flags
+render() { helm template validation "$CHART_DIR" $GVC "$@" 2>&1; }
+
+echo "== deps =="
+helm dependency build "$CHART_DIR" >/dev/null 2>&1 || { echo "helm dependency build failed"; exit 1; }
+
+echo "== positive (CP-TMPL-R001..R004) =="
+if OUT="$(render)"; then
+  pass "R001 renders with defaults + dummy gvc"
+  for t in 'cpln/marketplace: "true"' 'cpln/marketplace-template:' 'cpln/marketplace-template-version:' 'cpln/marketplace-gvc:'; do
+    echo "$OUT" | grep -q "$t" && pass "R002 tag present: $t" || fail "R002 tag missing: $t"
+  done
+  echo "$OUT" | grep -qE "image: ghcr.io/elevarq/signals@${EXPECTED_DIGEST}\b" \
+    && pass "R004 image is reviewed repository@digest" || fail "R004 image not digest-pinned to the reviewed digest"
+else
+  fail "R001 default render failed:"; echo "$OUT" | tail -3
+fi
+
+DESC="$(sed -n 's/^description:[[:space:]]*//p' "$CHART_DIR/Chart.yaml" | head -1)"
+WORDS="$(echo "$DESC" | tr ' ' '\n' | grep -cvE '^$|^(—|–|-)$')"
+[ "$WORDS" -le 15 ] && pass "R003 description is $WORDS words (<=15)" || fail "R003 description is $WORDS words (>15)"
+
+echo "== negative (each MUST fail to render) =="
+neg() { # <rule> <label> <helm args...>
+  local rule="$1" label="$2"; shift 2
+  if render "$@" >/dev/null 2>&1; then fail "$rule rendered but should have failed: $label"; else pass "$rule rejects $label"; fi
+}
+neg R005 "changed image.repository" --set image.repository=evil/signals
+neg R005 "changed image.digest"     --set image.digest=sha256:dead
+neg R006 "empty postgres.host"      --set-string postgres.host=
+neg R006 "empty postgres.password"  --set-string postgres.password=
+neg R006 "empty postgres.caCert"    --set-string postgres.caCert=
+neg R006 "empty api.token"          --set-string api.token=
+neg R007 "sslMode=require"          --set postgres.sslMode=require
+neg R008 "api.token < 32"           --set-string api.token=short
+neg R009 "logLevel=trace"           --set logLevel=trace
+neg R009 "inboundAllowType=public"  --set firewall.internal.inboundAllowType=public
+neg R009 "bad performanceClass"     --set storage.performanceClass=nvme
+neg R010 "port out of range"        --set postgres.port=70000
+neg R010 "capacity < 10"            --set storage.capacity=9
+neg R010 "high-throughput + 10GiB"  --set storage.performanceClass=high-throughput-ssd
+neg R011 "export.dest outside /data" --set export.dest=/tmp/exports
+
+echo
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$fails FAILED"; exit 1; fi

--- a/deploy/controlplane/signals/versions/1.0.0/Chart.yaml
+++ b/deploy/controlplane/signals/versions/1.0.0/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signals
-description: Elevarq Signals — lightweight, read-only PostgreSQL diagnostic and telemetry collector. Connects to an existing PostgreSQL you supply, collects statistics with an approved read-only SQL set, and stores portable snapshots locally. No data egress, no AI, no phone-home.
+description: Lightweight, read-only PostgreSQL diagnostic collector that stores portable snapshots locally.
 type: application
 version: 1.0.0
 appVersion: "1.3.0"

--- a/deploy/controlplane/signals/versions/1.0.0/README.md
+++ b/deploy/controlplane/signals/versions/1.0.0/README.md
@@ -3,8 +3,8 @@
 A lightweight, **read-only PostgreSQL diagnostic and telemetry collector**. Signals
 connects to an existing PostgreSQL database that *you* supply, collects statistics
 using an approved read-only SQL set, and stores portable snapshots on a local
-volume. No data ever leaves the workload — there is no AI, no analytics upload,
-and no phone-home.
+volume. Signals initiates no telemetry and no automatic upload; snapshots stay on
+the workload until you retrieve them. There is no AI in Signals.
 
 > Signals is the **collection layer** only. It is not the Elevarq Analyzer and
 > performs no AI analysis. Snapshots are collected locally and downloaded via the
@@ -17,7 +17,7 @@ and no phone-home.
 | `workload` (stateful, single replica) | The Signals collector daemon |
 | `volumeset` | Persistent `/data` store for the SQLite snapshot database |
 | `secret` (dictionary) | PostgreSQL password + API bearer token |
-| `secret` (opaque, optional) | PEM CA bundle for `verify-ca`/`verify-full` TLS |
+| `secret` (opaque, required) | PEM CA bundle for `verify-ca`/`verify-full` TLS |
 | `identity` + `policy` | Least-privilege `reveal` access to the secrets above |
 
 The image is pinned by immutable digest
@@ -57,12 +57,15 @@ The image is pinned by immutable digest
 | `postgres.sslMode` | `verify-full` | `verify-full` \| `verify-ca` (weaker modes are rejected by Signals in prod) |
 | `collection.pollInterval` | `5m` | Time between collection cycles |
 | `collection.retentionDays` | `30` | Snapshot retention window |
+| `collection.highSensitivityCollectorsEnabled` | `true` | Set `false` to exclude collectors that can capture live query text (`pg_stat_activity`) and object definitions (views/triggers/function bodies) from snapshots |
 | `logLevel` | `info` | `debug` \| `info` \| `warn` \| `error` |
 | `metrics.enabled` | `false` | Prometheus `/metrics` (behind the API token) |
 | `export.onCollect` | `true` | Drop one ZIP per database into `export.dest` after each cycle (see Snapshot exports) |
-| `export.dest` | `/data/exports` | Directory for dropped ZIPs — keep it on the volume (`/data...`) |
+| `export.dest` | `/data/exports` | Directory for dropped ZIPs — must be on the volume (`/data...`) |
 | `resources.cpu` / `resources.memory` | `100m` / `128Mi` | |
-| `storage.capacity` | `10` | Volume size in GiB (Control Plane minimum is 10) |
+| `storage.capacity` | `10` | Volume size in GiB (≥ 10; ≥ 200 for `high-throughput-ssd`) |
+| `storage.performanceClass` | `general-purpose-ssd` | `general-purpose-ssd` \| `high-throughput-ssd` |
+| `firewall.external.outboundAllowCIDR` | `[0.0.0.0/0]` | Egress to PostgreSQL. Hostname firewall rules can't reach 5432, so this is a CIDR; narrow it to your DB if it has a stable IP |
 
 ## Verifying it works
 
@@ -100,8 +103,9 @@ object storage.
 
 - Read-only enforced in three layers: static SQL linting, session
   `default_transaction_read_only=on`, and per-query `BEGIN READ ONLY`.
-- Runs as non-root (UID/GID 10001), all capabilities dropped, no privilege
-  escalation, TLS to PostgreSQL, and no outbound telemetry.
+- Runs as non-root (UID/GID 10001) under Control Plane's restricted container
+  capabilities, no privilege escalation, TLS to PostgreSQL. Signals initiates no
+  outbound telemetry (the workload's egress firewall still governs connectivity).
 - Credentials are held in Control Plane secrets and revealed only to the
   Signals identity via the bundled policy — never baked into the image or
   committed in plaintext.

--- a/deploy/controlplane/signals/versions/1.0.0/templates/_helpers.tpl
+++ b/deploy/controlplane/signals/versions/1.0.0/templates/_helpers.tpl
@@ -30,16 +30,15 @@ across multiple installs in the same GVC.
 
 {{/*
 ================================================================================
-Image reference — digest-pinned when a digest is provided (immutable), else the
-human-readable tag.
+Reviewed production image — mandatory and immutable. The renderer only ever
+emits repository@digest; there is no mutable-tag fallback. The values are pinned
+to the exact reviewed image and enforced in signals.validateConfig.
 ================================================================================
 */}}
+{{- define "signals.expectedRepository" -}}ghcr.io/elevarq/signals{{- end -}}
+{{- define "signals.expectedDigest" -}}sha256:76aeda85f41ee716797535824c62dee72b5524d98267deacf589983b9a6feadc{{- end -}}
 {{- define "signals.image" -}}
-{{- if .Values.image.digest -}}
-{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
-{{- else -}}
-{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | toString) -}}
-{{- end -}}
+{{- printf "%s@%s" (include "signals.expectedRepository" .) (include "signals.expectedDigest" .) -}}
 {{- end -}}
 
 {{/*
@@ -48,6 +47,13 @@ Validation — fail fast on missing/invalid inputs before any resource renders.
 ================================================================================
 */}}
 {{- define "signals.validateConfig" -}}
+{{- /* The reviewed production image is mandatory and unchangeable. */ -}}
+{{- if ne .Values.image.repository (include "signals.expectedRepository" .) -}}
+{{- fail (printf "image.repository must remain %s; the reviewed production image is used unchanged" (include "signals.expectedRepository" .)) -}}
+{{- end -}}
+{{- if ne .Values.image.digest (include "signals.expectedDigest" .) -}}
+{{- fail (printf "image.digest must remain %s; mutable tags and unreviewed digests are not allowed" (include "signals.expectedDigest" .)) -}}
+{{- end -}}
 {{- if not .Values.postgres.host -}}
 {{- fail "postgres.host is required (the PostgreSQL hostname reachable from the GVC)" -}}
 {{- end -}}
@@ -74,6 +80,35 @@ Validation — fail fast on missing/invalid inputs before any resource renders.
 {{- end -}}
 {{- if and .Values.export.onCollect (not .Values.export.dest) -}}
 {{- fail "export.dest is required when export.onCollect is true (use a path on the persistent volume, e.g. /data/exports)" -}}
+{{- end -}}
+{{- if and .Values.export.onCollect (not (or (eq (clean .Values.export.dest) "/data") (hasPrefix "/data/" (clean .Values.export.dest)))) -}}
+{{- fail "export.dest must resolve to /data or a directory below /data so exports survive restarts" -}}
+{{- end -}}
+{{- if lt (len (.Values.api.token | toString)) 32 -}}
+{{- fail "api.token must be at least 32 characters (openssl rand -base64 32)" -}}
+{{- end -}}
+{{- $logLevels := list "debug" "info" "warn" "error" -}}
+{{- if not (has .Values.logLevel $logLevels) -}}
+{{- fail (printf "logLevel '%s' is invalid; use one of: %s" .Values.logLevel (join ", " $logLevels)) -}}
+{{- end -}}
+{{- $port := int .Values.postgres.port -}}
+{{- if or (lt $port 1) (gt $port 65535) -}}
+{{- fail "postgres.port must be between 1 and 65535" -}}
+{{- end -}}
+{{- $classes := list "general-purpose-ssd" "high-throughput-ssd" -}}
+{{- if not (has .Values.storage.performanceClass $classes) -}}
+{{- fail (printf "storage.performanceClass must be one of: %s" (join ", " $classes)) -}}
+{{- end -}}
+{{- $capacity := int .Values.storage.capacity -}}
+{{- if or (lt $capacity 10) (gt $capacity 65536) -}}
+{{- fail "storage.capacity must be between 10 and 65536 GiB" -}}
+{{- end -}}
+{{- if and (eq .Values.storage.performanceClass "high-throughput-ssd") (lt $capacity 200) -}}
+{{- fail "storage.performanceClass high-throughput-ssd requires storage.capacity >= 200 GiB" -}}
+{{- end -}}
+{{- $inboundTypes := list "none" "same-gvc" "same-org" "workload-list" -}}
+{{- if not (has .Values.firewall.internal.inboundAllowType $inboundTypes) -}}
+{{- fail (printf "firewall.internal.inboundAllowType must be one of: %s" (join ", " $inboundTypes)) -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/controlplane/signals/versions/1.0.0/templates/workload-signals.yaml
+++ b/deploy/controlplane/signals/versions/1.0.0/templates/workload-signals.yaml
@@ -35,6 +35,8 @@ spec:
           value: {{ .Values.collection.pollInterval | quote }}
         - name: SIGNALS_RETENTION_DAYS
           value: {{ .Values.collection.retentionDays | quote }}
+        - name: SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED
+          value: {{ .Values.collection.highSensitivityCollectorsEnabled | quote }}
         - name: SIGNALS_METRICS_ENABLED
           value: {{ .Values.metrics.enabled | quote }}
         {{- if .Values.export.onCollect }}

--- a/deploy/controlplane/signals/versions/1.0.0/values.yaml
+++ b/deploy/controlplane/signals/versions/1.0.0/values.yaml
@@ -4,16 +4,20 @@
 # Signals is a read-only PostgreSQL diagnostic collector. It connects to an
 # existing PostgreSQL database that YOU supply, collects statistics with an
 # approved read-only SQL set, and stores portable ZIP snapshots on a local
-# volume. No data leaves the workload; there is no AI and no phone-home.
+# volume. Signals initiates no telemetry and no automatic upload; snapshots stay
+# on the workload until you retrieve them. There is no AI in Signals.
 #
-# Image is pinned by digest for supply-chain integrity. The digest below is the
-# multi-arch index for ghcr.io/elevarq/signals:1.3.0 (linux/amd64 + linux/arm64,
-# cosign-signed with an attached SPDX SBOM).
+# The values below are PLACEHOLDERS so the chart renders for catalog validation.
+# You MUST override the required inputs (postgres.host/user/password, api.token,
+# postgres.caCert) — the placeholders are intentionally non-functional.
+#
+# The image is pinned by immutable digest and is enforced: the chart only deploys
+# the exact reviewed image (ghcr.io/elevarq/signals:1.3.0 multi-arch index —
+# linux/amd64 + linux/arm64, cosign-signed with an attached SPDX SBOM). Changing
+# image.repository/digest is rejected.
 image:
   repository: ghcr.io/elevarq/signals
-  tag: "1.3.0"
-  # Immutable digest of the :1.3.0 multi-arch index. When set, the workload
-  # references repository@digest and `tag` is informational only.
+  tag: "1.3.0"                 # informational only; the digest is what deploys
   digest: "sha256:76aeda85f41ee716797535824c62dee72b5524d98267deacf589983b9a6feadc"
 
 # ---------------------------------------------------------------------------
@@ -28,21 +32,22 @@ resources:
 # Signals needs only a read-only role (e.g. `GRANT pg_monitor TO signals`).
 # ---------------------------------------------------------------------------
 postgres:
-  name: "default"        # logical target name shown in snapshots
-  host: ""               # REQUIRED — PostgreSQL hostname or IP reachable from the GVC
+  name: "default"                 # logical target name shown in snapshots
+  host: "postgres.example.com"    # REQUIRED — override with your PostgreSQL host/IP
   port: 5432
-  database: "postgres"   # database to connect to
-  user: ""               # REQUIRED — read-only role (see README: minimum grants)
-  password: ""           # REQUIRED — stored in a Control Plane dictionary secret
+  database: "postgres"            # database to connect to
+  user: "signals"                 # REQUIRED — read-only role (see README: minimum grants)
+  password: "REPLACE_WITH_DB_PASSWORD"  # REQUIRED — override; stored in a Control Plane secret
   # TLS to PostgreSQL. The workload runs with SIGNALS_ENV=prod, which requires a
   # verifying mode with a CA cert — `verify-full` (default) or `verify-ca`.
   # Weaker modes (require / prefer / disable) are rejected by Signals in prod.
   sslMode: "verify-full"
   # PEM CA bundle — REQUIRED (verify-full/verify-ca need it to verify the server
-  # certificate). For managed PostgreSQL use the provider bundle, e.g. Amazon RDS:
+  # certificate). REPLACE the placeholder with the real bundle. For managed
+  # PostgreSQL use the provider bundle, e.g. Amazon RDS:
   # https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
   # Stored in a Control Plane opaque secret and mounted read-only into the workload.
-  caCert: ""
+  caCert: "REPLACE_WITH_PEM_CA_BUNDLE"
 
 # ---------------------------------------------------------------------------
 # Signals HTTP API (bearer-token protected; used to trigger collection and
@@ -51,10 +56,10 @@ postgres:
 # ---------------------------------------------------------------------------
 api:
   # REQUIRED — bearer token for the API. Must be >= 32 chars with >= 8 distinct
-  # characters (enforced by Signals in prod). Generate with:
+  # characters (enforced by Signals in prod). REPLACE the placeholder; generate:
   #   openssl rand -base64 32
   # Stored in a Control Plane dictionary secret.
-  token: ""
+  token: "REPLACE_WITH_OPENSSL_RAND_BASE64_32BYTES"
 
 # ---------------------------------------------------------------------------
 # Collection behaviour.
@@ -62,14 +67,18 @@ api:
 collection:
   pollInterval: "5m"   # time between collection cycles (e.g. 5m, 1h)
   retentionDays: 30    # days of snapshots retained in the local SQLite store
+  # High-sensitivity collectors can capture live query text (pg_stat_activity)
+  # and application object definitions (views, triggers, function bodies) when
+  # the role can read them. Set false to exclude them from snapshots.
+  highSensitivityCollectorsEnabled: true
 
 # ---------------------------------------------------------------------------
 # Snapshot export. Signals always serves snapshots on demand via GET /export.
 # With onCollect enabled it ALSO drops one ZIP per database into `dest` after
-# every collection cycle (files are timestamped and accumulate — see README:
-# they are not pruned, so sync them out and/or size storage.capacity).
-# `dest` must be on the persistent volume (/data...) to survive restarts; the
-# directory is created automatically.
+# every collection cycle (files are timestamped and ACCUMULATE — Signals does
+# not prune them; sync them out and delete, or size storage.capacity for your
+# cadence/retention). `dest` must be on the persistent volume (/data...).
+# The directory is created automatically.
 # ---------------------------------------------------------------------------
 export:
   onCollect: true
@@ -84,16 +93,22 @@ metrics:
   enabled: false
 
 # ---------------------------------------------------------------------------
-# Local persistence for the snapshot store (SQLite at /data/signals.db).
-# Control Plane volumesets have a 10 GiB minimum; Signals' footprint is small.
+# Local persistence for the snapshot store (SQLite at /data/signals.db) plus
+# any dropped exports. Control Plane volumesets have a 10 GiB minimum;
+# high-throughput-ssd requires >= 200 GiB.
 # ---------------------------------------------------------------------------
 storage:
-  capacity: 10                          # GiB
+  capacity: 10                          # GiB (>= 10; >= 200 for high-throughput-ssd)
   performanceClass: general-purpose-ssd # general-purpose-ssd | high-throughput-ssd
 
 # ---------------------------------------------------------------------------
-# Firewall. Outbound is required to reach the PostgreSQL target; inbound is
-# limited to the same GVC so other workloads can call the Signals API.
+# Firewall.
+# Outbound defaults to 0.0.0.0/0 because Signals must reach the PostgreSQL
+# target on its port (typically 5432): Control Plane hostname firewall rules
+# only permit ports 80/443/445, so they cannot scope a 5432 connection, and a
+# CIDR rule needs a stable database IP (managed PostgreSQL IPs often rotate).
+# If your database has a stable address, narrow outboundAllowCIDR to it.
+# Inbound is limited to the same GVC so other workloads can call the Signals API.
 # ---------------------------------------------------------------------------
 firewall:
   internal:
@@ -101,7 +116,7 @@ firewall:
     workloads: []
   external:
     outboundAllowCIDR:
-      - 0.0.0.0/0                # narrow to the database CIDR in production
+      - 0.0.0.0/0                # narrow to the database CIDR when it is stable
 
 # Injected by the platform when createsGvc is false.
 global:


### PR DESCRIPTION
Addresses the external review of the `deploy/controlplane/` package. Every claim verified against the upstream `controlplane-com/templates/.github/workflows/validate-charts.yml` and the Control Plane workload/firewall/volumeset references.

## Submission blockers (upstream CI would reject)
- **Default render.** Upstream runs `helm template <dir> --set global.cpln.gvc=validation-gvc` with **default** values; our empty-string defaults failed it. Now ships **renderable placeholder defaults** (catalog convention — cf. debezium `password: "changeme"`); empty-string fail-fast guards retained. No usable credentials committed.
- **Description ≤ 15 words.** Shortened to 10 (upstream clips/rejects longer).
- **Immutable image.** Enforce the exact reviewed `repository@digest`; removed the mutable-tag fallback; `image.repository`/`image.digest` changes are rejected.

## Posture / hardening
- Validation added: `api.token` length, `logLevel`/`inboundAllowType`/`performanceClass` enums, `postgres.port` range, `storage.capacity` range, `high-throughput-ssd` ≥ 200 GiB, `export.dest` under `/data`.
- `collection.highSensitivityCollectorsEnabled` exposed (emits `SIGNALS_HIGH_SENSITIVITY_COLLECTORS_ENABLED`) — snapshots can otherwise capture live query text / stored SQL bodies with no control.
- Egress stays `0.0.0.0/0` **by necessity** (hostname firewall rules only reach 80/443/445, not 5432; CIDR needs a stable DB IP) — now documented, with CIDR-narrowing guidance.
- Docs/listing: PostgreSQL **14–18**; **single-target**; CA secret **required**; softened "no data ever leaves"/"all capabilities dropped" overclaims; runbook categories marked examples; `LISTING.md` noted internal.

## STDD / traceability
- `deploy/controlplane/signals/tests/render-acceptance.sh` — 21 rule-referenced positive+negative cases (all pass locally).
- `.github/workflows/controlplane-template.yml` — scoped CI gate running that suite.

## Deliberately unchanged (flagged)
`export.onCollect` default stays **on** per the prior product decision ("customers expect the ZIPs dropped"); native export-dir pruning is tracked in #385. Say the word to flip it off or isolate exports to a second volume.

## Validation
- Upstream-parity default render: OK (6 resources, all `cpln/marketplace*` tags, 10-word description, digest-pinned image).
- 21/21 acceptance cases pass; `helm lint` 0 failures; `actionlint`/`shellcheck` clean.

closes #384