### PR TITLE
Control Plane template: integer-shape validation for numeric inputs (round-3)

### DIFF
--- a/deploy/controlplane/signals/tests/render-acceptance.sh
+++ b/deploy/controlplane/signals/tests/render-acceptance.sh
@@ -53,10 +53,16 @@ if OUT="$(render)"; then
   else
     fail "R012 high-sensitivity default drift (expected \"false\")"
   fi
-  if echo "$OUT" | grep -qE 'protocol: tcp'; then
-    pass "R012 egress restricted to a TCP port (outboundAllowPort)"
+  EGRESS="$(echo "$OUT" | grep -A2 'outboundAllowPort:')"
+  if echo "$EGRESS" | grep -qE 'number: 5432' && echo "$EGRESS" | grep -qE 'protocol: tcp'; then
+    pass "R012 egress scoped to outboundAllowPort tcp/5432"
   else
-    fail "R012 egress not port-scoped (outboundAllowPort missing)"
+    fail "R012 egress not scoped to outboundAllowPort tcp/5432"
+  fi
+  if echo "$OUT" | grep -q 'api-token: "00000000000000000000000000000000"'; then
+    pass "R008 fail-closed token sentinel rendered exactly"
+  else
+    fail "R008 fail-closed token sentinel missing or changed"
   fi
 else
   fail "R001 default render failed:"; echo "$OUT" | tail -3
@@ -87,8 +93,11 @@ neg R009 "inboundAllowType=public"   --set firewall.internal.inboundAllowType=pu
 neg R009 "bad performanceClass"      --set storage.performanceClass=nvme
 neg R010 "port < 1"                  --set postgres.port=0
 neg R010 "port > 65535"              --set postgres.port=70000
+neg R010 "boolean port"              --set postgres.port=true
+neg R010 "fractional port"          --set-json postgres.port=5432.5
 neg R010 "capacity < 10"             --set storage.capacity=9
 neg R010 "capacity > 65536"          --set storage.capacity=65537
+neg R010 "fractional capacity"      --set-json storage.capacity=10.5
 neg R010 "high-throughput + 10GiB"   --set storage.performanceClass=high-throughput-ssd
 neg R011 "export.dest outside /data" --set export.onCollect=true --set export.dest=/tmp/exports
 neg R011 "empty export.dest"         --set export.onCollect=true --set-string export.dest=
@@ -98,12 +107,28 @@ neg R012 "string metrics.enabled"    --set-string metrics.enabled=false
 neg R013 "invalid pollInterval"      --set-string collection.pollInterval=garbage
 neg R013 "zero pollInterval"         --set-string collection.pollInterval=0s
 neg R013 "retentionDays < 1"         --set collection.retentionDays=0
+neg R013 "boolean retentionDays"     --set collection.retentionDays=true
+neg R013 "fractional retentionDays"  --set-json collection.retentionDays=1.5
+
+echo "== positive Go durations (must render) =="
+for d in 5m 1h30m 500ms 1.5h .5s +5m 1µs 1μs; do
+  if render --set-string "collection.pollInterval=$d" >/dev/null 2>&1; then
+    pass "R013 accepts valid duration: $d"
+  else
+    fail "R013 rejects valid duration: $d"
+  fi
+done
 
 echo "== positive opt-ins (must render) =="
 if render --set export.onCollect=true >/dev/null 2>&1; then
   pass "R011 export.onCollect=true renders (default dest under /data)"
 else
   fail "R011 export.onCollect=true failed to render"
+fi
+if render --set postgres.port=6432 2>/dev/null | grep -A2 'outboundAllowPort:' | grep -q 'number: 6432'; then
+  pass "R012 overridden postgres.port propagates to outboundAllowPort"
+else
+  fail "R012 overridden postgres.port not reflected in outboundAllowPort"
 fi
 if render --set collection.highSensitivityCollectorsEnabled=true >/dev/null 2>&1; then
   pass "R012 highSensitivityCollectorsEnabled=true renders"

--- a/deploy/controlplane/signals/versions/1.0.0/templates/_helpers.tpl
+++ b/deploy/controlplane/signals/versions/1.0.0/templates/_helpers.tpl
@@ -97,11 +97,12 @@ Validation — fail fast on missing/invalid inputs before any resource renders.
 {{- fail "api.token must contain at least 8 distinct characters (openssl rand -base64 32)" -}}
 {{- end -}}
 {{- $poll := .Values.collection.pollInterval | toString -}}
-{{- if or (not (regexMatch "^([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+$" $poll)) (not (regexMatch "[1-9]" $poll)) -}}
+{{- if or (not (regexMatch "^\\+?(([0-9]+(\\.[0-9]*)?|\\.[0-9]+)(ns|us|µs|μs|ms|s|m|h))+$" $poll)) (not (regexMatch "[1-9]" $poll)) -}}
 {{- fail "collection.pollInterval must be a positive Go duration (e.g. 30s, 5m, 1h)" -}}
 {{- end -}}
-{{- if lt (int .Values.collection.retentionDays) 1 -}}
-{{- fail "collection.retentionDays must be at least 1 (a finite retention window)" -}}
+{{- $retention := .Values.collection.retentionDays | toString -}}
+{{- if or (not (regexMatch "^[0-9]+$" $retention)) (lt (int $retention) 1) -}}
+{{- fail "collection.retentionDays must be a positive integer (>= 1)" -}}
 {{- end -}}
 {{- if and .Values.export.onCollect (not .Values.export.dest) -}}
 {{- fail "export.dest is required when export.onCollect is true (use a path on the persistent volume, e.g. /data/exports)" -}}
@@ -116,7 +117,11 @@ Validation — fail fast on missing/invalid inputs before any resource renders.
 {{- if not (has .Values.logLevel $logLevels) -}}
 {{- fail (printf "logLevel '%s' is invalid; use one of: %s" .Values.logLevel (join ", " $logLevels)) -}}
 {{- end -}}
-{{- $port := int .Values.postgres.port -}}
+{{- $portRaw := .Values.postgres.port | toString -}}
+{{- if not (regexMatch "^[0-9]+$" $portRaw) -}}
+{{- fail "postgres.port must be an integer between 1 and 65535" -}}
+{{- end -}}
+{{- $port := int $portRaw -}}
 {{- if or (lt $port 1) (gt $port 65535) -}}
 {{- fail "postgres.port must be between 1 and 65535" -}}
 {{- end -}}
@@ -124,7 +129,11 @@ Validation — fail fast on missing/invalid inputs before any resource renders.
 {{- if not (has .Values.storage.performanceClass $classes) -}}
 {{- fail (printf "storage.performanceClass must be one of: %s" (join ", " $classes)) -}}
 {{- end -}}
-{{- $capacity := int .Values.storage.capacity -}}
+{{- $capacityRaw := .Values.storage.capacity | toString -}}
+{{- if not (regexMatch "^[0-9]+$" $capacityRaw) -}}
+{{- fail "storage.capacity must be an integer number of GiB" -}}
+{{- end -}}
+{{- $capacity := int $capacityRaw -}}
 {{- if or (lt $capacity 10) (gt $capacity 65536) -}}
 {{- fail "storage.capacity must be between 10 and 65536 GiB" -}}
 {{- end -}}


### PR DESCRIPTION
Round-3 external review verdict was GO-WITH-FIXES. This closes the one substantive gap plus the two lows.

## Fix (the must-fix)
Sprig `int` silently coerces non-integer types, so `postgres.port=true`/`=5432.5`, `storage.capacity=10.5`, and `collection.retentionDays=true`/`=1.5` **rendered** instead of failing fast. The fractional port was the worst: `SIGNALS_TARGET_PORT="5432.5"` while the firewall emitted `5432`. Now the digits-only string form is validated **before** `int` conversion for `postgres.port`, `storage.capacity`, and `collection.retentionDays`.

## Lows
- `collection.pollInterval` grammar widened to match Go's `time.ParseDuration` — it previously false-rejected valid positive forms (`.5s`, `1.s`, `+5m`, `1µs`/`1μs`).
- Acceptance suite strengthened: boolean/fractional negatives for port/capacity/retention; a positive Go-duration matrix; the egress assertion now inspects the `outboundAllowPort` block (`number: 5432` + overridden-port propagation); an exact fail-closed token-sentinel assertion.

## Validation
- `helm lint` 0 failures; integer bypasses now rejected; previously-rejected valid durations accepted; acceptance suite ALL PASS; shellcheck clean (default severity).

Out of scope, tracked separately in #392: historical AI-tool-name strings in old CHANGELOG/test-name/PR bodies (no history rewrite).

closes #391