### PR TITLE
feat(collector): WAL-archiving + backup-health signals (wal_archiving_v1) (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   latest snapshot per database **immediately** (no up-to-one-poll-interval blind
   window); semantics stay latest-per-target, not a backlog replay. The push
   path + the #385 retention knobs are now documented in the adoption guide.
-
-### Changed
 - Neutralized historical AI-tool-name references ("Codex") in committed
   artifacts per the no-AI-attribution engineering standard (#392): renamed
   `tests/signals_codex_post_031_test.go` -> `tests/signals_post_031_test.go`
@@ -26,6 +24,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- New collector `wal_archiving_v1` (#304): WAL-archiving and backup-readiness
+  signals from `pg_stat_archiver` (archived/failed counts, last archived/failed
+  WAL + times, stats_reset) plus recovery-posture settings (`archive_mode`,
+  `archive_timeout`, `wal_level`) and **presence-only** flags for
+  `archive_command` / `restore_command`. Read-only, one row per cluster, 15m
+  cadence. Credential-safe: the archive/restore command strings are never
+  persisted — only a boolean indicating whether each is configured.
 - Bounded retention for the scheduled auto-export directory (#385, #350
   follow-up). `SIGNALS_EXPORT_RETENTION_DAYS` / `export_retention_days` and
   `SIGNALS_EXPORT_MAX_FILES` / `export_max_files` cap the per-target ZIPs the

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ audit the binary. You own the output.
   cloud IAM** (RDS / Cloud SQL / Azure), or with the password fetched **live
   from a cloud secret store**, so no database secret lives in config
   ([details](#connecting-to-your-databases--passwordless--secret-store-auth))
-- Runs 102 read-only diagnostic collectors covering:
+- Runs 103 read-only diagnostic collectors covering:
   - Server configuration, identity, and cluster fingerprint
   - Session activity and connection pressure
   - Table, index, and I/O statistics (incl. `pg_stat_io` /
@@ -511,7 +511,7 @@ inspect exactly what Elevarq Signals collects without running it.
 
 ## Collected signals
 
-Elevarq Signals includes 102 read-only collectors. Grouped by domain:
+Elevarq Signals includes 103 read-only collectors. Grouped by domain:
 
 - **Baseline & runtime** — server config, sessions, databases,
   tables, indexes, table / index I/O, query stats
@@ -967,7 +967,7 @@ analyzer).
 ## Project resources
 
 - [Architecture](docs/architecture.md) — components, data flow, trust boundary, and no-egress design
-- [Collector inventory](docs/collectors.md) — all 102 collectors with sources and cadences
+- [Collector inventory](docs/collectors.md) — all 103 collectors with sources and cadences
 - [Database connections](docs/database-connections.md) — per-cloud `auth_method` recipes (RDS IAM, Entra, Cloud SQL IAM, secret stores) + grants
 - [Runtime safety model](docs/runtime-safety-model.md) — read-only enforcement details
 - [Adoption guide](docs/adoption-guide.md) — production deployment guidance

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -69,6 +69,7 @@ down a PostgreSQL server.
 | `replication_status_v1` | `pg_stat_replication` | 5m | Replica lag and sync state (empty when standalone) |
 | `pg_stat_replication_slots_v1` | `pg_stat_replication_slots` | 5m | Logical slot spill/stream/total counters (PG 14+, empty when no logical slots) |
 | `checkpointer_stats_v1` | `pg_stat_checkpointer` | 15m | Checkpoint stats (PG 17+ only, complements bgwriter) |
+| `wal_archiving_v1` | `pg_stat_archiver` + archive/recovery `pg_settings` | 15m | WAL-archiving progress/failures + recovery posture (archive_mode, wal_level, archive/restore command presence — never the command string) |
 | `vacuum_health_v1` | `pg_stat_user_tables` + `pg_class` | 15m | Dead tuple pressure, overdue vacuum, XID freeze age |
 | `idle_in_txn_offenders_v1` | `pg_stat_activity` | 5m | Idle-in-transaction backends holding locks |
 | `database_sizes_v1` | `pg_database` | 1h | All database sizes for growth monitoring |

--- a/internal/pgqueries/catalog_wal.go
+++ b/internal/pgqueries/catalog_wal.go
@@ -1,0 +1,38 @@
+package pgqueries
+
+import "time"
+
+// WAL-archiving and backup-health signals (#304). Read-only recovery-posture
+// evidence: archiver progress/failures (pg_stat_archiver) plus the
+// archive/recovery settings that determine whether continuous archiving and
+// PITR are actually possible. Downstream analysis reasons about recovery
+// readiness (archive_mode off, failing archiver, wal_level too low, etc.).
+//
+// Credential safety: archive_command / restore_command can embed secrets
+// (e.g. a cloud credential in the shell command), so this collector emits
+// only their PRESENCE as a boolean — never the command string itself.
+
+func init() {
+	Register(QueryDef{
+		ID:       "wal_archiving_v1",
+		Category: "server",
+		SQL: `SELECT
+			s.archived_count,
+			s.failed_count,
+			s.last_archived_wal,
+			s.last_archived_time,
+			s.last_failed_wal,
+			s.last_failed_time,
+			s.stats_reset,
+			current_setting('archive_mode')                                AS archive_mode,
+			current_setting('archive_timeout')                             AS archive_timeout,
+			current_setting('wal_level')                                   AS wal_level,
+			(COALESCE(current_setting('archive_command', true), '') <> '') AS archive_command_configured,
+			(COALESCE(current_setting('restore_command', true), '') <> '') AS restore_command_configured
+		FROM pg_stat_archiver s`,
+		ResultKind:     ResultScalar,
+		RetentionClass: RetentionMedium,
+		Timeout:        5 * time.Second,
+		Cadence:        Cadence15m,
+	})
+}

--- a/specifications/collectors/collector-inventory.json
+++ b/specifications/collectors/collector-inventory.json
@@ -397,6 +397,10 @@
       "name": "vacuum_health_v1"
     },
     {
+      "category": "server",
+      "name": "wal_archiving_v1"
+    },
+    {
       "category": "wraparound",
       "name": "wraparound_blockers_v1"
     },

--- a/specifications/collectors/wal_archiving_v1.md
+++ b/specifications/collectors/wal_archiving_v1.md
@@ -1,0 +1,85 @@
+# wal_archiving_v1 — Collector Specification
+
+## Purpose
+
+WAL-archiving and backup-readiness signals so downstream analysis can
+reason about recovery posture: whether continuous archiving is enabled
+and healthy, whether the archiver is falling behind or failing, and
+whether the WAL level supports the intended recovery/replication model.
+These signals are not collected elsewhere; standby/replication lag is
+covered separately by the replication collectors.
+
+## Catalog source
+
+- `pg_stat_archiver` (single-row, cluster-wide)
+- `pg_settings` via `current_setting()` for `archive_mode`,
+  `archive_timeout`, `wal_level`, and the **presence** of
+  `archive_command` / `restore_command`
+
+## Query shape
+
+Explicit column projection (no `SELECT *`). One row per cluster.
+`archive_command` and `restore_command` can embed credentials, so the
+query emits only a boolean **presence** flag for each
+(`current_setting(name, true) <> ''`) — never the command string. The
+`, true` (missing_ok) form keeps the query robust across versions where
+`restore_command` may be absent.
+
+## Output columns
+
+| Column | Type | Description |
+|---|---|---|
+| archived_count | bigint | WAL files successfully archived (cumulative) |
+| failed_count | bigint | Failed archive attempts (cumulative) |
+| last_archived_wal | text | Name of the last successfully archived WAL file |
+| last_archived_time | timestamptz | Time of the last successful archive |
+| last_failed_wal | text | WAL file of the last failed archive attempt |
+| last_failed_time | timestamptz | Time of the last failed archive attempt |
+| stats_reset | timestamptz | When the archiver statistics were last reset |
+| archive_mode | text | `archive_mode` setting (`off` / `on` / `always`) |
+| archive_timeout | text | `archive_timeout` setting (forced WAL-switch interval) |
+| wal_level | text | `wal_level` setting (`minimal` / `replica` / `logical`) |
+| archive_command_configured | boolean | Whether `archive_command` is set (presence only; never the command string) |
+| restore_command_configured | boolean | Whether `restore_command` is set (presence only; never the command string) |
+
+## Scope filter
+
+None. `pg_stat_archiver` is a single-row, cluster-wide view present on
+every supported version, so the collector always emits exactly one row.
+
+## Invariants
+
+- Exactly one row per collection (cluster-wide view).
+- No command strings are ever persisted — only the boolean presence
+  flags. This holds regardless of the high-sensitivity setting.
+
+## Failure Conditions
+
+- `pg_stat_archiver` and `current_setting()` are readable by
+  `pg_monitor` / `pg_read_all_stats`; no elevated privilege is required,
+  so a permission error is a genuine fault, not an expected boundary.
+
+## Configuration
+
+- Cadence: 15m (recovery posture changes slowly).
+- Retention class: medium.
+
+## Sensitivity
+
+Not high-sensitivity: the collector emits counters, timestamps, and
+enum-valued settings, plus **presence-only** booleans for the archive/
+restore commands. It runs unconditionally (nothing to redact), and the
+command strings — the only credential-bearing surface — are never read
+into a persisted column.
+
+## Analyzer requirements unblocked
+
+- Recovery-readiness / backup-health detection: archiving disabled,
+  archiver failing or stalled, `wal_level` below the required level for
+  the intended recovery/replication model.
+
+## Relationship to other collectors
+
+- Complements the replication collectors (standby/slot lag) with the
+  archiving side of durability. Distinct from `checkpointer_stats_v1` /
+  `bgwriter_stats_v1`, which cover in-memory buffer/checkpoint activity.


### PR DESCRIPTION
## Summary
New read-only collector `wal_archiving_v1` capturing **recovery posture**, not collected today:
- **`pg_stat_archiver`**: `archived_count`, `failed_count`, `last_archived_wal`, `last_archived_time`, `last_failed_wal`, `last_failed_time`, `stats_reset`.
- **archive/recovery settings**: `archive_mode`, `archive_timeout`, `wal_level`, plus **presence-only** booleans `archive_command_configured` / `restore_command_configured`.

## Credential safety
`archive_command` / `restore_command` can embed secrets (e.g. a cloud credential in the shell command), so the query emits only a **boolean presence** flag for each — never the command string. Uses `current_setting(name, true) <> ''`.

## Shape
One row per cluster (`pg_stat_archiver` is a single-row view), 15m cadence, medium retention, **not** high-sensitivity (nothing to redact). Readable by `pg_monitor` / `pg_read_all_stats` — no elevated privilege.

## Included (collector-add checklist)
- Registration (`internal/pgqueries/catalog_wal.go`), spec with the Output-columns contract (`specifications/collectors/wal_archiving_v1.md`).
- Regenerated `collector-inventory.json` (drift gate), README count bump (102 → 103), `docs/collectors.md` row.

## Verification
`go build`/`vet`/`gofmt` clean; the README-count, collector-inventory-sync, and collectors-doc-completeness guards pass; `go test ./tests ./internal/pgqueries ./internal/collector` green; docs + de-arq guards pass. (The live-PG output-contract assertion runs in CI's `integration-pg`.)

closes #304