### PR TITLE
feat(export): make the destination the switch for scheduled push (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- Scheduled directory-push: the **destination is the switch** (#403). Setting
+  `export_dest` / `SIGNALS_EXPORT_DEST` now enables the per-cycle push on its
+  own; `export_on_collect` becomes an explicit opt-OUT (`false` suppresses the
+  push while keeping a dest configured). Pull via `GET /export` remains the
+  default when no destination is set. On enable, Signals now writes the current
+  latest snapshot per database **immediately** (no up-to-one-poll-interval blind
+  window); semantics stay latest-per-target, not a backlog replay. The push
+  path + the #385 retention knobs are now documented in the adoption guide.
+
+### Changed
 - Neutralized historical AI-tool-name references ("Codex") in committed
   artifacts per the no-AI-attribution engineering standard (#392): renamed
   `tests/signals_codex_post_031_test.go` -> `tests/signals_post_031_test.go`

--- a/cmd/signals/main.go
+++ b/cmd/signals/main.go
@@ -224,11 +224,13 @@ func run() error {
 		})
 	}
 
-	// #350: scheduled auto-export. When enabled, write the latest snapshot
-	// export ZIP to the configured file location after every collection
-	// cycle. A failed export logs and is skipped — it must never disrupt
-	// collection. Signals has no knowledge of any downstream consumer.
-	if cfg.Signals.ExportOnCollect && cfg.Signals.ExportDest != "" {
+	// #350/#403: scheduled auto-export. The destination is the switch — when
+	// export_dest is set (and not explicitly opted out via export_on_collect:
+	// false), write the latest snapshot ZIP per database to it after every
+	// cycle, and once immediately on enable. A failed export logs and is
+	// skipped — it must never disrupt collection. Signals has no knowledge of
+	// any downstream consumer.
+	if cfg.Signals.ScheduledExportEnabled() {
 		se := export.NewScheduledExporter(exporter, cfg.Signals.ExportDest, instanceID, nil, slog.Warn)
 		// #385 — bound the export directory (0/0 = unbounded, pre-#385 default).
 		se.SetRetention(cfg.Signals.ExportRetentionDays, cfg.Signals.ExportMaxFiles)
@@ -242,6 +244,18 @@ func run() error {
 			slog.Info("scheduled export written", "files", len(paths), "dest", cfg.Signals.ExportDest)
 		})
 		slog.Info("scheduled auto-export enabled (one file per database)", "dest", cfg.Signals.ExportDest, "cadence", "per collection cycle")
+		// #403 — populate the destination immediately with the current latest
+		// per target, so there is no up-to-one-poll-interval blind window when
+		// push is first enabled (e.g. a restart with data already in the store).
+		// Best-effort: a fresh install has nothing to export yet; a failure is
+		// logged and never blocks startup. Semantics are latest-per-target,
+		// NOT a backlog replay.
+		if paths, eerr := se.ExportLatest(ctx); eerr != nil {
+			slog.Warn("scheduled export: initial export failed; will retry next cycle",
+				"err", eerr.Error(), "dest", cfg.Signals.ExportDest)
+		} else if len(paths) > 0 {
+			slog.Info("scheduled export: initial export written", "files", len(paths), "dest", cfg.Signals.ExportDest)
+		}
 	}
 
 	// Start collector in background.

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -388,9 +388,57 @@ The per-target fields for the non-`password` methods (`region`,
 
 ## Integrating with Existing Workflows
 
+### Getting data out: pull vs. push
+
+By default Elevarq Signals is **pull-based**: it collects and stores locally, and
+you fetch a snapshot ZIP on demand via `GET /export` or `signalsctl export`
+(see [Getting Started](#getting-started)). Nothing is written to a directory
+unless you ask for it.
+
+For a hands-off feed — for example to hand snapshots to a downstream watcher or
+the Elevarq Analyzer inbox — Signals can **push** a fresh ZIP per database to a
+directory after each collection cycle.
+
+### Scheduled export to a directory (opt-in)
+
+The **destination is the switch**: set `export_dest` (env `SIGNALS_EXPORT_DEST`)
+to a directory and Signals writes the latest snapshot for each database there
+after every collection cycle — and once immediately when it starts. No
+`export_dest` ⇒ pull-only (the default).
+
+```yaml
+signals:
+  export_dest: /var/lib/signals/exports   # enables the push
+  # export_on_collect: false              # explicit opt-out: keep a dest but suppress the push
+  # Bound the directory so it doesn't grow without limit (~288 files/db/day at a
+  # 5m cadence). 0 = unbounded (the default). Both may be set together.
+  export_retention_days: 7                 # delete ZIPs older than N days
+  export_max_files: 500                    # keep at most N ZIPs per database
+```
+
+Equivalent environment variables: `SIGNALS_EXPORT_DEST`,
+`SIGNALS_EXPORT_ON_COLLECT` (opt-out), `SIGNALS_EXPORT_RETENTION_DAYS`,
+`SIGNALS_EXPORT_MAX_FILES`.
+
+Notes:
+
+- **Latest, not the backlog.** Each cycle writes the *latest* snapshot per
+  database — one ZIP per database, named `<instance>-t<target>-<timestamp>.zip`.
+  Enabling the push does **not** replay previously collected snapshots; it
+  writes the current latest (immediately on enable) and each new latest going
+  forward. This is intentional — a consumer wants the current state, not a
+  replay of stale snapshots.
+- **Restart to enable.** The exporter is wired at startup. `POST /reload`
+  (SIGHUP) re-reads targets, not the export wiring — so turning the push on/off
+  takes effect on restart.
+- **Bounded + safe.** Pruning keeps only *this* instance's files per target, so
+  several instances writing to one shared directory never delete each other's
+  exports; a failed prune or export is logged and never disrupts collection.
+
 ### Scheduled Export via Cron
 
-Run Elevarq Signals as a daemon and export snapshots on a schedule:
+Prefer pull on a timer? Run Elevarq Signals as a daemon and export snapshots on
+a schedule instead:
 
 ```bash
 # Export a snapshot every hour

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,12 +69,15 @@ type SignalsConfig struct {
 	// `per-collector/<query_id>.json` directory to the export ZIP.
 	// Default off — canonical NDJSON layout is unaffected.
 	ExportPerCollectorFiles bool `yaml:"export_per_collector_files"`
-	// #350: scheduled auto-export. When ExportOnCollect is true and
-	// ExportDest is a non-empty directory, Signals writes the latest
-	// snapshot export ZIP to ExportDest after each collection cycle. Both
-	// default off (no scheduled export). What consumes the files is out of
-	// scope for Signals.
-	ExportOnCollect bool   `yaml:"export_on_collect"`
+	// #350/#403: scheduled auto-export to a directory. The DESTINATION is the
+	// switch — when ExportDest is a non-empty directory, Signals writes the
+	// latest snapshot export ZIP per database to it after each collection cycle
+	// (and once immediately on enable). No ExportDest ⇒ pull-only via
+	// GET /export, the shipped default. ExportOnCollect is an explicit
+	// opt-OUT: nil (unset) or true keeps the push on when a dest is set; false
+	// suppresses it even with a dest configured. See ScheduledExportEnabled.
+	// What consumes the files is out of scope for Signals.
+	ExportOnCollect *bool  `yaml:"export_on_collect"`
 	ExportDest      string `yaml:"export_dest"`
 	// #385: bound the scheduled-export directory so it does not grow without
 	// limit (one ZIP per database per cycle, ~288/db/day at a 5m cadence).
@@ -84,6 +87,17 @@ type SignalsConfig struct {
 	// behaviour), so existing deployments are unaffected until they opt in.
 	ExportRetentionDays int `yaml:"export_retention_days"`
 	ExportMaxFiles      int `yaml:"export_max_files"`
+}
+
+// ScheduledExportEnabled reports whether the scheduled directory-push is on
+// (#403). The destination is the switch: a non-empty ExportDest enables the
+// push, unless ExportOnCollect is explicitly false (the opt-out). Unset (nil)
+// or true keeps it on. No destination ⇒ pull-only via GET /export (default).
+func (s SignalsConfig) ScheduledExportEnabled() bool {
+	if s.ExportDest == "" {
+		return false
+	}
+	return s.ExportOnCollect == nil || *s.ExportOnCollect
 }
 
 // CircuitConfig holds the per-target circuit-breaker thresholds
@@ -614,11 +628,13 @@ func applyEnvOverrides(cfg *Config) error {
 	} else if ok {
 		cfg.Signals.ExportPerCollectorFiles = b
 	}
-	// #350 — scheduled auto-export to a file location.
+	// #350/#403 — scheduled auto-export to a file location. The destination is
+	// the switch; SIGNALS_EXPORT_ON_COLLECT is an explicit opt-out override.
 	if b, ok, err := parseEnvBool("SIGNALS_EXPORT_ON_COLLECT"); err != nil {
 		return err
 	} else if ok {
-		cfg.Signals.ExportOnCollect = b
+		bb := b
+		cfg.Signals.ExportOnCollect = &bb
 	}
 	if v := os.Getenv("SIGNALS_EXPORT_DEST"); v != "" {
 		cfg.Signals.ExportDest = v
@@ -944,6 +960,14 @@ func ValidateStrict(cfg Config) (warnings []string, err error) {
 	}
 	if len(cfg.Targets) == 0 {
 		warnings = append(warnings, "no targets configured; the collector will start but have nothing to collect")
+	}
+	// #403 — the destination is the switch for the scheduled export. Catch the
+	// two mismatches so a misconfigured push is loud, not silent.
+	if cfg.Signals.ExportOnCollect != nil && *cfg.Signals.ExportOnCollect && cfg.Signals.ExportDest == "" {
+		warnings = append(warnings, "signals.export_on_collect is enabled but signals.export_dest is empty; nothing will be pushed — set export_dest (the destination is the switch)")
+	}
+	if cfg.Signals.ExportOnCollect != nil && !*cfg.Signals.ExportOnCollect && cfg.Signals.ExportDest != "" {
+		warnings = append(warnings, "signals.export_dest is set but signals.export_on_collect is false; the scheduled directory-push is suppressed (data is still available via GET /export)")
 	}
 	for i, t := range cfg.Targets {
 		if cfg.Env != "prod" && t.SSLMode == "prefer" {

--- a/internal/config/scheduled_export_enabled_test.go
+++ b/internal/config/scheduled_export_enabled_test.go
@@ -1,0 +1,28 @@
+package config
+
+import "testing"
+
+// TestScheduledExportEnabled_403 — the destination is the switch: a non-empty
+// export_dest enables the scheduled directory-push unless export_on_collect is
+// explicitly false (the opt-out). No dest ⇒ pull-only (default).
+func TestScheduledExportEnabled_403(t *testing.T) {
+	p := func(b bool) *bool { return &b }
+	cases := []struct {
+		name      string
+		dest      string
+		onCollect *bool
+		want      bool
+	}{
+		{"no dest, unset -> pull-only (default)", "", nil, false},
+		{"no dest, on_collect=true -> still no push (nowhere to write)", "", p(true), false},
+		{"dest set, unset -> push (dest is the switch)", "/exports", nil, true},
+		{"dest set, on_collect=true -> push", "/exports", p(true), true},
+		{"dest set, on_collect=false -> opt-out, no push", "/exports", p(false), false},
+	}
+	for _, c := range cases {
+		s := SignalsConfig{ExportDest: c.dest, ExportOnCollect: c.onCollect}
+		if got := s.ScheduledExportEnabled(); got != c.want {
+			t.Errorf("%s: ScheduledExportEnabled() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #350 / #385, and fixes a documentation gap. **Pull via `GET /export` stays the default throughout.**

## Changes
1. **Destination is the switch.** Setting `export_dest` / `SIGNALS_EXPORT_DEST` enables the per-cycle push on its own. `export_on_collect` becomes a `*bool` explicit **opt-out** (`false` suppresses the push while keeping a dest configured; unset/`true` keep it on). No dest ⇒ pull-only. `ValidateStrict` warns on both mismatches (`on_collect=true` + no dest; dest + `on_collect=false`).
2. **Immediate export on enable.** When push is enabled, the current latest snapshot per database is written **at startup**, so there's no up-to-one-`poll_interval` (5m) blind window. Semantics stay **latest-per-target, not a backlog replay** — a consumer wants current state, not stale history.
3. **Docs.** The adoption guide now documents the push path (`export_dest` / `export_on_collect`), the #385 retention knobs (`export_retention_days` / `export_max_files`), the restart-to-enable note (`POST /reload` re-reads targets only), and the latest-not-backlog semantics — clearly marked opt-in, alongside the default pull flow.

## Verification
`ScheduledExportEnabled()` unit-tested across the dest × opt-out matrix; `go test ./internal/config ./internal/export` green; `gofmt`/`vet` clean; `golangci-lint` 0 issues; docs-drift + de-arq guards pass.

closes #403