### PR TITLE
test(contract): classify pg_stat_progress_* family as column-dynamic (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Flaky `integration-pg` output-contract test: the `pg_stat_progress_*` family
+  collectors share one family spec (`pg_stat_progress_family_v1.md`) that
+  intentionally carries no `## Output columns` table (their columns are
+  per-major, populated by `RegisterOverride`, documented inline at the
+  registration site). The resolver derived a per-collector `<id>.md` path that
+  does not exist and failed whenever a progress row was sampled — a flake,
+  since a progress row only appears while the operation is in flight. The six
+  progress collectors are now classified column-dynamic (row-presence only,
+  consistent with the family spec), and a deterministic regression asserts
+  every `pg_stat_progress_*` collector stays classified. (#383)
+
 ## [1.3.0] - 2026-08-17
 
 ### Added

--- a/tests/signals_collector_output_contract_columns.go
+++ b/tests/signals_collector_output_contract_columns.go
@@ -30,12 +30,13 @@ import (
 	"testing"
 )
 
-// dynamicColumnCollectors emit a version-dependent column set via
-// SELECT * (documented in their specs as R037 dynamic-column precedent),
-// so a fixed declared-column list cannot be asserted. Their row-presence
-// and char/status invariants are still covered by the ALL-payload
-// sweeps (OC-R003/R004/R005). Each entry carries the reason it is
-// column-dynamic.
+// dynamicColumnCollectors emit a version-dependent column set — either via
+// SELECT * (documented in their specs as R037 dynamic-column precedent) or,
+// for the pg_stat_progress_* family, via explicit per-major column
+// projections populated by RegisterOverride — so a fixed declared-column
+// list cannot be asserted. Their row-presence and char/status invariants are
+// still covered by the ALL-payload sweeps (OC-R003/R004/R005). Each entry
+// carries the reason it is column-dynamic.
 var dynamicColumnCollectors = map[string]string{
 	"pg_version_v1":                        "scalar SELECT version(); single value keyed by the version() output column, no fixed column table",
 	"bgwriter_stats_v1":                    "spec-documented dynamic: whatever pg_stat_bgwriter exposes on the target (PG 17 split checkpoints into pg_stat_checkpointer, so the pre-17 columns are absent)",
@@ -51,6 +52,21 @@ var dynamicColumnCollectors = map[string]string{
 	"timescaledb_compression_settings_v1":  "SELECT * over compression_settings; column set drifts across TimescaleDB versions",
 	"timescaledb_compression_stats_v1":     "SELECT * over compression stats; column set drifts across TimescaleDB versions",
 	"timescaledb_hypertable_sizes_v1":      "SELECT * over hypertable sizes; column set drifts across TimescaleDB versions",
+	// pg_stat_progress_* family (#383): columns are per-major (RegisterOverride
+	// populates version-specific columns) and are documented inline at the
+	// registration site rather than in a spec table — pg_stat_progress_family_v1.md
+	// deliberately carries no "## Output columns" table to avoid spec/code drift.
+	// So there is no fixed declared-column list to assert; row-presence + the
+	// ALL-payload char/status sweeps cover them. Without this classification the
+	// resolver looked for a non-existent per-collector <id>.md and Fatal'd
+	// whenever a progress row happened to be sampled (a flake, since a row only
+	// appears while the operation is in flight).
+	"pg_stat_progress_analyze_v1":      "progress-family: per-major projected columns, documented in code per pg_stat_progress_family_v1.md (no spec column table)",
+	"pg_stat_progress_basebackup_v1":   "progress-family: per-major projected columns, documented in code per pg_stat_progress_family_v1.md (no spec column table)",
+	"pg_stat_progress_cluster_v1":      "progress-family: per-major projected columns, documented in code per pg_stat_progress_family_v1.md (no spec column table)",
+	"pg_stat_progress_copy_v1":         "progress-family: per-major projected columns, documented in code per pg_stat_progress_family_v1.md (no spec column table)",
+	"pg_stat_progress_create_index_v1": "progress-family: per-major projected columns, documented in code per pg_stat_progress_family_v1.md (no spec column table)",
+	"pg_stat_progress_vacuum_v1":       "progress-family: per-major projected columns, documented in code per pg_stat_progress_family_v1.md (no spec column table)",
 }
 
 // zeroRowAllowlist enumerates the collectors that legitimately emit no

--- a/tests/signals_collector_output_contract_progress_test.go
+++ b/tests/signals_collector_output_contract_progress_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+// Deterministic regression for #383: the pg_stat_progress_* family collectors
+// share one family spec (pg_stat_progress_family_v1.md) that intentionally
+// carries no "## Output columns" table (their columns are per-major and
+// documented inline at the registration site to avoid spec/code drift). The
+// output-contract resolver (declaredColumnsForCollector) therefore cannot
+// derive a fixed column list for them; each must be classified column-dynamic
+// (dynamicColumnCollectors) so the resolver never looks for a non-existent
+// per-collector <id>.md. Before this classification the harness Fatal'd
+// whenever a progress row was sampled — a flake, because a progress row only
+// exists while the operation is in flight.
+//
+// This test needs no live PostgreSQL, so it runs on every integration build
+// and catches a newly-added progress collector deterministically, rather than
+// waiting for an ANALYZE to coincide with a collection.
+
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elevarq/signals/internal/pgqueries"
+)
+
+func TestProgressFamilyCollectorsAreClassified_383(t *testing.T) {
+	found := 0
+	for _, q := range pgqueries.All() {
+		if !strings.HasPrefix(q.ID, "pg_stat_progress_") {
+			continue
+		}
+		found++
+		if _, ok := dynamicColumnCollectors[q.ID]; !ok {
+			t.Errorf("#383: progress-family collector %q is not classified column-dynamic. "+
+				"Add it to dynamicColumnCollectors — the family spec "+
+				"pg_stat_progress_family_v1.md has no per-collector column table, so the "+
+				"output-contract resolver cannot derive a declared-column list for it.", q.ID)
+		}
+	}
+	if found == 0 {
+		t.Fatal("#383: no pg_stat_progress_* collectors found in pgqueries.All() — " +
+			"did the registry or the naming convention change? Update this regression.")
+	}
+}


### PR DESCRIPTION
## Problem
`integration-pg` flaked on `main`: the output-contract test resolved a per-collector spec path (`specifications/collectors/<id>.md`) from the collector ID, but the `pg_stat_progress_*` family shares one family spec (`pg_stat_progress_family_v1.md`) that intentionally carries **no `## Output columns` table** (columns are per-major, populated by `RegisterOverride`, documented inline at the registration site to avoid spec/code drift). So the resolver looked for a non-existent `pg_stat_progress_<op>_v1.md` and `Fatal`'d — but only whenever a progress row was actually sampled, which is non-deterministic (a progress row exists only while the operation is in flight; a PG18 autoanalyze overlapping the collection triggered it).

## Fix
Classify the six progress collectors (`analyze`, `basebackup`, `cluster`, `copy`, `create_index`, `vacuum`) as **column-dynamic** — row-presence only, consistent with the family spec's no-column-table decision. The ALL-payload char/status sweeps (OC-R003/R004/R005) still cover them. This is the honest classification: there is no static column contract to assert (the columns vary by major).

Add a **deterministic regression** (`TestProgressFamilyCollectorsAreClassified_383`, needs no live PG) asserting every `pg_stat_progress_*` collector in the registry stays classified, so a newly-added progress collector can't reintroduce the flake — it fails on the next build rather than waiting for an ANALYZE to coincide with a collection.

## Verification
- `gofmt`, `go vet -tags=integration`, `golangci-lint --build-tags=integration`: clean.
- The new regression runs and passes without a `SIGNALS_TEST_PG_DSN` (found all 6 progress collectors, all classified).

closes #383