### PR TITLE
feat(export): bounded retention for the scheduled export directory (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Bounded retention for the scheduled auto-export directory (#385, #350
+  follow-up). `SIGNALS_EXPORT_RETENTION_DAYS` / `export_retention_days` and
+  `SIGNALS_EXPORT_MAX_FILES` / `export_max_files` cap the per-target ZIPs the
+  export-on-collect writer accumulates (~288/db/day at a 5m cadence): after
+  each cycle the exporter prunes its OWN older ZIPs per target — keeping at
+  most `max_files` and deleting any older than `retention_days`. Both default 0
+  = unbounded (pre-#385 behaviour); instances sharing one directory never
+  delete each other's exports. Pruning is best-effort and never fails a cycle.
 - Startup warning when an enabled target's connect host is **non-canonical** —
   a loopback (`localhost` / `127.0.0.0/8` / `::1`) or a bare IP literal (#396).
   The Analyzer keys database identity on `(lower(trim(host)):port, dbname)` with

--- a/cmd/signals/main.go
+++ b/cmd/signals/main.go
@@ -230,6 +230,8 @@ func run() error {
 	// collection. Signals has no knowledge of any downstream consumer.
 	if cfg.Signals.ExportOnCollect && cfg.Signals.ExportDest != "" {
 		se := export.NewScheduledExporter(exporter, cfg.Signals.ExportDest, instanceID, nil, slog.Warn)
+		// #385 — bound the export directory (0/0 = unbounded, pre-#385 default).
+		se.SetRetention(cfg.Signals.ExportRetentionDays, cfg.Signals.ExportMaxFiles)
 		coll.SetAfterCycle(func(ctx context.Context) {
 			paths, err := se.ExportLatest(ctx)
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,14 @@ type SignalsConfig struct {
 	// scope for Signals.
 	ExportOnCollect bool   `yaml:"export_on_collect"`
 	ExportDest      string `yaml:"export_dest"`
+	// #385: bound the scheduled-export directory so it does not grow without
+	// limit (one ZIP per database per cycle, ~288/db/day at a 5m cadence).
+	// After each cycle the exporter prunes its own older ZIPs per target:
+	// keeping at most ExportMaxFiles (when > 0) and deleting any older than
+	// ExportRetentionDays (when > 0). Both default 0 = unbounded (the pre-#385
+	// behaviour), so existing deployments are unaffected until they opt in.
+	ExportRetentionDays int `yaml:"export_retention_days"`
+	ExportMaxFiles      int `yaml:"export_max_files"`
 }
 
 // CircuitConfig holds the per-target circuit-breaker thresholds
@@ -614,6 +622,17 @@ func applyEnvOverrides(cfg *Config) error {
 	}
 	if v := os.Getenv("SIGNALS_EXPORT_DEST"); v != "" {
 		cfg.Signals.ExportDest = v
+	}
+	// #385 — bound the scheduled-export directory (0 = unbounded).
+	if n, ok, err := parseEnvInt("SIGNALS_EXPORT_RETENTION_DAYS"); err != nil {
+		return err
+	} else if ok {
+		cfg.Signals.ExportRetentionDays = n
+	}
+	if n, ok, err := parseEnvInt("SIGNALS_EXPORT_MAX_FILES"); err != nil {
+		return err
+	} else if ok {
+		cfg.Signals.ExportMaxFiles = n
 	}
 	// File takes precedence over the raw env var when both are set —
 	// matches the _FILE convention used by the official postgres image.

--- a/internal/export/scheduled.go
+++ b/internal/export/scheduled.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 )
@@ -40,6 +41,10 @@ type ScheduledExporter struct {
 	instanceID string
 	now        func() time.Time
 	logf       func(msg string, args ...any)
+	// Retention bounds for the export directory (#385). Zero = unbounded
+	// (the pre-#385 behaviour). Set via SetRetention.
+	retentionDays int
+	maxFiles      int
 }
 
 // NewScheduledExporter constructs the exporter. `dest` is the destination
@@ -54,6 +59,59 @@ func NewScheduledExporter(b snapshotSource, dest, instanceID string, now func() 
 		logf = func(string, ...any) {}
 	}
 	return &ScheduledExporter{builder: b, dest: dest, instanceID: instanceID, now: now, logf: logf}
+}
+
+// SetRetention bounds the export directory (#385): after each cycle the
+// exporter prunes its OWN older ZIPs per target — keeping at most maxFiles
+// (when > 0) and deleting any older than retentionDays (when > 0). Zero for
+// both is unbounded (the pre-#385 behaviour). Only this instance's files
+// (`<instance>-t<target>-*.zip`) are pruned, so several instances sharing one
+// directory never delete each other's exports.
+func (e *ScheduledExporter) SetRetention(retentionDays, maxFiles int) {
+	e.retentionDays = retentionDays
+	e.maxFiles = maxFiles
+}
+
+// pruneTarget deletes this instance's older export ZIPs for one target so the
+// scheduled-export directory stays bounded (#385). It keeps the newest
+// maxFiles and deletes any older than retentionDays; both bounds apply when
+// set. Best-effort — a failed unlink is logged and never fails the export
+// (the fresh ZIP for this cycle is already durably written). The per-target
+// timestamped filename sorts lexicographically == chronologically, so the tail
+// of the sorted list is the newest.
+func (e *ScheduledExporter) pruneTarget(targetID int64) {
+	if e.retentionDays <= 0 && e.maxFiles <= 0 {
+		return // unbounded
+	}
+	inst := instanceToken.ReplaceAllString(strings.TrimSpace(e.instanceID), "_")
+	if inst == "" {
+		inst = "signals"
+	}
+	matches, err := filepath.Glob(filepath.Join(e.dest, fmt.Sprintf("%s-t%d-*.zip", inst, targetID)))
+	if err != nil || len(matches) == 0 {
+		return
+	}
+	sort.Strings(matches) // oldest first (timestamp in the name)
+
+	remove := make(map[string]bool)
+	if e.maxFiles > 0 && len(matches) > e.maxFiles {
+		for _, p := range matches[:len(matches)-e.maxFiles] {
+			remove[p] = true
+		}
+	}
+	if e.retentionDays > 0 {
+		cutoff := e.now().Add(-time.Duration(e.retentionDays) * 24 * time.Hour)
+		for _, p := range matches {
+			if info, serr := os.Stat(p); serr == nil && info.ModTime().Before(cutoff) {
+				remove[p] = true
+			}
+		}
+	}
+	for p := range remove {
+		if rerr := os.Remove(p); rerr != nil {
+			e.logf("scheduled export: prune %s failed (%v); leaving it in place", filepath.Base(p), rerr)
+		}
+	}
 }
 
 // instanceToken keeps the filename component filesystem-safe and flat.
@@ -102,6 +160,7 @@ func (e *ScheduledExporter) ExportLatest(_ context.Context) ([]string, error) {
 			return written, fmt.Errorf("scheduled export: target %d: %w", id, err)
 		}
 		written = append(written, final)
+		e.pruneTarget(id) // #385 — bound the dir; best-effort, never fails the export
 	}
 	return written, nil
 }

--- a/internal/export/scheduled_retention_test.go
+++ b/internal/export/scheduled_retention_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Scantr LLC. All rights reserved.
+// Elevarq is a trade name of Scantr LLC.
+// This file is part of Elevarq Signals. Use is governed by the
+// commercial license at LICENSE in the repository root.
+
+package export
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func zipsFor(t *testing.T, dest, inst string, targetID int64) []string {
+	t.Helper()
+	m, err := filepath.Glob(filepath.Join(dest, inst+"-t"+itoa(targetID)+"-*.zip"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	return m
+}
+
+func itoa(n int64) string {
+	// small helper so the test does not import strconv just for this.
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+// #385 — ExportMaxFiles keeps only the newest N ZIPs per target; each cycle
+// prunes this instance's older exports.
+func TestScheduledExporter_Retention_MaxFiles(t *testing.T) {
+	dest := t.TempDir()
+	fw := &fakeWriter{targetIDs: []int64{1}, payload: []byte("PK\x03\x04zip")}
+	base := time.Date(2026, 8, 14, 9, 30, 0, 0, time.UTC)
+	clk := base
+	se := NewScheduledExporter(fw, dest, "signals-prod-1", func() time.Time { return clk }, nil)
+	se.SetRetention(0, 2) // keep newest 2
+
+	for i := 0; i < 5; i++ {
+		clk = base.Add(time.Duration(i) * time.Minute) // distinct timestamp per cycle
+		if _, err := se.ExportLatest(context.Background()); err != nil {
+			t.Fatalf("cycle %d: ExportLatest: %v", i, err)
+		}
+	}
+
+	got := zipsFor(t, dest, "signals-prod-1", 1)
+	if len(got) != 2 {
+		t.Fatalf("after 5 cycles with max_files=2, want 2 ZIPs, got %d: %v", len(got), got)
+	}
+	// The two survivors must be the newest two timestamps (cycles 3 and 4).
+	for _, want := range []string{
+		"signals-prod-1-t1-20260814T093300.000000000Z.zip",
+		"signals-prod-1-t1-20260814T093400.000000000Z.zip",
+	} {
+		if _, err := os.Stat(filepath.Join(dest, want)); err != nil {
+			t.Errorf("newest survivor %q missing: %v", want, err)
+		}
+	}
+}
+
+// #385 — ExportRetentionDays deletes ZIPs older than the cutoff by mtime.
+func TestScheduledExporter_Retention_Days(t *testing.T) {
+	dest := t.TempDir()
+	now := time.Date(2026, 8, 14, 9, 30, 0, 0, time.UTC)
+	se := NewScheduledExporter(
+		&fakeWriter{targetIDs: []int64{7}},
+		dest, "signals-prod-1", func() time.Time { return now }, nil,
+	)
+	se.SetRetention(2, 0) // 2-day age bound
+
+	mk := func(name string, age time.Duration) {
+		p := filepath.Join(dest, name)
+		if err := os.WriteFile(p, []byte("z"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		mt := now.Add(-age)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatalf("chtimes %s: %v", name, err)
+		}
+	}
+	mk("signals-prod-1-t7-old1.zip", 5*24*time.Hour)  // 5 days → pruned
+	mk("signals-prod-1-t7-old2.zip", 3*24*time.Hour)  // 3 days → pruned
+	mk("signals-prod-1-t7-fresh.zip", 1*24*time.Hour) // 1 day → kept
+	// Another instance's file for the same target must NOT be touched.
+	mk("other-inst-t7-old.zip", 9*24*time.Hour)
+
+	se.pruneTarget(7)
+
+	if got := zipsFor(t, dest, "signals-prod-1", 7); len(got) != 1 {
+		t.Errorf("retention_days=2: want 1 fresh ZIP left, got %d: %v", len(got), got)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "other-inst-t7-old.zip")); err != nil {
+		t.Errorf("another instance's file was pruned (must not be): %v", err)
+	}
+}
+
+// #385 — the default (0/0) is unbounded: nothing is pruned (pre-#385 behaviour).
+func TestScheduledExporter_Retention_UnboundedByDefault(t *testing.T) {
+	dest := t.TempDir()
+	base := time.Date(2026, 8, 14, 9, 30, 0, 0, time.UTC)
+	clk := base
+	se := NewScheduledExporter(
+		&fakeWriter{targetIDs: []int64{1}, payload: []byte("z")},
+		dest, "signals-prod-1", func() time.Time { return clk }, nil,
+	)
+	// No SetRetention call → 0/0.
+	for i := 0; i < 4; i++ {
+		clk = base.Add(time.Duration(i) * time.Minute)
+		if _, err := se.ExportLatest(context.Background()); err != nil {
+			t.Fatalf("cycle %d: %v", i, err)
+		}
+	}
+	if got := zipsFor(t, dest, "signals-prod-1", 1); len(got) != 4 {
+		t.Errorf("unbounded default: want all 4 ZIPs, got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Problem
The scheduled auto-export (#350, `export_on_collect`) writes one timestamped ZIP per database per cycle and **never prunes** them — ~288/db/day at a 5m cadence, growing the export volume without bound. Surfaced in the Control Plane catalog packaging, where it writes to the workload volume and can fill it. Only the SQLite store honoured retention.

## Fix
Per-target retention on the scheduled exporter:
- **`SIGNALS_EXPORT_RETENTION_DAYS` / `export_retention_days`** — delete ZIPs older than the cutoff (by mtime).
- **`SIGNALS_EXPORT_MAX_FILES` / `export_max_files`** — keep only the newest N.

After each cycle the exporter prunes **its own** older ZIPs per target (both bounds apply when set). Both default **0 = unbounded** (pre-#385 behaviour), so existing deployments are unaffected until they opt in. Only `<instance>-t<target>-*.zip` for *this* instance is pruned, so instances sharing a directory never delete each other's exports. Pruning is **best-effort** — a failed unlink is logged and never fails the cycle (the fresh ZIP is already durably written).

## Verification
Tests: max-files (keep newest N across 5 cycles), retention-days (mtime cutoff + another instance's file left untouched), unbounded default. `gofmt`/`vet` clean; `go test ./internal/export ./internal/config` green; `golangci-lint` 0 issues; docs + de-arq guards pass.

closes #385